### PR TITLE
add Slack notifications and deployment to slack

### DIFF
--- a/.github/actions/build-release-apk/action.yml
+++ b/.github/actions/build-release-apk/action.yml
@@ -95,5 +95,4 @@ runs:
         
         echo "APK_NAME=$APK_NAME" >> $GITHUB_ENV
         echo "SIGNED_APK_PATH=composeApp/build/outputs/apk/${{ steps.convert.outputs.build_type_lower }}/release/$APK_NAME.apk" >> $GITHUB_ENV
-        cat local.properties
       shell: bash

--- a/.github/actions/build-release-apk/action.yml
+++ b/.github/actions/build-release-apk/action.yml
@@ -9,6 +9,10 @@ inputs:
     required: true
   android-key-alias-password:
     required: true
+  build-type:
+    required: true
+  base-url:
+    required: true
 
 runs:
   using: "composite"
@@ -29,6 +33,20 @@ runs:
         restore-keys: |
           gradle-${{ runner.os }}-
 
+    - name: Install ImageMagick 7
+      shell: bash
+      run: |
+        sudo apt-get update && sudo apt-get install -y libfuse2
+        wget https://download.imagemagick.org/ImageMagick/download/binaries/magick
+        chmod +x magick
+        mv magick /usr/local/bin/
+
+    - name: Create local.properties with base URLs
+      shell: bash
+      run: |
+        UPPER_BUILD_TYPE=$(echo "${{ inputs.build-type }}" | tr '[:lower:]' '[:upper:]')
+        echo "BASE_URL_${UPPER_BUILD_TYPE}=${{ inputs.base-url }}" >> local.properties
+
     - name: Make gradlew executable
       run: chmod +x ./gradlew
       shell: bash
@@ -40,14 +58,21 @@ runs:
         versionCode: ${{ github.run_number }}
         versionName: 1.0.${{ github.run_number }}
 
+    - name: convert build type to lowercase
+      id: convert
+      run: |
+        BUILD_TYPE_LOWER=$(echo "${{ inputs.build-type }}" | tr '[:upper:]' '[:lower:]')
+        echo "build_type_lower=$BUILD_TYPE_LOWER" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Generate unsigned APK
-      run: ./gradlew :composeApp:assembleRelease --build-cache -x test -x lint
+      run: ./gradlew :composeApp:assemble${{ inputs.build-type }}Release --build-cache -x test -x lint
       shell: bash
 
     - name: Sign APK
       uses: r0adkll/sign-android-release@v1
       with:
-        releaseDirectory: composeApp/build/outputs/apk/release
+        releaseDirectory: composeApp/build/outputs/apk/${{ steps.convert.outputs.build_type_lower }}/release
         signingKeyBase64: ${{ inputs.android-keystore-base64 }}
         keyStorePassword: ${{ inputs.keystore-password }}
         alias: ${{ inputs.android-key-alias }}
@@ -56,5 +81,19 @@ runs:
         BUILD_TOOLS_VERSION: "35.0.0"
 
     - name: Set signed APK path to env
-      run: echo "SIGNED_APK_PATH=composeApp/build/outputs/apk/release/composeApp-release-unsigned-signed.apk" >> $GITHUB_ENV
+      run: |
+        if [[ "${{ inputs.build-type }}" == "Production" ]]; then
+          VERSION_NAME="Mena"
+        else
+          VERSION_NAME="Mena-${{ inputs.build-type }}"
+        fi
+        
+        APK_NAME="${VERSION_NAME}-v1.0.${{ github.run_number }}"
+        
+        mv composeApp/build/outputs/apk/${{ steps.convert.outputs.build_type_lower }}/release/composeApp-${{ steps.convert.outputs.build_type_lower }}-release-unsigned-signed.apk \
+           composeApp/build/outputs/apk/${{ steps.convert.outputs.build_type_lower }}/release/$APK_NAME.apk
+        
+        echo "APK_NAME=$APK_NAME" >> $GITHUB_ENV
+        echo "SIGNED_APK_PATH=composeApp/build/outputs/apk/${{ steps.convert.outputs.build_type_lower }}/release/$APK_NAME.apk" >> $GITHUB_ENV
+        cat local.properties
       shell: bash

