### PR TITLE
Feature/FTH-33-sur-view-model-unit-test

### DIFF
--- a/faith_presentation/build.gradle.kts
+++ b/faith_presentation/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.kover)
+    alias(libs.plugins.mockkery)
 }
 
 kotlin {
@@ -50,6 +51,9 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.turbine)
+            implementation(libs.mokkery.core)
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/sur/SurViewModel.kt
@@ -1,18 +1,23 @@
 package net.thechance.mena.faith.presentation.feature.quran.sur
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import net.thechance.mena.faith.domain.entity.Surah
 import net.thechance.mena.faith.domain.repository.QuranRepository
 import net.thechance.mena.faith.presentation.base.BaseViewModel
 
 class SurViewModel(
-    val quranRepository: QuranRepository
+    private val quranRepository: QuranRepository,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : BaseViewModel<SurScreenState, SurEffect>(SurScreenState()), SurInteractionListener {
 
     init {
         initializeSur()
     }
 
-    override fun onSurahClick(surahId: Int, surahName: String) = sendEffect(SurEffect.NavigateToSurahDetails(surahId, surahName))
+    override fun onSurahClick(surahId: Int, surahName: String) =
+        sendEffect(SurEffect.NavigateToSurahDetails(surahId, surahName))
 
     override fun onBackClick() = sendEffect(SurEffect.NavigateBack)
 
@@ -24,7 +29,8 @@ class SurViewModel(
             execute = { quranRepository.getAllSur() },
             onSuccess = { sur -> handleSuccessState(sur) },
             onError = { throwable -> handleErrorState(throwable) },
-            onFinally = { setLoadingState(false) }
+            onFinally = { setLoadingState(false) },
+            dispatcher = dispatcher
         )
     }
 

--- a/faith_presentation/src/test/java/net/thechance/mena/faith/presentation/feature/quran/sur/SurViewModelTest.kt
+++ b/faith_presentation/src/test/java/net/thechance/mena/faith/presentation/feature/quran/sur/SurViewModelTest.kt
@@ -1,0 +1,186 @@
+package net.thechance.mena.faith.presentation.feature.quran.sur
+
+import app.cash.turbine.test
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import mena.faith_presentation.generated.resources.Res
+import mena.faith_presentation.generated.resources.ic_al_baqarah
+import mena.faith_presentation.generated.resources.ic_al_fatihah
+import net.thechance.mena.faith.domain.entity.Surah
+import net.thechance.mena.faith.domain.repository.QuranRepository
+import org.junit.Test
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SurViewModelTest {
+
+    private lateinit var viewModel: SurViewModel
+    private lateinit var quranRepository: QuranRepository
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        quranRepository = mock(mode = MockMode.autofill)
+        everySuspend { quranRepository.getAllSur() } returns surList
+        viewModel = SurViewModel(quranRepository, testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initialize view model should set empty state when getAllSur returns no data`() = runTest {
+        // Given
+        everySuspend { quranRepository.getAllSur() } returns emptyList()
+
+        // When
+        viewModel = SurViewModel(quranRepository, testDispatcher)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        assertEquals(emptyUiState, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `initialize view model should set success state when getAllSur returns data`() =
+        runTest {
+            // Given
+            everySuspend { quranRepository.getAllSur() } returns surList
+
+            // When
+            viewModel = SurViewModel(quranRepository, testDispatcher)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then
+            assertEquals(
+                emptyUiState.copy(sur = surahUiList, errorMessage = null, isLoading = false),
+                viewModel.uiState.value
+            )
+        }
+
+    @Test
+    fun `initialize view model should handle error state when getAllSur fails`() = runTest {
+        // Given
+        everySuspend { quranRepository.getAllSur() } throws Exception("Error")
+
+        // When
+        viewModel = SurViewModel(quranRepository, testDispatcher)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        assertEquals(
+            emptyUiState.copy(errorMessage = "Error", isLoading = false),
+            viewModel.uiState.value
+        )
+    }
+
+    @Test
+    fun `onSurahClick should navigate to surah details screen with surah id and name`() = runTest {
+        // Given
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // When
+        viewModel.uiEffect.test {
+            viewModel.onSurahClick(AL_FATIHAH_ID, AL_FATIHAH_NAME)
+
+            // Then
+            assertEquals(
+                SurEffect.NavigateToSurahDetails(AL_FATIHAH_ID, AL_FATIHAH_NAME),
+                awaitItem()
+            )
+        }
+    }
+
+    @Test
+    fun `onBackClick should navigate back`() = runTest {
+        // Given
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // When
+        viewModel.uiEffect.test {
+            viewModel.onBackClick()
+
+            // Then
+            assertEquals(
+                SurEffect.NavigateBack,
+                awaitItem()
+            )
+        }
+    }
+
+    @Test
+    fun `onBookmarkClick should navigate to bookmark screen`() = runTest {
+        // Given
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // When
+        viewModel.uiEffect.test {
+            viewModel.onBookmarkClick()
+
+            // Then
+            assertEquals(
+                SurEffect.NavigateToBookmark,
+                awaitItem()
+            )
+        }
+    }
+
+    private companion object {
+        val emptyUiState = SurScreenState(
+            isLoading = false,
+            errorMessage = null,
+            sur = emptyList()
+        )
+        const val AL_FATIHAH_ID = 1
+        const val AL_FATIHAH_NAME = "Al-Fatihah"
+        val surList = listOf(
+            Surah(
+                id = 1,
+                order = Surah.SurahOrder.AlFatihah,
+                name = "Al-Fatihah",
+                ayahCount = 7,
+                isMakkia = true
+            ),
+            Surah(
+                id = 2,
+                order = Surah.SurahOrder.AlBaqarah,
+                name = "Al-Baqarah",
+                ayahCount = 286,
+                isMakkia = false
+            )
+        )
+
+        val surahUiList = listOf(
+            SurScreenState.SurahUiState(
+                id = 1,
+                surahOrder = 1,
+                arabicNameImg = Res.drawable.ic_al_fatihah,
+                surahName = "Al-Fatihah",
+                ayatCount = 7,
+                isMakki = true
+            ),
+            SurScreenState.SurahUiState(
+                id = 2,
+                surahOrder = 2,
+                arabicNameImg = Res.drawable.ic_al_baqarah,
+                surahName = "Al-Baqarah",
+                ayatCount = 286,
+                isMakki = false
+            )
+        )
+    }
+}

--- a/faith_presentation/src/test/java/net/thechance/mena/faith/presentation/feature/quran/sur/SurViewModelTest.kt
+++ b/faith_presentation/src/test/java/net/thechance/mena/faith/presentation/feature/quran/sur/SurViewModelTest.kt
@@ -6,20 +6,15 @@ import dev.mokkery.answering.returns
 import dev.mokkery.answering.throws
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import mena.faith_presentation.generated.resources.Res
 import mena.faith_presentation.generated.resources.ic_al_baqarah
 import mena.faith_presentation.generated.resources.ic_al_fatihah
 import net.thechance.mena.faith.domain.entity.Surah
 import net.thechance.mena.faith.domain.repository.QuranRepository
 import org.junit.Test
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/faith_presentation/src/test/java/net/thechance/mena/faith/presentation/feature/quran/sur/SurViewModelTest.kt
+++ b/faith_presentation/src/test/java/net/thechance/mena/faith/presentation/feature/quran/sur/SurViewModelTest.kt
@@ -25,22 +25,9 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalCoroutinesApi::class)
 class SurViewModelTest {
 
-    private lateinit var viewModel: SurViewModel
-    private lateinit var quranRepository: QuranRepository
+    private val quranRepository: QuranRepository = mock(MockMode.autofill)
     private val testDispatcher = StandardTestDispatcher()
-
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-        quranRepository = mock(mode = MockMode.autofill)
-        everySuspend { quranRepository.getAllSur() } returns surList
-        viewModel = SurViewModel(quranRepository, testDispatcher)
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
+    private var viewModel = SurViewModel(quranRepository, testDispatcher)
 
     @Test
     fun `initialize view model should set empty state when getAllSur returns no data`() = runTest {


### PR DESCRIPTION
**Testing :**

* Added the `mokkery` plugin and relevant libraries (`turbine`, `mokkery.core`, `kotlinx.coroutines.test`) to the build configuration in `faith_presentation/build.gradle.kts` 

* Added a comprehensive test suite for `SurViewModel` in `SurViewModelTest.kt`, covering initialization, success/error states, and navigation effects, using `mokkery` for mocking and `turbine` for effect testing.

**SurViewModel improvements :**

* Modified the `SurViewModel` constructor to accept a `CoroutineDispatcher` (defaulting to `Dispatchers.IO`) for easier testing and better control of coroutine context.
