### PR TITLE
Feature/FTH-18 empty book mark

### DIFF
--- a/faith_presentation/build.gradle.kts
+++ b/faith_presentation/build.gradle.kts
@@ -48,6 +48,8 @@ kotlin {
 android {
     namespace = "net.thechance.mena.faith.presentation"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
+    
+    sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
         minSdk = libs.versions.android.minSdk.get().toInt()

--- a/faith_presentation/src/commonMain/composeResources/drawable/ic_not_saved_book_mark.xml
+++ b/faith_presentation/src/commonMain/composeResources/drawable/ic_not_saved_book_mark.xml
@@ -1,0 +1,47 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+    <path android:pathData="M24.02,9.2C21.37,9.2 19.22,11.25 19.22,13.79V96.55C19.22,98.19 20.13,99.71 21.61,100.53C23.09,101.35 24.92,101.36 26.41,100.54L50.51,87.37C54.94,84.94 60.38,84.94 64.81,87.37L88.91,100.54C90.39,101.36 92.22,101.35 93.7,100.53C95.18,99.71 96.1,98.19 96.1,96.55V13.79C96.1,11.25 93.94,9.2 91.29,9.2H24.02Z">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:endX="58.1"
+                android:endY="67.68"
+                android:startX="57.66"
+                android:startY="9.2"
+                android:type="linear">
+                <item
+                    android:color="#FF393939"
+                    android:offset="0" />
+                <item
+                    android:color="#FF000000"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+    <path
+        android:fillType="evenOdd"
+        android:pathData="M1.67,16C1.67,8.08 8.08,1.67 16,1.67C23.92,1.67 30.33,8.08 30.33,16C30.33,23.92 23.92,30.33 16,30.33C8.08,30.33 1.67,23.92 1.67,16ZM14.67,21.33C14.67,20.6 15.26,20 15.99,20H16.01C16.74,20 17.33,20.6 17.33,21.33C17.33,22.07 16.74,22.67 16.01,22.67H15.99C15.26,22.67 14.67,22.07 14.67,21.33ZM14.67,16C14.67,16.74 15.26,17.33 16,17.33C16.74,17.33 17.33,16.74 17.33,16V10.67C17.33,9.93 16.74,9.33 16,9.33C15.26,9.33 14.67,9.93 14.67,10.67V16Z">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:endX="16.11"
+                android:endY="19.9"
+                android:startX="16"
+                android:startY="1.67"
+                android:type="linear">
+                <item
+                    android:color="#FF393939"
+                    android:offset="0" />
+                <item
+                    android:color="#FF000000"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+    <path
+        android:fillAlpha="0.6"
+        android:fillColor="#3E4252"
+        android:pathData="M36.71,26.85C34.06,26.85 31.9,28.91 31.9,31.45V114.21C31.9,115.85 32.82,117.36 34.3,118.18C35.78,119.01 37.61,119.01 39.09,118.2L63.19,105.02C67.62,102.6 73.06,102.6 77.49,105.02L101.59,118.2C103.08,119.01 104.91,119.01 106.39,118.18C107.87,117.36 108.78,115.85 108.78,114.21V31.45C108.78,28.91 106.63,26.85 103.98,26.85H36.71Z" />
+</vector>

--- a/faith_presentation/src/commonMain/composeResources/values/strings.xml
+++ b/faith_presentation/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="start_tilawah">Start Tilawah</string>
+</resources>

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/component/EmptyBookMark.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/component/EmptyBookMark.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import mena.faith_presentation.generated.resources.Res
 import mena.faith_presentation.generated.resources.ic_not_saved_book_mark
@@ -51,6 +52,7 @@ fun EmptyBookMarkState(
             text = title,
             style = Theme.typography.title.medium,
             color = Theme.colorScheme.shadePrimary,
+            textAlign = TextAlign.Center,
             modifier = Modifier.padding(top = Theme.spacing._24, bottom = Theme.spacing._8)
         )
 
@@ -58,6 +60,7 @@ fun EmptyBookMarkState(
             text = subTitle,
             color = Theme.colorScheme.shadeSecondary,
             style = Theme.typography.body.small,
+            textAlign = TextAlign.Center,
             modifier = Modifier.padding(
                 start = Theme.spacing._4, end = Theme.spacing._4, bottom = Theme.spacing._24
             )

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/component/EmptyBookMark.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/component/EmptyBookMark.kt
@@ -28,7 +28,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-fun EmptyBookMarkState(
+fun EmptyBookmarkState(
     title: String,
     icon: DrawableResource,
     contentDescription: String,
@@ -61,9 +61,7 @@ fun EmptyBookMarkState(
             color = Theme.colorScheme.shadeSecondary,
             style = Theme.typography.body.small,
             textAlign = TextAlign.Center,
-            modifier = Modifier.padding(
-                start = Theme.spacing._4, end = Theme.spacing._4, bottom = Theme.spacing._24
-            )
+            modifier = Modifier.padding(bottom = Theme.spacing._24)
         )
 
         Button(
@@ -71,10 +69,8 @@ fun EmptyBookMarkState(
                 .background(
                     color = Theme.colorScheme.primary.primary,
                     shape = RoundedCornerShape(Theme.radius.md)
-                ).padding(horizontal = 28.dp),
-            onClick = {
-                onClickButton()
-            },
+                ),
+            onClick = onClickButton,
         ) {
             MenaText(
                 text = stringResource(Res.string.start_tilawah),
@@ -90,7 +86,7 @@ fun EmptyBookMarkState(
 @Composable
 private fun EmptyBookMarkPreview() {
     MenaTheme {
-        EmptyBookMarkState(
+        EmptyBookmarkState(
             icon = Res.drawable.ic_not_saved_book_mark,
             contentDescription = "Empty Bookmark",
             title = "No Bookmarks Yet",

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/component/EmptyBookMark.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/component/EmptyBookMark.kt
@@ -1,0 +1,97 @@
+package net.thechance.mena.faith.presentation.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import mena.faith_presentation.generated.resources.Res
+import mena.faith_presentation.generated.resources.ic_not_saved_book_mark
+import mena.faith_presentation.generated.resources.start_tilawah
+import net.thechance.mena.designsystem.presentation.component.button.Button
+import net.thechance.mena.designsystem.presentation.component.image.MenaImage
+import net.thechance.mena.designsystem.presentation.component.text.MenaText
+import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
+import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun EmptyBookMarkState(
+    title: String,
+    icon: DrawableResource,
+    contentDescription: String,
+    subTitle: String,
+    modifier: Modifier = Modifier,
+    onClickButton: () -> Unit = {},
+) {
+    Column(
+        modifier = modifier.fillMaxSize().padding(horizontal = 28.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+
+        MenaImage(
+            painter = painterResource(icon),
+            contentDescription = contentDescription,
+            modifier = Modifier.size(128.dp)
+        )
+
+        MenaText(
+            text = title,
+            style = Theme.typography.title.medium,
+            color = Theme.colorScheme.shadePrimary,
+            modifier = Modifier.padding(top = Theme.spacing._24, bottom = Theme.spacing._8)
+        )
+
+        MenaText(
+            text = subTitle,
+            color = Theme.colorScheme.shadeSecondary,
+            style = Theme.typography.body.small,
+            modifier = Modifier.padding(
+                start = Theme.spacing._4, end = Theme.spacing._4, bottom = Theme.spacing._24
+            )
+        )
+
+        Button(
+            modifier = Modifier.fillMaxWidth().height(48.dp)
+                .background(
+                    color = Theme.colorScheme.primary.primary,
+                    shape = RoundedCornerShape(Theme.radius.md)
+                ).padding(horizontal = 28.dp),
+            onClick = {
+                onClickButton()
+            },
+        ) {
+            MenaText(
+                text = stringResource(Res.string.start_tilawah),
+                style = Theme.typography.label.medium,
+                color = Theme.colorScheme.primary.onPrimary
+            )
+        }
+    }
+}
+
+
+@Preview()
+@Composable
+private fun EmptyBookMarkPreview() {
+    MenaTheme {
+        EmptyBookMarkState(
+            icon = Res.drawable.ic_not_saved_book_mark,
+            contentDescription = "Empty Bookmark",
+            title = "No Bookmarks Yet",
+            subTitle = "You haven't added any bookmarks. Start exploring and add your favorite items to your bookmarks."
+        )
+    }
+}


### PR DESCRIPTION
## Description
This PR adds resource directory support for the commonMain source set and implements empty bookmark state functionality.

## Changes Made
- ✅ Added resource directory for commonMain source set
- ✅ Added vector asset for unsaved bookmark icon
- ✅ Added string resources for empty bookmark state
- ✅ Implemented `EmptyBookMarkState` composable for displaying empty bookmark UI

## Technical Details
- **Target Source Set**: commonMain
- **Resource Types Added**: Vector assets, string resources
- **New Component**: `EmptyBookMarkState` composable function


## Screen Shoot
<img width="331" height="750" alt="Screenshot 2025-09-15 at 1 08 01 AM" src="https://github.com/user-attachments/assets/544bff1a-1f3c-4195-8bc0-ecbce1643a47" />
reenshots 

## Related Ticket
FTH-18