--- a/.github/actions/slack/send-pr-notification/action.yml
+++ b/.github/actions/slack/send-pr-notification/action.yml
@@ -1,0 +1,99 @@
+name: 'Send notification PR to Slack'
+
+inputs:
+  slack-bot-token:
+    required: true
+  slack-notification-channel-id:
+    required: true
+  bot-app-id:
+    required: true
+  branch-name:
+    required: true
+  message:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+
+    - name: Install jq
+      shell: bash
+      run: |
+        sudo apt-get update && sudo apt-get install -y jq
+
+    - name: Send notification to specific squad
+      shell: bash
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}
+        SLACK_NOTIFICATION_CHANNEL_ID: ${{ inputs.slack-notification-channel-id }}
+        BOT_APP_ID: ${{ inputs.bot-app-id }}
+        BRANCH_NAME: ${{ inputs.branch-name }}
+        MESSAGE: ${{ inputs.message }}
+      run: |
+        SQUADS=("IDN" "DKN" "CHT" "FTH" "TRN" "WLT")
+
+        messages=$(curl -s -X POST "https://slack.com/api/conversations.history" \
+          -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+          -H "Content-type: application/json" \
+          --data "{\"channel\": \"$SLACK_NOTIFICATION_CHANNEL_ID\"}")
+
+        bot_messages=$(echo "$messages" | jq --arg app_id "$BOT_APP_ID" '[.messages[] | select(.app_id == $app_id)]')
+        message_count=$(echo "$bot_messages" | jq 'length')
+
+        if [ "$message_count" -lt 6 ]; then
+          for SQUAD in "${SQUADS[@]}"; do
+            curl -s -X POST https://slack.com/api/chat.postMessage \
+              -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+              -H "Content-type: application/json; charset=utf-8" \
+              --data "{
+                \"channel\": \"$SLACK_NOTIFICATION_CHANNEL_ID\",
+                \"blocks\": [
+                  {
+                    \"type\": \"section\",
+                    \"text\": {
+                      \"type\": \"mrkdwn\",
+                      \"text\": \"${SQUAD} prs info\"
+                    }
+                  }
+                ]
+              }"
+          done
+
+          messages=$(curl -s -X POST "https://slack.com/api/conversations.history" \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-type: application/json" \
+            --data "{\"channel\": \"$SLACK_NOTIFICATION_CHANNEL_ID\"}")
+
+          bot_messages=$(echo "$messages" | jq --arg app_id "$BOT_APP_ID" '[.messages[] | select(.app_id == $app_id)]')
+          message_count=$(echo "$bot_messages" | jq 'length')
+        fi
+
+        team=$(echo "$BRANCH_NAME" | cut -d'/' -f2)
+        prefix="${team:0:3}"
+
+        for i in "${!SQUADS[@]}"; do
+          if [[ "${SQUADS[$i]}" == "$prefix" ]]; then
+            thread_ts=$(echo "$bot_messages" | jq -r ".[$message_count - 1 -$i].ts")
+
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+              -H "Content-type: application/json; charset=utf-8" \
+              --data "{
+                \"channel\": \"$SLACK_NOTIFICATION_CHANNEL_ID\",
+                \"unfurl_links\": false,
+                \"unfurl_media\": false,
+                \"thread_ts\": \"$thread_ts\",
+                \"blocks\": [
+                  {
+                    \"type\": \"section\",
+                    \"text\": {
+                      \"type\": \"mrkdwn\",
+                      \"text\": \"$MESSAGE\"
+                    }
+                  }
+                ]
+              }"
+          fi
+        done

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -31,3 +31,23 @@ jobs:
 
       - name: Build modules
         run: ./gradlew $(for m in $(echo '${{ needs.detect.outputs.modules }}' | jq -r '.[]'); do echo ":$m:assemble"; done) --parallel --build-cache --no-daemon -x lintVitalRelease -x lint -x assembleRelease
+
+  notify-slack-on-failure:
+    if: failure()
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Notify Slack on failure
+        uses: ./.github/actions/slack/send-pr-notification
+        with:
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-notification-channel-id: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
+          bot-app-id: ${{ secrets.BOT_APP_ID }}
+          branch-name: ${{ github.head_ref }}
+          message: |
+            🚨 *Build Failed on Android!*
+            Branch Name: ${{ github.head_ref }}
+            PR: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/deploy_develop_release.yml
+++ b/.github/workflows/deploy_develop_release.yml
@@ -1,4 +1,4 @@
-name: Deploy release APK from develop to Firebase
+name: Deploy develop release APK
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - develop
 
 jobs:
-  deploy-release:
+  deploy-develop-release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -19,12 +19,26 @@ jobs:
           keystore-password: ${{ secrets.KEYSTORE_PASSWORD }}
           android-key-alias: ${{ secrets.ANDROID_KEY_ALIAS }}
           android-key-alias-password: ${{ secrets.ANDROID_KEY_ALIAS_PASSWORD }}
+          build-type: Development
+          base-url: ${{ secrets.BASE_URL_DEVELOPMENT }}
 
       - name: Deploy to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
