### PR TITLE
Feature/TRN-51-fix-upload-reel-bug

### DIFF
--- a/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/repository/ReelsRepositoryImpl.kt
+++ b/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/repository/ReelsRepositoryImpl.kt
@@ -7,6 +7,7 @@ import io.ktor.client.request.parameter
 import io.ktor.client.request.setBody
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
+import io.ktor.http.contentType
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.asSource
 import kotlinx.coroutines.flow.Flow
@@ -57,6 +58,7 @@ internal class ReelsRepositoryImpl(
         val request = UpdateReelRequestDTO(description, categoryIds)
         safeApiCall<Unit> {
             networkClient.put("$TRENDS_PATH/$REELS_ENDPOINT/$id") {
+                contentType(io.ktor.http.ContentType.Application.Json)
                 setBody(request)
             }
         }
@@ -107,7 +109,7 @@ internal class ReelsRepositoryImpl(
                         ByteReadChannel(reelBytes).asSource().buffered()
                     },
                     headers = Headers.build {
-                        append(HttpHeaders.ContentType, "video/*")
+                        append(HttpHeaders.ContentType, "video/$mimeType")
                         append(HttpHeaders.ContentDisposition, "filename=\"$name.$mimeType\"")
                     }
                 )

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/manage_my_trends/ManageTrendsScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/manage_my_trends/ManageTrendsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -64,6 +65,10 @@ internal fun ManageTrendsScreen(
                 navController.navigate(Route.ReelDetails(effect.reelId))
             }
         }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.getReels()
     }
 
     ManageTrendsScreenContent(

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
@@ -74,7 +74,6 @@ internal fun UserReelScreen(
     )
 }
 
-// TODO: That Screen Should be improved later when implementing video player
 @Composable
 private fun UserReelScreenContent(
     state: UserReelState,
@@ -105,6 +104,7 @@ private fun UserReelScreenContent(
                     buttonText = "",
                     dismissOnBackPress = true,
                     dismissOnClickOutside = true,
+                    isVisible = state.isReelDeleted == true && state.error == null,
                     onDismiss = {
                         listener.onDismissSuccessDialog()
                         listener.onBackClick()
@@ -126,6 +126,7 @@ private fun UserReelScreenContent(
                     buttonText = "",
                     dismissOnBackPress = true,
                     dismissOnClickOutside = true,
+                    isVisible = state.error != null,
                     onDismiss = { listener.onDismissErrorDialog() },
                     onCancelClick = { listener.onDismissErrorDialog() },
                     dialogCornerShape = RoundedCornerShape(12.dp),

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
@@ -88,6 +88,7 @@ private fun UserReelScreenContent(
                     buttonText = stringResource(Res.string.delete),
                     dismissOnBackPress = true,
                     dismissOnClickOutside = true,
+                    isVisible = state.isConfirmationDialogVisible,
                     onDismiss = { listener.onDismissConfirmationDialog() },
                     onActionClick = { listener.onConfirmDeleteClick() },
                     onCancelClick = { listener.onDismissConfirmationDialog() },


### PR DESCRIPTION
- Display success and error dialogs based on the deletion status.
- Add `LaunchedEffect` in `ManageTrendsScreen` to fetch reels upon composition.
- Set the `Content-Type` to `application/json` in the `updateReel` request.
- Dynamically set the video `Content-Type` based on the MIME type during upload.