### PR TITLE
Feature/FTH-21 navigation from the surah list

### DIFF
--- a/faith_presentation/build.gradle.kts
+++ b/faith_presentation/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
             implementation(libs.koin.core)
             implementation(libs.koin.compose)
             implementation(libs.koin.compose.viewmodel)
+            implementation(libs.androidx.navigation.compose)
         }
         iosMain.dependencies {
 

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurEffect.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurEffect.kt
@@ -3,5 +3,5 @@ package net.thechance.mena.faith.presentation.feature.quran.sur
 sealed interface SurEffect {
     data object NavigateToBack : SurEffect
     data object NavigateToBookmark : SurEffect
-    data class NavigateToSurahDetails(val surahId: Int) : SurEffect
+    data class NavigateToSurahDetails(val surahId: Int,val surahName: String) : SurEffect
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurInteractionListener.kt
@@ -1,7 +1,7 @@
 package net.thechance.mena.faith.presentation.feature.quran.sur
 
 interface SurInteractionListener {
-    fun onSurahClick(id: Int,surahName: String)
+    fun onSurahClick(surahId: Int, surahName: String)
     fun onBackClick()
     fun onBookmarkClick()
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurInteractionListener.kt
@@ -1,7 +1,7 @@
 package net.thechance.mena.faith.presentation.feature.quran.sur
 
 interface SurInteractionListener {
-    fun onSurahClick(id: Int)
+    fun onSurahClick(id: Int,surahName: String)
     fun onBackClick()
     fun onBookmarkClick()
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurScreen.kt
@@ -323,9 +323,9 @@ private fun SurScreenPreview() {
                 )
             ),
             interactionListener = object : SurInteractionListener {
-                override fun onSurahClick(surahId: Int, surahName: String) {}
-                override fun onBackClick() {}
-                override fun onBookmarkClick() {}
+                override fun onSurahClick(surahId: Int, surahName: String) = Unit
+                override fun onBackClick() = Unit
+                override fun onBookmarkClick() = Unit
             }
         )
     }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurScreen.kt
@@ -323,7 +323,7 @@ private fun SurScreenPreview() {
                 )
             ),
             interactionListener = object : SurInteractionListener {
-                override fun onSurahClick(id: Int,surahName: String) {}
+                override fun onSurahClick(surahId: Int, surahName: String) {}
                 override fun onBackClick() {}
                 override fun onBookmarkClick() {}
             }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurScreen.kt
@@ -56,24 +56,26 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun SurScreen(
     viewModel: SurViewModel = koinViewModel(),
+    onNavigateBack: () -> Unit = {},
+    onNavigateToBookmarks: () -> Unit = {},
+    onNavigateToSurahDetails: (surahId: Int, surahName: String) -> Unit = { _, _ -> }
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
-
     val effect by viewModel.uiEffect.collectAsState(initial = null)
 
     LaunchedEffect(effect) {
         effect?.let { currentEffect ->
             when (currentEffect) {
                 is SurEffect.NavigateToBack -> {
-                    //TODO() navigate back
+                    onNavigateBack()
                 }
 
                 is SurEffect.NavigateToBookmark -> {
-                    //TODO() navigate to bookmark screen
+                    onNavigateToBookmarks()
                 }
 
                 is SurEffect.NavigateToSurahDetails -> {
-                    //TODO() navigate to SurahDetails screen
+                    onNavigateToSurahDetails(currentEffect.surahId, currentEffect.surahName)
                 }
             }
         }
@@ -84,6 +86,7 @@ fun SurScreen(
         interactionListener = viewModel
     )
 }
+
 
 @Composable
 private fun Content(
@@ -115,7 +118,10 @@ private fun Content(
         }
 
         items(uiState.sur) { surah ->
-            SurahItem(surah = surah, onClick = interactionListener::onSurahClick)
+            SurahItem(
+                surah = surah,
+                onClick = { interactionListener.onSurahClick(surah.id, surah.surahName) }
+            )
         }
     }
 }
@@ -318,7 +324,7 @@ private fun SurScreenPreview() {
                 )
             ),
             interactionListener = object : SurInteractionListener {
-                override fun onSurahClick(id: Int) {}
+                override fun onSurahClick(id: Int,surahName: String) {}
                 override fun onBackClick() {}
                 override fun onBookmarkClick() {}
             }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurScreen.kt
@@ -87,7 +87,6 @@ fun SurScreen(
     )
 }
 
