### PR TITLE
Fix Country Picker Issues

### DIFF
--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/bottomSheet/BottomSheet.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/bottomSheet/BottomSheet.kt
@@ -199,6 +199,7 @@ fun ScaffoldScope.BottomSheet(
                     .offset(
                         y = stickyBottomOffset
                     )
+                    .clickable(false) {}
             ) {
                 stickyFooterContent()
             }

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/bottomSheet/BottomSheet.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/bottomSheet/BottomSheet.kt
@@ -1,7 +1,6 @@
 package net.thechance.mena.designsystem.presentation.component.bottomSheet
 
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.AnchoredDraggableState
@@ -9,7 +8,6 @@ import androidx.compose.foundation.gestures.DraggableAnchors
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.anchoredDraggable
 import androidx.compose.foundation.gestures.animateTo
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -27,11 +25,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -41,15 +37,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import net.thechance.mena.designsystem.presentation.component.button.PrimaryButton
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.component.scaffold.ScaffoldScope
@@ -81,79 +74,64 @@ fun ScaffoldScope.BottomSheet(
     stickyFooterContent: @Composable BoxScope.() -> Unit = {},
     sheetContent: @Composable ColumnScope.() -> Unit
 ) {
-    val scope = rememberCoroutineScope()
+    val density = LocalDensity.current
     var sheetSize by remember { mutableStateOf(IntSize.Zero) }
-    val sheetCollapsedHeightPx = with(LocalDensity.current) {
-        340.dp.toPx()
-    }
-    val stickyBottomOffset = WindowInsets.navigationBars.asPaddingValues()
-        .calculateBottomPadding()
 
-    val dragState = remember(sheetSize) {
+    val sheetCollapsedHeightPx = with(density) { 340.dp.toPx() }
+
+    val dragState = remember {
         AnchoredDraggableState(
-            initialValue = BottomSheetValue.COLLAPSED,
+            initialValue = BottomSheetValue.HIDDEN,
             anchors = DraggableAnchors {
-                BottomSheetValue.HIDDEN at sheetSize.height.toFloat()
-                BottomSheetValue.COLLAPSED at if (skipPartiallyExpanded) 0f else (sheetSize.height.toFloat() - sheetCollapsedHeightPx)
-                BottomSheetValue.EXPANDED at 0f
+                BottomSheetValue.HIDDEN at Float.MAX_VALUE
+                BottomSheetValue.COLLAPSED at Float.MAX_VALUE
+                BottomSheetValue.EXPANDED at Float.MAX_VALUE
             }
         )
+    }
+
+    LaunchedEffect(sheetSize) {
+        if (sheetSize != IntSize.Zero) {
+            val containerHeight = sheetSize.height.toFloat()
+            val collapsedOffset =
+                if (skipPartiallyExpanded) 0f else containerHeight - sheetCollapsedHeightPx
+
+            dragState.updateAnchors(
+                DraggableAnchors {
+                    BottomSheetValue.EXPANDED at 0f
+                    BottomSheetValue.COLLAPSED at collapsedOffset
+                    BottomSheetValue.HIDDEN at containerHeight
+                }
+            )
+
+            dragState.animateTo(
+                BottomSheetValue.COLLAPSED,
+                tween(500)
+            )
+        }
+    }
+
+    LaunchedEffect(dragState.targetValue) {
+        if (dragState.targetValue == BottomSheetValue.HIDDEN) {
+            dragState.animateTo(BottomSheetValue.HIDDEN, tween(250))
+                .also {
+                    onDismissRequest()
+                }
+        }
     }
 
     val nestedConnection = remember(dragState) {
         sheetNestedScrollConnection(dragState, Orientation.Vertical)
     }
 
-    LaunchedEffect(dragState.settledValue) {
-        if (dragState.settledValue != BottomSheetValue.HIDDEN) {
-            dragState.animateTo(
-                targetValue = dragState.settledValue,
-                animationSpec = spring(stiffness = Spring.StiffnessMedium)
-            )
-        } else {
-            animateClose(scope, dragState, onDismissRequest)
-        }
-    }
+    Box(modifier = modifier.fillMaxSize()) {
 
-    Box(
-        modifier = modifier.fillMaxSize()
-    ) {
-
-        BackHandler {
-            scope.launch {
-                dragState.animateTo(BottomSheetValue.HIDDEN)
-            }
-        }
-
-        val scrimAlpha by derivedStateOf {
-            val progress =
-                1f - dragState.progress(dragState.settledValue, BottomSheetValue.HIDDEN)
-            (progress * 0.5f).coerceIn(0f, 0.5f)
-        }
-
-        if (scrimAlpha > 0f) {
-            Box(
-                modifier = Modifier.fillMaxSize()
-                    .background(color = scrimColor)
-                    .pointerInput(Unit) {
-                        detectTapGestures(
-                            onTap = {
-                                if (dismissOnBackPress) {
-                                    animateClose(
-                                        scope,
-                                        dragState,
-                                        onDismissRequest
-                                    )
-                                }
-                            }
-                        )
-                    }
-            )
-        }
+        BackHandler(dismissOnBackPress) { onDismissRequest() }
 
         Box(
             modifier = Modifier
                 .fillMaxSize()
+                .background(color = scrimColor)
                 .clickable(
                     enabled = dismissOnClickOutside,
                     onClick = onDismissRequest,
@@ -194,30 +172,20 @@ fun ScaffoldScope.BottomSheet(
             }
         }
 
-        if (dragState.settledValue != BottomSheetValue.HIDDEN) {
+        if (dragState.currentValue != BottomSheetValue.HIDDEN && sheetSize != IntSize.Zero) {
             Box(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .offset(
-                        y = stickyBottomOffset
+                        y = WindowInsets.navigationBars
+                            .asPaddingValues()
+                            .calculateBottomPadding()
                     )
                     .clickable(false) {}
             ) {
                 stickyFooterContent()
             }
         }
-    }
-}
-
-private fun animateClose(
-    scope: CoroutineScope,
-    dragState: AnchoredDraggableState<BottomSheetValue>,
-    onDismissRequest: () -> Unit
-) {
-    scope.launch {
-        dragState.animateTo(BottomSheetValue.HIDDEN, spring(stiffness = Spring.StiffnessMedium))
-    }.invokeOnCompletion {
-        onDismissRequest()
     }
 }
 
@@ -237,13 +205,16 @@ private fun SimpleBottomSheetPreview() {
                                 text = "Test",
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                                    .fillMaxWidth()
+                                    .background(Theme.colorScheme.background.surface)
+                                    .padding(horizontal = 16.dp, vertical = 12.dp)
+                                    .padding(bottom = 12.dp),
                                 onClick = {},
                             )
                         },
                         sheetContent = {
                             LazyColumn {
-                                items(3) { index ->
+                                items(10) { index ->
                                     Text(
                                         modifier = Modifier
                                             .fillMaxWidth()

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/bottomSheet/BottomSheet.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/bottomSheet/BottomSheet.kt
@@ -100,7 +100,7 @@ fun ScaffoldScope.BottomSheet(
         )
     }
 
-    val nestedConnection = remember {
+    val nestedConnection = remember(dragState) {
         sheetNestedScrollConnection(dragState, Orientation.Vertical)
     }
 
@@ -126,7 +126,8 @@ fun ScaffoldScope.BottomSheet(
         }
 
         val scrimAlpha by derivedStateOf {
-            val progress = 1f - dragState.progress(dragState.settledValue, BottomSheetValue.HIDDEN)
+            val progress =
+                1f - dragState.progress(dragState.settledValue, BottomSheetValue.HIDDEN)
             (progress * 0.5f).coerceIn(0f, 0.5f)
         }
 
@@ -166,8 +167,8 @@ fun ScaffoldScope.BottomSheet(
                 .padding(top = paddingFromTop)
                 .fillMaxWidth()
                 .align(Alignment.BottomCenter)
-                .nestedScroll(nestedConnection)
                 .offset { IntOffset(0, dragState.requireOffset().roundToInt()) }
+                .nestedScroll(nestedConnection)
                 .anchoredDraggable(
                     state = dragState,
                     orientation = Orientation.Vertical
@@ -183,7 +184,8 @@ fun ScaffoldScope.BottomSheet(
                 Box(
                     modifier = Modifier.padding(vertical = 6.dp)
                         .size(width = 39.dp, height = 2.dp)
-                        .align(Alignment.CenterHorizontally).background(
+                        .align(Alignment.CenterHorizontally)
+                        .background(
                             color = Theme.colorScheme.shadeTertiary,
                             shape = RoundedCornerShape(2.dp)
                         )

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/CountrySelectableRowItem.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/CountrySelectableRowItem.kt
@@ -54,6 +54,7 @@ internal fun CountrySelectableRowItem(
             )
             .clip(RoundedCornerShape(Theme.radius.lg))
             .clickable(
+                enabled = !isSelected,
                 onClick = {
                     onClick(selectedCountry)
                 },

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreenModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreenModel.kt
@@ -8,9 +8,9 @@ import net.thechance.mena.identity.presentation.countryPicker.menaCountries.Mena
 import net.thechance.mena.identity.presentation.countryPicker.selectByCountry
 import net.thechance.mena.identity.presentation.mapper.mapErrorToMessage
 
-class LoginScreenModel (
-   val loginUseCase: LoginUseCase
-): BaseScreenModel<LoginScreenUIState, LoginScreenUIEffect>(LoginScreenUIState()),
+class LoginScreenModel(
+    val loginUseCase: LoginUseCase
+) : BaseScreenModel<LoginScreenUIState, LoginScreenUIEffect>(LoginScreenUIState()),
     LoginScreenInteractionListener {
     override val viewModelScope: CoroutineScope
         get() = screenModelScope
@@ -20,21 +20,27 @@ class LoginScreenModel (
         updateState { copy(isLoading = true, errorMessage = null) }
         tryToExecute(
             function = {
-               loginUseCase.login(
-                   state.value.countryPickerUIState.currentCountry.callingCode,
-                   state.value.phoneNumber,
-                   state.value.password
-               )
+                loginUseCase.login(
+                    state.value.countryPickerUIState.currentCountry.callingCode,
+                    state.value.phoneNumber,
+                    state.value.password
+                )
             },
             onSuccess = {
                 updateState { copy(isLoading = false) }
                 sendNewEffect(LoginScreenUIEffect.NavigateToHome)
             },
             onError = { errorState ->
-                updateState { copy(isLoading = false, errorMessage = mapErrorToMessage(errorState)) }
+                updateState {
+                    copy(
+                        isLoading = false,
+                        errorMessage = mapErrorToMessage(errorState)
+                    )
+                }
             }
         )
     }
+
     override fun onRegisterClicked() {
         sendNewEffect(LoginScreenUIEffect.NavigateToRegister)
     }
@@ -63,9 +69,10 @@ class LoginScreenModel (
     }
 
     override fun onPasswordVisibilityToggled() {
-        updateState { copy(isPasswordVisible = !isPasswordVisible ) }
+        updateState { copy(isPasswordVisible = !isPasswordVisible) }
     }
-    override fun clearErrorMessage(){
+
+    override fun clearErrorMessage() {
         updateState { copy(errorMessage = null) }
     }
 
@@ -84,7 +91,7 @@ class LoginScreenModel (
                 countryPickerUIState = countryPickerUIState.copy(
                     selectedCountry = country,
                     countries = countryPickerUIState.countries.selectByCountry(country),
-                    isEnabled = countryPickerUIState.selectedCountry != country
+                    isEnabled = countryPickerUIState.currentCountry != country
                 )
             )
         }


### PR DESCRIPTION
## Summary

This pull request addresses several issues in the BottomSheet component and the LoginScreenModel to enhance user experience and code readability. Key changes include making the sticky footer in the BottomSheet component non-clickable, ensuring consistent country selection logic, and improving the draging functionality and visual feedback of the BottomSheet.

---
## Changes

1. **BottomSheet Component:**

* **Sticky Footer Fix:** Updated the sticky footer to be non-clickable, allowing clicks to pass through to the content behind it.
* **Drag Functionality Enhancements:** Refactored the BottomSheet composable to improve drag functionality and visual feedback:
    * Correctly remembered `nestedConnection` with `dragState` as a key.
    * Adjusted `scrimAlpha` calculation for clarity.
* **Improved User Experience:** Enhanced animation and state handling for smoother interactions.

2. **State and Interactions**
* **Country Selection Consistency:** Updated to use `currentCountry` instead of `selectedCountry` for logging in and determining country picker enablement.
* **Code Refactoring:**
    * Refactored `onLoginClicked` for better readability.
    * Corrected logic in `onCountrySelected` to compare `currentCountry` with `selectedCountry`.
* **CountrySelectableRowItem Enhancements:**
    * Disabled click interaction if the item is already selected.
    * Disabled click effect on selected country to prevent redundant `onClick` handler calls.
        
---
## ShowCase
https://github.com/user-attachments/assets/dad2691f-c98f-485e-82a5-507f442431da



        

 