### PR TITLE
Feature/IDN-81 Add contacts and internet permissions for Android and iOS

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_CONTACTS"/>
+    <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
 
     <application
         android:name=".MenaApp"

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -8,5 +8,7 @@
     <string>$(BASE_URL)</string>
     <key>CFBundleShortVersionString</key>
     <string>$(CFBundleShortVersionString)</string>
+    <key>NSContactsUsageDescription</key>
+    <string>We need access to your contacts.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Added permissions for accessing contacts in the project.
On Android included READ_CONTACTS and WRITE_CONTACTS in the manifest.
On iOS added NSContactsUsageDescription to Info.plist with a usage explanation.