### PR TITLE
Fix Bottom sheet dismissing behavior

### DIFF
--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/bottomSheet/BottomSheet.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/bottomSheet/BottomSheet.kt
@@ -113,10 +113,11 @@ fun ScaffoldScope.BottomSheet(
 
     LaunchedEffect(dragState.targetValue) {
         if (dragState.targetValue == BottomSheetValue.HIDDEN) {
-            dragState.animateTo(BottomSheetValue.HIDDEN, tween(250))
-                .also {
-                    onDismissRequest()
-                }
+            try {
+                dragState.animateTo(BottomSheetValue.HIDDEN, tween(250))
+            } finally {
+                onDismissRequest()
+            }
         }
     }
 


### PR DESCRIPTION
Ensure onDismissRequest is called in BottomSheet

The `onDismissRequest` callback was previously nested within the `also` block of the animation. This change moves `onDismissRequest` into a `finally` block to guarantee its execution, even if the animation is interrupted or fails.