### PR TITLE
Test/ FTH 53 add hash check for Surah data class test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/commonMain/kotlin/net/thechance/mena/faith/domain/entity/Surah.kt text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-src/commonMain/kotlin/net/thechance/mena/faith/domain/entity/Surah.kt text eol=lf
+faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/entity/Surah.kt text eol=lf

--- a/faith_domain/src/jvmTest/kotlin/net/thechance/mena/faith/domain/entity/SurahTest.kt
+++ b/faith_domain/src/jvmTest/kotlin/net/thechance/mena/faith/domain/entity/SurahTest.kt
@@ -14,12 +14,12 @@ class SurahTest {
         assertEquals(
             FILE_HASH,
             actualHash,
-            message = "Surah.kt file has been modified!${actualHash}\n Please check the changes."
+            message = "Surah.kt file has been modified! new hash:${actualHash}\n Please check the changes."
         )
     }
 
     private companion object {
-        const val FILE_HASH = "9d8cb4694b0e7e74899c8d62a5cedc97"
+        const val FILE_HASH = "3ee45be83f266197549c3a15534bfe18"
         const val SURAH_FILE_PATH =
             "src/commonMain/kotlin/net/thechance/mena/faith/domain/entity/Surah.kt"
     }

--- a/faith_domain/src/jvmTest/kotlin/net/thechance/mena/faith/domain/entity/SurahTest.kt
+++ b/faith_domain/src/jvmTest/kotlin/net/thechance/mena/faith/domain/entity/SurahTest.kt
@@ -1,0 +1,34 @@
+package net.thechance.mena.faith.domain.entity
+
+import java.io.File
+import java.io.FileInputStream
+import java.security.MessageDigest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SurahTest {
+
+    @Test
+    fun `verify that Surah data class has not been modified`() {
+        val actualHash = calculateFileMd5Hash(File(SURAH_FILE_PATH))
+        assertEquals(FILE_HASH, actualHash, "Surah.kt file has been modified!")
+    }
+
+    private companion object {
+        const val FILE_HASH = "9d8cb4694b0e7e74899c8d62a5cedc97"
+        const val SURAH_FILE_PATH =
+            "src/commonMain/kotlin/net/thechance/mena/faith/domain/entity/Surah.kt"
+    }
+}
+
+private fun calculateFileMd5Hash(file: File): String {
+    val buffer = ByteArray(4 * 1024)
+    val md = MessageDigest.getInstance("MD5")
+    FileInputStream(file).use { fis ->
+        var bytesRead: Int
+        while (fis.read(buffer).also { bytesRead = it } != -1) {
+            md.update(buffer, 0, bytesRead)
+        }
+    }
+    return md.digest().joinToString("") { "%02x".format(it) }
+}

--- a/faith_domain/src/jvmTest/kotlin/net/thechance/mena/faith/domain/entity/SurahTest.kt
+++ b/faith_domain/src/jvmTest/kotlin/net/thechance/mena/faith/domain/entity/SurahTest.kt
@@ -14,11 +14,15 @@ class SurahTest {
         assertEquals(
             FILE_HASH,
             actualHash,
-            message = "Surah.kt file has been modified! new hash:${actualHash}\n Please check the changes."
+            message = "Surah.kt file has been modified! actual hash:${actualHash}\n Please check the changes."
         )
     }
 
     private companion object {
+        // NOTE: This MD5 hash is calculated from the Surah.kt file with LF line endings.
+        // Do not change unless Surah.kt itself is intentionally modified.
+        // If you run the test locally on Windows and see a different hash, make sure
+        // the file uses LF line endings (see .gitattributes).
         const val FILE_HASH = "3ee45be83f266197549c3a15534bfe18"
         const val SURAH_FILE_PATH =
             "src/commonMain/kotlin/net/thechance/mena/faith/domain/entity/Surah.kt"

--- a/faith_domain/src/jvmTest/kotlin/net/thechance/mena/faith/domain/entity/SurahTest.kt
+++ b/faith_domain/src/jvmTest/kotlin/net/thechance/mena/faith/domain/entity/SurahTest.kt
@@ -11,7 +11,11 @@ class SurahTest {
     @Test
     fun `verify that Surah data class has not been modified`() {
         val actualHash = calculateFileMd5Hash(File(SURAH_FILE_PATH))
-        assertEquals(FILE_HASH, actualHash, "Surah.kt file has been modified!")
+        assertEquals(
+            FILE_HASH,
+            actualHash,
+            message = "Surah.kt file has been modified!${actualHash}\n Please check the changes."
+        )
     }
 
     private companion object {


### PR DESCRIPTION
Added a new test class `SurahTest` to verify the integrity of the `Surah.kt` file.
This test calculates the MD5 hash of `Surah.kt` and compares it against a known hash value.
This ensures that the `Surah` data class, which represents critical domain data, is not accidentally modified.