-
 @Composable
 private fun Content(
     uiState: SurScreenState,

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurScreen.kt
@@ -56,9 +56,9 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun SurScreen(
     viewModel: SurViewModel = koinViewModel(),
-    onNavigateBack: () -> Unit = {},
-    onNavigateToBookmarks: () -> Unit = {},
-    onNavigateToSurahDetails: (surahId: Int, surahName: String) -> Unit = { _, _ -> }
+    onNavigateBack: () -> Unit,
+    onNavigateToBookmarks: () -> Unit,
+    onNavigateToSurahDetails: (surahId: Int, surahName: String) -> Unit
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val effect by viewModel.uiEffect.collectAsState(initial = null)

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurScreen.kt
@@ -55,10 +55,10 @@ import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun SurScreen(
-    viewModel: SurViewModel = koinViewModel(),
     onNavigateBack: () -> Unit,
     onNavigateToBookmarks: () -> Unit,
-    onNavigateToSurahDetails: (surahId: Int, surahName: String) -> Unit
+    onNavigateToSurahDetails: (surahId: Int, surahName: String) -> Unit,
+    viewModel: SurViewModel = koinViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val effect by viewModel.uiEffect.collectAsState(initial = null)

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurViewModel.kt
@@ -12,7 +12,7 @@ class SurViewModel(
         initializeSur()
     }
 
-    override fun onSurahClick(id: Int, surahName: String) = sendEffect(SurEffect.NavigateToSurahDetails(id, surahName))
+    override fun onSurahClick(surahId: Int, surahName: String) = sendEffect(SurEffect.NavigateToSurahDetails(surahId, surahName))
 
     override fun onBackClick() = sendEffect(SurEffect.NavigateToBack)
 

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurViewModel.kt
@@ -12,7 +12,7 @@ class SurViewModel(
         initializeSur()
     }
 
-    override fun onSurahClick(id: Int) = sendEffect(SurEffect.NavigateToSurahDetails(id))
+    override fun onSurahClick(id: Int, surahName: String) = sendEffect(SurEffect.NavigateToSurahDetails(id, surahName))
 
     override fun onBackClick() = sendEffect(SurEffect.NavigateToBack)
 

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/navigation/FaithNavGraph.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/navigation/FaithNavGraph.kt
@@ -23,7 +23,6 @@ fun FaithNavigation() {
             composable<SurRoute> {
                 SurScreen(
                     onNavigateBack = {
-                        // Handle back navigation
                         navController.popBackStack()
                     },
                     onNavigateToBookmarks = {

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/navigation/FaithNavGraph.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/navigation/FaithNavGraph.kt
@@ -1,0 +1,48 @@
+package net.thechance.mena.faith.presentation.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import net.thechance.mena.faith.presentation.feature.quran.sur.SurScreen
+
+@Composable
+fun FaithNavigation() {
+    val navController = rememberNavController()
+
+    CompositionLocalProvider(
+        LocalNavController provides navController
+    ) {
+        NavHost(
+            navController = navController,
+            startDestination = SurRoute
+        ) {
+            composable<SurRoute> {
+                SurScreen(
+                    onNavigateBack = {
+                        // Handle back navigation
+                        navController.popBackStack()
+                    },
+                    onNavigateToBookmarks = {
+                        navController.navigate(BookmarksRoute)
+                    },
+                    onNavigateToSurahDetails = { surahId, surahName ->
+                        navController.navigate(
+                            SurahDetailsRoute(
+                                surahId = surahId,
+                                surahName = surahName
+                            )
+                        )
+                    }
+                )
+            }
+        }
+    }
+}
+
+val LocalNavController = staticCompositionLocalOf<NavHostController> {
+    error("No nav controller provided")
+}

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/navigation/Routes.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/navigation/Routes.kt
@@ -1,0 +1,15 @@
+package net.thechance.mena.faith.presentation.navigation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object SurRoute
+
+@Serializable
+data class SurahDetailsRoute(
+    val surahId: Int,
+    val surahName: String
+)
+
+@Serializable
+data object BookmarksRoute


### PR DESCRIPTION
## Navigation Implementation for Surah Screen

This PR introduces navigation functionality to the Surah (chapter) screen of the Quran feature, enabling navigation to bookmarks and surah details, and establishes a navigation graph using Jetpack Compose Navigation. It also updates related interfaces and effect classes to support passing both the Surah ID and name when navigating to Surah details.

**Navigation System Integration**
- Added new FaithNavigation composable and supporting navigation graph in `FaithNavGraph.kt` using Jetpack Compose Navigation
- Implemented routes for Surah list, Surah details, and bookmarks screens
- Defined navigation routes as serializable objects and data classes in `Routes.kt` to support type-safe navigation and route arguments
- Added required navigation library dependency to Gradle build file (`faith_presentation/build.gradle.kts`)

**Surah Details Navigation**  
- Updated `SurEffect.NavigateToSurahDetails` effect to include both `surahId` and `surahName` parameters
- Modified `SurInteractionListener.onSurahClick` interface to pass both Surah ID and name for navigation
- Enhanced `SurViewModel` and related classes to handle the additional navigation data
- Ensured Surah name availability for proper navigation context

**Screen Navigation Handling**
- Modified `SurScreen` composable to accept navigation callbacks for:
  - Back navigation
  - Bookmarks navigation  
  - Surah details navigation
- Implemented effect handling to invoke navigation callbacks in response to user interactions
- Integrated navigation flow with existing UI components and user interactions