### PR TITLE
Add auto-generated Xcode files  to the gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ captures
 iosApp/Pods
 *.podspec
 */schemas
+*.xcworkspace
+*.lock


### PR DESCRIPTION
This PR removes some auto-generated files by Xcode that does not need to be versioned.