### PR TITLE
Add SLASH variable for escaping in xcconfig

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -219,8 +219,13 @@ tasks.register("generateEnvironmentXcconfig") {
     doLast {
         val outputFile = outputFileProperty.get().asFile
         outputFile.parentFile.mkdirs()
-        outputFile.writeText("BASE_URL=$baseUrl")
-        println("Generated environment.xcconfig")
+
+        outputFile.writeText(
+            """
+          SLASH = /
+          BASE_URL = ${baseUrl.replace("//", "$(SLASH)$(SLASH)")}
+        """.trimIndent()
+        )
     }
 }
 


### PR DESCRIPTION
This PR updates the `BASE_URL` in `environment.xcconfig` to use a `SLASH` variable to properly escape forward slashes. This ensures the URL is correctly interpreted by Xcode.