-          appId: ${{ secrets.FIREBASE_APP_ID }}
+          appId: ${{ secrets.FIREBASE_DEVELOPMENT_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           file: ${{ env.SIGNED_APK_PATH }}
           debug: true
-          groups: testers
+          groups: testers-develop
+
+      - name: Deploy APK to Slack
+        uses: MeilCli/slack-upload-file@v4.0.20
+        with:
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel_id: ${{ secrets.SLACK_DEVELOPMENT_CHANNEL_ID }}
+          file_path: ${{ env.SIGNED_APK_PATH }}
+          file_name: "app-release-${{ github.run_number }}.apk"
+          initial_comment: |
+            📲 *New Develop APK Build Released*
+            *Version:* `1.0.${{ github.run_number }}`
+            *File:* `${{ env.APK_NAME }}`

--- a/.github/workflows/deploy_production_release.yml
+++ b/.github/workflows/deploy_production_release.yml
@@ -1,0 +1,44 @@
+name: Deploy production release APK
+
+on:
+  push:
+    branches:
+      - production
+
+jobs:
+  deploy-production-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Build and Sign APK
+        uses: ./.github/actions/build-release-apk
+        with:
+          android-keystore-base64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          keystore-password: ${{ secrets.KEYSTORE_PASSWORD }}
+          android-key-alias: ${{ secrets.ANDROID_KEY_ALIAS }}
+          android-key-alias-password: ${{ secrets.ANDROID_KEY_ALIAS_PASSWORD }}
+          build-type: Production
+          base-url: ${{ secrets.BASE_URL_PRODUCTION }}
+
+      - name: Deploy to Firebase
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_PRODUCTION_APP_ID }}
+          serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
+          file: ${{ env.SIGNED_APK_PATH }}
+          debug: true
+          groups: testers-production
+
+      - name: Deploy APK to Slack
+        uses: MeilCli/slack-upload-file@v4.0.20
+        with:
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel_id: ${{ secrets.SLACK_PRODUCTION_CHANNEL_ID }}
+          file_path: ${{ env.SIGNED_APK_PATH }}
+          file_name: "app-release-${{ github.run_number }}.apk"
+          initial_comment: |
+            📲 *New Production APK Build Released*
+            *Version:* `1.0.${{ github.run_number }}`
+            *File:* `${{ env.APK_NAME }}`

--- a/.github/workflows/deploy_staging_release.yml
+++ b/.github/workflows/deploy_staging_release.yml
@@ -1,0 +1,44 @@
+name: Deploy staging release APK
+
+on:
+  push:
+    branches:
+      - staging
+
+jobs:
+  deploy-staging-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Build and Sign APK
+        uses: ./.github/actions/build-release-apk
+        with:
+          android-keystore-base64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          keystore-password: ${{ secrets.KEYSTORE_PASSWORD }}
+          android-key-alias: ${{ secrets.ANDROID_KEY_ALIAS }}
+          android-key-alias-password: ${{ secrets.ANDROID_KEY_ALIAS_PASSWORD }}
+          build-type: Staging
+          base-url: ${{ secrets.BASE_URL_STAGING }}
+
+      - name: Deploy to Firebase
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_STAGING_APP_ID }}
+          serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
+          file: ${{ env.SIGNED_APK_PATH }}
+          debug: true
+          groups: testers-staging
+
+      - name: Deploy APK to Slack
+        uses: MeilCli/slack-upload-file@v4.0.20
+        with:
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel_id: ${{ secrets.SLACK_STAGING_CHANNEL_ID }}
+          file_path: ${{ env.SIGNED_APK_PATH }}
+          file_name: "app-release-${{ github.run_number }}.apk"
+          initial_comment: |
+            📲 *New Staging APK Build Released*
+            *Version:* `1.0.${{ github.run_number }}`
+            *File:* `${{ env.APK_NAME }}`

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -43,3 +43,23 @@ jobs:
             build \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO
+
+  notify-slack-on-failure:
+    if: failure()
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Notify Slack on failure
+        uses: ./.github/actions/slack/send-pr-notification
+        with:
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-notification-channel-id: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
+          bot-app-id: ${{ secrets.BOT_APP_ID }}
+          branch-name: ${{ github.head_ref }}
+          message: |
+            🚨 *Build Failed on IOS!*
+            Branch Name: ${{ github.head_ref }}
+            PR: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -66,3 +66,24 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage-reports/
           fail_ci_if_error: true
+
+
+  notify-slack-on-failure:
+    if: failure()
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Notify Slack on failure
+        uses: ./.github/actions/slack/send-pr-notification
+        with:
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-notification-channel-id: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
+          bot-app-id: ${{ secrets.BOT_APP_ID }}
+          branch-name: ${{ github.head_ref }}
+          message: |
+            🚨 *Test Coverage Failed!*
+            Branch Name: ${{ github.head_ref }}
+            PR: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
### implement slack notification 
1 - build error on ios or android 
2 - test coverage 
3 - deployment to slack and firebase with develop , staging , production build flavors

#### what should you add to secret 
SLACK_DEVELOPMENT_CHANNEL_ID
SLACK_STAGING_CHANNEL_ID
SLACK_PRODUCTION_CHANNEL_ID

FIREBASE_DEVELOPMENT_APP_ID
FIREBASE_STAGING_APP_ID
FIREBASE_PRODUCTION_APP_ID

BASE_URL_DEVELOPMENT
BASE_URL_PRODUCTION
BASE_URL_STAGING


ANDROID_KEYSTORE_BASE64
KEYSTORE_PASSWORD
ANDROID_KEY_ALIAS
ANDROID_KEY_ALIAS_PASSWORD
CREDENTIAL_FILE_CONTENT

SLACK_NOTIFICATION_CHANNEL_ID
SLACK_BOT_TOKEN
BOT_APP_ID

#### you should create these groups in firebase

testers-develop
testers-staging
testers-production
