### PR TITLE
include debug implementation for compose.uiTooling in dependencies

### DIFF
--- a/core_chat_presentation/build.gradle.kts
+++ b/core_chat_presentation/build.gradle.kts
@@ -53,3 +53,7 @@ android {
         minSdk = libs.versions.android.minSdk.get().toInt()
     }
 }
+
+dependencies {
+    debugImplementation(compose.uiTooling)
+}

--- a/design_system/build.gradle.kts
+++ b/design_system/build.gradle.kts
@@ -43,3 +43,7 @@ android {
         minSdk = libs.versions.android.minSdk.get().toInt()
     }
 }
+
+dependencies {
+    debugImplementation(compose.uiTooling)
+}

--- a/dukan_presentation/build.gradle.kts
+++ b/dukan_presentation/build.gradle.kts
@@ -53,3 +53,7 @@ android {
         minSdk = libs.versions.android.minSdk.get().toInt()
     }
 }
+
+dependencies {
+    debugImplementation(compose.uiTooling)
+}

--- a/faith_presentation/build.gradle.kts
+++ b/faith_presentation/build.gradle.kts
@@ -53,3 +53,7 @@ android {
         minSdk = libs.versions.android.minSdk.get().toInt()
     }
 }
+
+dependencies {
+    debugImplementation(compose.uiTooling)
+}

--- a/identity_presentation/build.gradle.kts
+++ b/identity_presentation/build.gradle.kts
@@ -53,3 +53,7 @@ android {
         minSdk = libs.versions.android.minSdk.get().toInt()
     }
 }
+
+dependencies {
+    debugImplementation(compose.uiTooling)
+}

--- a/trends_presentation/build.gradle.kts
+++ b/trends_presentation/build.gradle.kts
@@ -53,3 +53,7 @@ android {
         minSdk = libs.versions.android.minSdk.get().toInt()
     }
 }
+
+dependencies {
+    debugImplementation(compose.uiTooling)
+}

--- a/wallet_presentation/build.gradle.kts
+++ b/wallet_presentation/build.gradle.kts
@@ -53,3 +53,7 @@ android {
         minSdk = libs.versions.android.minSdk.get().toInt()
     }
 }
+
+dependencies {
+    debugImplementation(compose.uiTooling)
+}


### PR DESCRIPTION
This pull request adds a new debug dependency to several module build files to improve development tooling support. Specifically, it introduces the `compose.uiTooling` library as a `debugImplementation` dependency, which provides enhanced UI inspection and debugging capabilities for Jetpack Compose during development.

**Development tooling enhancements:**

* Added `debugImplementation(compose.uiTooling)` to the dependencies block in the following module build files to enable Jetpack Compose UI tooling during debug builds:
  * `core_chat_presentation/build.gradle.kts`
  * `design_system/build.gradle.kts`
  * `dukan_presentation/build.gradle.kts`
  * `faith_presentation/build.gradle.kts`
  * `identity_presentation/build.gradle.kts`
  * `trends_presentation/build.gradle.kts`
  * `wallet_presentation/build.gradle.kts`