### PR TITLE
Feature/TRN-44-Enforce test coverage and refine Kover filters

### DIFF
--- a/trends_data/build.gradle.kts
+++ b/trends_data/build.gradle.kts
@@ -75,7 +75,7 @@ android {
 kover.reports {
     verify {
         rule {
-            minBound(70) // This should be 80 later
+            minBound(80)
         }
     }
 

--- a/trends_data/build.gradle.kts
+++ b/trends_data/build.gradle.kts
@@ -81,7 +81,7 @@ kover.reports {
 
     filters {
         excludes {
-            packages("mena.trends_presentation.generated.resources*")
+            packages("mena.trends_data.generated.resources*")
             classes(
                 "**.di.**",
                 "**.dto.**",

--- a/trends_data/build.gradle.kts
+++ b/trends_data/build.gradle.kts
@@ -75,7 +75,19 @@ android {
 kover.reports {
     verify {
         rule {
-            minBound(0)
+            minBound(80)
+        }
+    }
+
+    filters {
+        excludes {
+            packages("mena.trends_presentation.generated.resources*")
+            classes(
+                "**.di.**",
+                "**.dto.**",
+                "**.util.**",
+                "**org.koin.ksp.generated**",
+            )
         }
     }
 }

--- a/trends_data/build.gradle.kts
+++ b/trends_data/build.gradle.kts
@@ -75,7 +75,7 @@ android {
 kover.reports {
     verify {
         rule {
-            minBound(80)
+            minBound(70) // This should be 80 later
         }
     }
 

--- a/trends_domain/build.gradle.kts
+++ b/trends_domain/build.gradle.kts
@@ -48,7 +48,19 @@ project.tasks.withType(KotlinCompilationTask::class.java).configureEach {
 kover.reports {
     verify {
         rule {
-            minBound(0)
+            minBound(80)
+        }
+    }
+
+    filters {
+        excludes {
+            packages("mena.trends_presentation.generated.resources*")
+            classes(
+                "**.di.**",
+                "**.entity.**",
+                "**.exception.**",
+                "**org.koin.ksp.generated**",
+            )
         }
     }
 }

--- a/trends_domain/build.gradle.kts
+++ b/trends_domain/build.gradle.kts
@@ -54,7 +54,7 @@ kover.reports {
 
     filters {
         excludes {
-            packages("mena.trends_presentation.generated.resources*")
+            packages("mena.trends_domain.generated.resources*")
             classes(
                 "**.di.**",
                 "**.entity.**",

--- a/trends_presentation/build.gradle.kts
+++ b/trends_presentation/build.gradle.kts
@@ -103,13 +103,23 @@ android {
 kover.reports {
     verify {
         rule {
-            minBound(0)
+            minBound(80)
         }
     }
 
     filters {
+        includes {
+            classes("**.*ViewModel")
+        }
+
         excludes {
             packages("mena.trends_presentation.generated.resources*")
+            classes(
+                "**.di.**",
+                "**.navigation.**",
+                "**.shared.**",
+                "**org.koin.ksp.generated**",
+            )
         }
     }
 }

--- a/trends_presentation/build.gradle.kts
+++ b/trends_presentation/build.gradle.kts
@@ -103,7 +103,7 @@ android {
 kover.reports {
     verify {
         rule {
-            minBound(80)
+            minBound(75) // This should be 80 later
         }
     }
 


### PR DESCRIPTION
Kover report filters have been updated:
- In `trends_presentation`, reports will now specifically include `**.*ViewModel` classes and exclude DI, navigation, shared components, and Koin generated classes.
- In `trends_domain`, entities, exceptions, DI components, and Koin generated classes are excluded.
- In `trends_data`, DTOs, utility classes, DI components, and Koin generated classes are excluded.