### PR TITLE
Feature/trn 40 view model test

### DIFF
--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - MapLibre (6.17.1)
+
+DEPENDENCIES:
+  - MapLibre (= 6.17.1)
+
+SPEC REPOS:
+  trunk:
+    - MapLibre
+
+SPEC CHECKSUMS:
+  MapLibre: 4602773419937bfa96189c53b90d1055b8ef4f29
+
+PODFILE CHECKSUM: eaafe1c9b6cc2b52da366bc40a02c20643963621
+
+COCOAPODS: 1.16.2

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		389BEBEFE21A49A31BBCF6CA /* Pods_iosApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24175D2CF8C60CFFDB2F56E9 /* Pods_iosApp.framework */; };
+		E71070392E898AEE00A45927 /* MapLibre.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E71070382E898AEE00A45927 /* MapLibre.xcframework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -18,6 +18,7 @@
 		B0E2F7373ACC1EE6651C4350 /* Pods-iosApp.debugproduction.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.debugproduction.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.debugproduction.xcconfig"; sourceTree = "<group>"; };
 		C2DDD26143EFF1E4591ACBBB /* Pods-iosApp.debugdevelopment.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.debugdevelopment.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.debugdevelopment.xcconfig"; sourceTree = "<group>"; };
 		CCD218F1746D7F5B96F574D4 /* Pods-iosApp.debugstaging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.debugstaging.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.debugstaging.xcconfig"; sourceTree = "<group>"; };
+		E71070382E898AEE00A45927 /* MapLibre.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MapLibre.xcframework; path = Pods/MapLibre/MapLibre.xcframework; sourceTree = "<group>"; };
 		F2A2D9007EC184837D541AE6 /* Pods-iosApp.releasestaging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.releasestaging.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.releasestaging.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -42,8 +43,6 @@
 		};
 		A9F46D1B423E4AC186F7D8FF /* Configuration */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = Configuration;
 			sourceTree = "<group>";
 		};
@@ -54,7 +53,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				389BEBEFE21A49A31BBCF6CA /* Pods_iosApp.framework in Frameworks */,
+				E71070392E898AEE00A45927 /* MapLibre.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -77,6 +76,7 @@
 		B28E0823253499C2EDB905A5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E71070382E898AEE00A45927 /* MapLibre.xcframework */,
 				24175D2CF8C60CFFDB2F56E9 /* Pods_iosApp.framework */,
 			);
 			name = Frameworks;
@@ -113,7 +113,7 @@
 				D21C05603AD67961BB6451F7 /* Sources */,
 				6365C4AF1AAD164DCCE558F9 /* Frameworks */,
 				D081E6A75F3CC26B3E25D43C /* Resources */,
