### PR TITLE
feature/WLT-47 Integrate FileKit for file operations

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -83,6 +83,9 @@ kotlin {
             implementation(projects.trendsPresentation)
             implementation(projects.trendsDomain)
             implementation(projects.trendsData)
+
+            // File kit
+            implementation(libs.bundles.filekit)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/androidMain/kotlin/net/thechance/mena/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/net/thechance/mena/MainActivity.kt
@@ -6,11 +6,14 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.dialogs.init
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        FileKit.init(this)
         setContent {
             App()
         }


### PR DESCRIPTION
Add file kit initialization
using FileKit to manage saving files will need less code than writing two separate native implementations. also, file kit receves frequent update to stay compatible with newer kotlin versions