### PR TITLE
Implement enhanced API error handling

### DIFF
--- a/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/repository/dto/ErrorResponse.kt
+++ b/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/repository/dto/ErrorResponse.kt
@@ -1,0 +1,23 @@
+package net.thechance.mena.dukan.data.repository.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ErrorResponse(
+    val message: String,
+    val errors: Map<String, String>? = null,
+    val errorCode: Int? = null
+)
+
+object DukanErrorCodes {
+    const val DUKAN_CREATION_FAILED = 1101
+    const val DUKAN_NOT_FOUND = 1102
+    const val INVALID_IMAGE_FORMAT = 1201
+    const val IMAGE_UPLOAD_FAILED = 1202
+    const val PRODUCT_NOT_FOUND = 1301
+    const val DUKAN_PRODUCT_CREATION_FAILED = 1302
+    const val PRODUCT_NAME_ALREADY_TAKEN = 1303
+    const val SHELF_DELETION_NOT_ALLOWED = 1401
+    const val SHELF_NOT_FOUND = 1402
+    const val SHELF_NAME_ALREADY_TAKEN = 1403
+}

--- a/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/repository/util/safeApiCall.kt
+++ b/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/repository/util/safeApiCall.kt
@@ -3,6 +3,8 @@ package net.thechance.mena.dukan.data.repository.util
 import io.ktor.client.call.body
 import io.ktor.client.statement.HttpResponse
 import kotlinx.io.IOException
+import net.thechance.mena.dukan.data.repository.dto.DukanErrorCodes
+import net.thechance.mena.dukan.data.repository.dto.ErrorResponse
 import net.thechance.mena.dukan.domain.exceptions.DukanException
 import net.thechance.mena.dukan.domain.exceptions.DukanNotFoundException
 import net.thechance.mena.dukan.domain.exceptions.NoInternetException
@@ -29,11 +31,46 @@ suspend inline fun <reified T> handleResponse(response: HttpResponse): T {
                 throw DukanException("Error parsing response")
             }
         }
-        400 -> throw DukanNotFoundException("Bad request")
+
+        400 -> {
+            val errorResponse = try {
+                response.body<ErrorResponse>()
+            } catch (_: Exception) {
+                ErrorResponse("Bad request")
+            }
+            throw mapErrorResponseToException(errorResponse)
+        }
+
         401 -> throw DukanException("Unauthorized")
+        404 -> {
+            val errorResponse = try {
+                response.body<ErrorResponse>()
+            } catch (_: Exception) {
+                ErrorResponse("Not found")
+            }
+            throw mapErrorResponseToException(errorResponse)
+        }
+
         408 -> throw DukanException("Request timeout")
         429 -> throw DukanException("Too many requests")
         in 500..599 -> throw DukanException("Server error")
         else -> throw DukanException("Unexpected error")
+    }
+}
+
+fun mapErrorResponseToException(errorResponse: ErrorResponse): Exception {
+    val errorCode = errorResponse.errorCode
+    return when (errorCode) {
+        DukanErrorCodes.DUKAN_CREATION_FAILED -> DukanException("Dukan creation failed: ${errorResponse.message}")
+        DukanErrorCodes.DUKAN_NOT_FOUND -> DukanNotFoundException("Dukan not found: ${errorResponse.message}")
+        DukanErrorCodes.INVALID_IMAGE_FORMAT -> DukanException("Invalid image format: ${errorResponse.message}")
+        DukanErrorCodes.IMAGE_UPLOAD_FAILED -> DukanException("Image upload failed: ${errorResponse.message}")
+        DukanErrorCodes.PRODUCT_NOT_FOUND -> DukanNotFoundException("Product not found: ${errorResponse.message}")
+        DukanErrorCodes.DUKAN_PRODUCT_CREATION_FAILED -> DukanException("Product creation failed: ${errorResponse.message}")
+        DukanErrorCodes.PRODUCT_NAME_ALREADY_TAKEN -> DukanException("Product name already taken: ${errorResponse.message}")
+        DukanErrorCodes.SHELF_DELETION_NOT_ALLOWED -> DukanException("Shelf deletion not allowed: ${errorResponse.message}")
+        DukanErrorCodes.SHELF_NOT_FOUND -> DukanNotFoundException("Shelf not found: ${errorResponse.message}")
+        DukanErrorCodes.SHELF_NAME_ALREADY_TAKEN -> DukanException("Shelf name already taken: ${errorResponse.message}")
+        else -> DukanException(errorResponse.message)
     }
 }


### PR DESCRIPTION
# Add centralized error handling for Dukan API

- Add ErrorResponse model to parse API error payloads
- Define DukanErrorCodes constants
- Map HTTP error codes (400, 401, 404, 408, 429) to domain exceptions
- Implement mapErrorResponseToException to convert errorCode -> Exception