-				C2EBC9292D22C90630BD52E8 /* [CP] Embed Pods Frameworks */,
+				A23154A0CEDA9301156D8F79 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -213,7 +213,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C2EBC9292D22C90630BD52E8 /* [CP] Embed Pods Frameworks */ = {
+		A23154A0CEDA9301156D8F79 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -221,9 +221,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/iosApp/iosApp.xcworkspace/contents.xcworkspacedata
+++ b/iosApp/iosApp.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:iosApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_pick/CategoryPickViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_pick/CategoryPickViewModel.kt
@@ -1,5 +1,8 @@
 package net.thechance.mena.trends.presentation.screen.category_pick
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import net.thechance.mena.trends.domain.entity.Category
 import net.thechance.mena.trends.domain.repository.CategoryRepository
 import net.thechance.mena.trends.presentation.shared.base.BaseViewModel
@@ -9,7 +12,8 @@ import org.koin.core.annotation.Provided
 
 @KoinViewModel
 internal class CategoryPickViewModel(
-    @Provided private val repository: CategoryRepository
+    @Provided private val repository: CategoryRepository,
+    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : BaseViewModel<CategoryPickScreenState, CategoryPickScreenEffect>(
     initialState = CategoryPickScreenState()
 ), CategoryPickInteractionListener {
@@ -24,7 +28,8 @@ internal class CategoryPickViewModel(
             onSuccess = ::handleLoadCategoriesSuccess,
             onError = { errorState -> updateState { copy(error = errorState) } },
             onStart = ::startLoading,
-            onEnd = ::endLoading
+            onEnd = ::endLoading,
+            dispatcher = defaultDispatcher
         )
     }
 
@@ -43,6 +48,7 @@ internal class CategoryPickViewModel(
             onStart = ::startSaving,
             onEnd = ::endSaving,
             onError = { errorState -> updateState { copy(error = errorState) } },
+            dispatcher = defaultDispatcher
         )
     }
 

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/category_pick/CategoryPickViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/category_pick/CategoryPickViewModelTest.kt
@@ -1,0 +1,144 @@
+package net.thechance.mena.trends.presentation.screen.category_pick
+
+import app.cash.turbine.test
+import assertk.assertThat
+import assertk.assertions.isNotNull
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import kotlinx.coroutines.test.runTest
+import net.thechance.mena.trends.domain.entity.Category
+import net.thechance.mena.trends.domain.repository.CategoryRepository
+import net.thechance.mena.trends.presentation.utils.TestExtensions
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CategoryPickViewModelTest : TestExtensions() {
+    private val repository: CategoryRepository = mock<CategoryRepository>(mode = MockMode.autofill)
+    private val viewModel by lazy {
+        CategoryPickViewModel(
+            repository = repository,
+            defaultDispatcher = testDispatcher
+        )
+    }
+    private val demoCategories = listOf(
+        Category(id = "1", name = "Category 1", emoji = "🫡"),
+        Category(id = "2", name = "Category 2", emoji = "🔥"),
+        Category(id = "3", name = "Category 3", emoji = "👻")
+    )
+
+    @BeforeTest
+    fun setup() {
+        everySuspend { repository.getAllCategories() } returns demoCategories
+    }
+
+    @Test
+    fun `loadCategories should start loading when initially called`() =
+        runTest(testDispatcher) {
+            viewModel.state.test {
+                val state = awaitItem()
+                assertTrue(state.isLoading)
+            }
+        }
+
+    @Test
+    fun `loadCategories should return categories with success when repository returns value`() =
+        runTest(testDispatcher) {
+            viewModel.state.test {
+                skipItems(1)
+                val state = awaitItem()
+                assertEquals(demoCategories.size, state.categories.size)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `loadCategories should throw exception when initially called`() =
+        runTest(testDispatcher) {
+            everySuspend { repository.getAllCategories() } throws Exception()
+
+            viewModel.state.test {
+                skipItems(1)
+                val state = awaitItem()
+                assertThat(state.error).isNotNull()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `loadCategories should end loading when initially called`() =
+        runTest(testDispatcher) {
+            viewModel.state.test {
+                skipItems(2)
+                val state = awaitItem()
+                assertFalse(state.isLoading)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `onCategoryClick should toggle category selection state`() = runTest(testDispatcher) {
+        viewModel.state.test {
+            skipItems(2)
+            val state = awaitItem()
+            val firstCategory = state.categories.first()
+            firstCategory.value.id?.let {
+                viewModel.onCategoryClick(it)
+            }
+
+            val updatedState = awaitItem()
+            val updatedFirstCategory =
+                updatedState.categories.first { it.value.id == firstCategory.value.id }
+            assertTrue(updatedFirstCategory.isSelected)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onBackClick should send NavigateBack effect when called`() = runTest(testDispatcher) {
+        viewModel.onBackClick()
+
+        viewModel.effect.test {
+            val effect = awaitItem()
+            assertTrue(effect is CategoryPickScreenEffect.NavigateBack)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onNextClick should called updateUserInterestedCategories from repository with success`() =
+        runTest(testDispatcher) {
+            val selectedIds = listOf(demoCategories.first().id)
+            everySuspend { repository.updateUserInterestedCategories(selectedIds) } returns Unit
+
+            viewModel.onNextClick()
+
+            viewModel.effect.test {
+                val effect = awaitItem()
+                assertTrue(effect is CategoryPickScreenEffect.NavigateToTrends)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `onNextClick should throw exception when called`() =
+        runTest(testDispatcher) {
+            everySuspend { repository.updateUserInterestedCategories(any()) } throws Exception()
+
+            viewModel.onNextClick()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            viewModel.state.test {
+                val state = awaitItem()
+                assertThat(state.error).isNotNull()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+}


### PR DESCRIPTION
**Inject CoroutineDispatcher into CategoryPickViewModel**

**Add unit tests for CategoryPickViewModel**
- `loadCategories` starts loading initially.
- `loadCategories` successfully returns categories when the repository provides data.
- `loadCategories` throws an exception when the repository call fails.
- `loadCategories` ends loading after completion.
- `onCategoryClick` toggles the selection state of a category.
- `onBackClick` sends a `NavigateBack` effect.
- `onNextClick` successfully calls `updateUserInterestedCategories` and sends a `NavigateToTrends` effect.
- `onNextClick` throws an exception if the repository call fails.