### PR TITLE
fix/DKN-70-dukan-managmenet

### DIFF
--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/productCard/LoadingProductCard.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/productCard/LoadingProductCard.kt
@@ -1,5 +1,6 @@
 package net.thechance.mena.dukan.presentation.component.productCard
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,24 +15,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
 import mena.dukan_presentation.generated.resources.Res
 import mena.dukan_presentation.generated.resources.koin_icon
-import mena.dukan_presentation.generated.resources.product_image
 import mena.dukan_presentation.generated.resources.silver_tc
-import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
-import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ProductUiState
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
-
 
 @Composable
-fun ProductCard(
-    productUiState: ProductUiState,
-    productAction: @Composable () -> Unit,
+fun LoadingProductCard(
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -52,13 +45,11 @@ fun ProductCard(
                 )
             )
         ) {
-            AsyncImage(
-                model = productUiState.imageUrl,
-                contentDescription = stringResource(Res.string.product_image),
+            Box(
                 modifier = Modifier
                     .size(96.dp)
-                    .clip(RoundedCornerShape(Theme.radius.sm)),
-                contentScale = ContentScale.Crop
+                    .clip(RoundedCornerShape(Theme.radius.sm))
+                    .background(Theme.colorScheme.disabled),
             )
         }
         Column(
@@ -70,9 +61,20 @@ fun ProductCard(
                     end = Theme.spacing._4
                 ),
         ) {
-            ProductInfo(
-                name = productUiState.name,
-                description = productUiState.description
+            Box(
+                modifier = Modifier
+                    .height(Theme.spacing._16)
+                    .fillMaxWidth(0.33f)
+                    .clip(RoundedCornerShape(Theme.radius.full))
+                    .background(Theme.colorScheme.disabled)
+            )
+            Box(
+                modifier = Modifier
+                    .padding(top = Theme.spacing._2)
+                    .height(Theme.spacing._32)
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(Theme.radius.md))
+                    .background(Theme.colorScheme.disabled)
             )
             Spacer(modifier = Modifier.weight(1f))
             Row(
@@ -81,33 +83,28 @@ fun ProductCard(
                     .padding(vertical = Theme.spacing._4),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                PriceWithIcon(
-                    price = productUiState.price.toString(),
-                    iconRes = Res.drawable.silver_tc,
-                    contentDescription = stringResource(Res.string.koin_icon),
-                )
-                Spacer(modifier = Modifier.weight(1f))
+                Row(
+                    modifier = modifier,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .height(Theme.spacing._24)
+                            .fillMaxWidth(0.25f)
+                            .clip(RoundedCornerShape(Theme.radius.full))
+                            .background(Theme.colorScheme.disabled)
+                    )
 
-                productAction()
+                    Image(
+                        painter = painterResource(Res.drawable.silver_tc),
+                        contentDescription = stringResource(Res.string.koin_icon),
+                        modifier = Modifier
+                            .padding(start = Theme.spacing._4)
+                            .size(20.dp)
+                    )
+                }
+                Spacer(modifier = Modifier.weight(1f))
             }
         }
-    }
-}
-
-@Preview
-@Composable
-private fun ProductCardPreview() {
-    MenaTheme {
-        ProductCard(
-            ProductUiState(
-                id = "1",
-                imageUrl = "https://calvinklein.scene7.com/is/image/CalvinKlein/LX001376_100_alternate1?wid=1728&qlt=80%2C0&resMode=sharp2&op_usm=0.9%2C1.0%2C8%2C0&iccEmbed=0&fmt=webp",
-                name = "Girls Crochet Tank Top",
-                description = "Girls Crochet Tank Top description text here for this product",
-                price = 39.5
-            ),
-            productAction = { EditProductIcon(onClick = {}) },
-            modifier = Modifier.padding(Theme.spacing._12),
-        )
     }
 }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/productCard/PriceWithIcon.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/productCard/PriceWithIcon.kt
@@ -1,5 +1,6 @@
 package net.thechance.mena.dukan.presentation.component.productCard
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -10,7 +11,6 @@ import androidx.compose.ui.unit.dp
 import mena.dukan_presentation.generated.resources.Res
 import mena.dukan_presentation.generated.resources.koin_icon
 import mena.dukan_presentation.generated.resources.silver_tc
-import net.thechance.mena.designsystem.presentation.component.image.Image
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import org.jetbrains.compose.resources.DrawableResource

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/productCard/ProductCard.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/productCard/ProductCard.kt
@@ -51,7 +51,6 @@ fun ProductCard(
                 )
             )
         ) {
-
             AsyncImage(
                 model = productUiState.imageUrl,
                 contentDescription = stringResource(Res.string.product_image),
@@ -59,7 +58,6 @@ fun ProductCard(
                     .size(96.dp)
                     .clip(RoundedCornerShape(Theme.radius.sm)),
             )
-
         }
         Column(
             modifier = Modifier
@@ -74,9 +72,7 @@ fun ProductCard(
                 name = productUiState.name,
                 description = productUiState.description
             )
-
             Spacer(modifier = Modifier.weight(1f))
-
             Row(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/productCard/ProductInfo.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/productCard/ProductInfo.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 
@@ -22,10 +23,13 @@ fun ProductInfo(
 
         description?.let {
             Text(
+                modifier = Modifier.padding(top = Theme.spacing._2),
                 text = it,
                 style = Theme.typography.label.small,
                 color = Theme.colorScheme.shadeTertiary,
-                modifier = Modifier.padding(top = Theme.spacing._2)
+                maxLines = 2,
+                minLines = 2,
+                overflow = TextOverflow.Ellipsis
             )
         }
     }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/main/MainScreen.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/main/MainScreen.kt
@@ -59,7 +59,7 @@ private fun MainContent(
         topBar = {
             TopAppBar(
                 modifier = Modifier.statusBarsPadding(),
-                onAddDukanIconClicked = listener::onDukanButtonClicked,
+                onDukanIconClicked = listener::onDukanButtonClicked,
                 dukanButtonStatus = state.dukanState.status
             )
         },

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/main/components/TopAppBar.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/main/components/TopAppBar.kt
@@ -39,7 +39,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @Composable
 fun TopAppBar(
     modifier: Modifier = Modifier,
-    onAddDukanIconClicked: () -> Unit,
+    onDukanIconClicked: () -> Unit,
     dukanButtonStatus: MainScreenUiState.DukanStatusUi,
 ) {
     AppBar(
@@ -53,7 +53,7 @@ fun TopAppBar(
         trailingContent = {
             DukanIconButton(
                 dukanButtonStatus = dukanButtonStatus,
-                onAddDukanIconClicked = onAddDukanIconClicked
+                onDukanIconClicked = onDukanIconClicked
             )
         }
     )
@@ -62,7 +62,7 @@ fun TopAppBar(
 @Composable
 private fun DukanIconButton(
     dukanButtonStatus: MainScreenUiState.DukanStatusUi,
-    onAddDukanIconClicked: () -> Unit,
+    onDukanIconClicked: () -> Unit,
 ) {
     AnimatedContent(
         targetState = dukanButtonStatus,
@@ -70,40 +70,52 @@ private fun DukanIconButton(
         label = stringResource(resource = Res.string.dukan_button)
     )
     { dukanStatus ->
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .background(
-                    color = Theme.colorScheme.background.surfaceLow,
-                    shape = RoundedCornerShape(Theme.radius.md)
-                )
-                .clip(shape = RoundedCornerShape(Theme.radius.md))
-                .clickable(onClick = onAddDukanIconClicked),
-            contentAlignment = Alignment.Center
-        ) {
-            when (dukanStatus) {
-                MainScreenUiState.DukanStatusUi.None -> {
-                    Icon(
-                        painter = painterResource(resource = Res.drawable.ic_add_dukan),
-                        contentDescription = stringResource(resource = Res.string.add_dukan_icon)
-                    )
-                }
-
-                MainScreenUiState.DukanStatusUi.Pending -> {
-                    Icon(
-                        painter = painterResource(resource = Res.drawable.ic_dukan),
-                        contentDescription = stringResource(resource = Res.string.dukan_icon)
-                    )
-                }
-
-                MainScreenUiState.DukanStatusUi.Approved -> {
-                    Icon(
-                        painter = painterResource(resource = Res.drawable.ic_dukan),
-                        contentDescription = stringResource(resource = Res.string.dukan_icon)
-                    )
+        when (dukanStatus) {
+            MainScreenUiState.DukanStatusUi.Loading -> {}
+            else -> {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .background(
+                            color = Theme.colorScheme.background.surfaceLow,
+                            shape = RoundedCornerShape(Theme.radius.md)
+                        )
+                        .clip(shape = RoundedCornerShape(Theme.radius.md))
+                        .clickable(onClick = onDukanIconClicked),
+                    contentAlignment = Alignment.Center
+                ) {
+                    DukanIcon(dukanStatus)
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun DukanIcon(dukanStatus: MainScreenUiState.DukanStatusUi) {
+    when (dukanStatus) {
+        MainScreenUiState.DukanStatusUi.None -> {
+            Icon(
+                painter = painterResource(resource = Res.drawable.ic_add_dukan),
+                contentDescription = stringResource(resource = Res.string.add_dukan_icon)
+            )
+        }
+
+        MainScreenUiState.DukanStatusUi.Pending -> {
+            Icon(
+                painter = painterResource(resource = Res.drawable.ic_dukan),
+                contentDescription = stringResource(resource = Res.string.dukan_icon)
+            )
+        }
+
+        MainScreenUiState.DukanStatusUi.Approved -> {
+            Icon(
+                painter = painterResource(resource = Res.drawable.ic_dukan),
+                contentDescription = stringResource(resource = Res.string.dukan_icon)
+            )
+        }
+
+        MainScreenUiState.DukanStatusUi.Loading -> {}
     }
 }
 
@@ -135,7 +147,7 @@ private fun TopAppBarPreview() {
         ) {
             TopAppBar(
                 dukanButtonStatus = MainScreenUiState.DukanStatusUi.None,
-                onAddDukanIconClicked = {})
+                onDukanIconClicked = {})
         }
     }
 }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/manageDukan/compnent/ProductsList.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/manageDukan/compnent/ProductsList.kt
@@ -3,6 +3,7 @@ package net.thechance.mena.dukan.presentation.screen.manageDukan.compnent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -33,7 +34,8 @@ fun ProductsList(
     lazyListState.LoadMoreOnScroll(pager)
 
     LazyColumn(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth()
+            .padding(top = Theme.spacing._8),
         verticalArrangement = Arrangement.spacedBy(Theme.spacing._8),
         contentPadding = PaddingValues(
             horizontal = Theme.spacing._16,
@@ -43,6 +45,7 @@ fun ProductsList(
     ) {
         items(products) { product ->
             ProductCard(
+                modifier = Modifier.animateItem(),
                 productUiState = product,
                 productAction = {
                     EditProductIcon(onClick = {

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/manageDukan/content/ManageDukanContent.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/manageDukan/content/ManageDukanContent.kt
@@ -1,5 +1,9 @@
 package net.thechance.mena.dukan.presentation.screen.manageDukan.content
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -15,6 +19,7 @@ import mena.dukan_presentation.generated.resources.ic_arrow_left
 import mena.dukan_presentation.generated.resources.my_dukan
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
 import net.thechance.mena.designsystem.presentation.component.button.FabButton
+import net.thechance.mena.designsystem.presentation.component.button.TextButton
 import net.thechance.mena.designsystem.presentation.component.dialog.Dialog
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
@@ -45,73 +50,103 @@ fun ManageDukanContent(
     OnSystemBackPressed(listener::onBackButtonClicked)
 
     Scaffold(
-        overlays = {
-            dialog(state.showDeleteConfirmationDialog) {
-                state.deleteShelfConfirmationDialogUiState?.let {
-                    DeleteShelfConfirmationDialog(
-                        state = it,
-                        deletedShelfId = state.deleteShelfConfirmationDialogUiState.shelfId,
-                        listener = listener
-                    )
-                }
-            }
-        },
-        topBar = {
-            AppBar(
-                title = stringResource(Res.string.my_dukan),
-                onLeadingClick = listener::onBackButtonClicked,
-                contentPadding = PaddingValues(
-                    horizontal = Theme.spacing._16,
-                    vertical = Theme.spacing._8
-                ),
-                leadingContent = {
-                    Icon(
-                        painter = painterResource(Res.drawable.ic_arrow_left),
-                        contentDescription = stringResource(Res.string.back_arrow),
-                        tint = Theme.colorScheme.shadePrimary
-                    )
-                }
-            )
-        }
+        overlays = { manageDukanDialog(state, listener) },
+        topBar = { ManageDukanAppBar(listener) },
+        snakeBar = { ManageDukanSnackbar(state, listener) }
     ) {
-        Column(
+        Box(
             modifier = Modifier.fillMaxSize()
         ) {
-            if (state.shelves.isNotEmpty()) {
-                ManageDukanHeader(
-                    state = state,
-                    listener = listener
-                )
-            }
+            Column {
+                AnimatedContent(state.shelves.isNotEmpty()) {
+                    if (it) {
+                        ManageDukanHeader(
+                            state = state,
+                            listener = listener
+                        )
+                    }
+                }
 
-            if (state.shelves.isEmpty() || state.products.items.isEmpty()) {
+                if (state.shelves.isEmpty() || state.products.items.isEmpty()) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+
+                ManageDukanProducts(
+                    state = state,
+                    onProductClick = listener::onProductClick,
+                    pager = pager
+                )
+
                 Spacer(modifier = Modifier.weight(1f))
             }
-
-            ManageDukanProducts(
-                state = state,
-                onProductClick = listener::onProductClick,
-                pager = pager
-            )
-
-            Spacer(modifier = Modifier.weight(1f))
-
             FabButton(
                 modifier = Modifier
-                    .align(Alignment.End)
+                    .align(Alignment.BottomEnd)
                     .padding(end = Theme.spacing._16, bottom = Theme.spacing._24),
                 onClick = listener::onAddShelfClicked,
                 painter = painterResource(Res.drawable.ic_add_bold)
             )
-
         }
     }
+}
 
-    state.snackBarState?.let { snackBarState ->
-        SnackBar(
-            snackBarUiState = snackBarState,
-            onDismiss = listener::onDismissSnackBar
-        )
+private fun ScaffoldScope.manageDukanDialog(
+    state: ManageDukanUiState,
+    listener: ManageDukanInteractionListener
+) {
+    dialog(state.showDeleteConfirmationDialog) {
+        state.deleteShelfConfirmationDialogUiState?.let {
+            DeleteShelfConfirmationDialog(
+                state = state.deleteShelfConfirmationDialogUiState,
+                deletedShelfId = state.deleteShelfConfirmationDialogUiState.shelfId,
+                listener = listener
+            )
+        }
+    }
+}
+
+@Composable
+private fun ManageDukanAppBar(listener: ManageDukanInteractionListener) {
+    AppBar(
+        title = stringResource(Res.string.my_dukan),
+        onLeadingClick = listener::onBackButtonClicked,
+        contentPadding = PaddingValues(
+            horizontal = Theme.spacing._16,
+            vertical = Theme.spacing._8
+        ),
+        leadingContent = {
+            Icon(
+                painter = painterResource(Res.drawable.ic_arrow_left),
+                contentDescription = stringResource(Res.string.back_arrow),
+                tint = Theme.colorScheme.shadePrimary
+            )
+        }
+    )
+}
+
+@Composable
+private fun ManageDukanSnackbar(
+    state: ManageDukanUiState,
+    listener: ManageDukanInteractionListener
+) {
+    AnimatedContent(
+        targetState = state.snackBarState != null,
+        transitionSpec = {
+            slideIntoContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Down
+            ) togetherWith slideOutOfContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Up
+            )
+        }
+    ) {
+        if (it) {
+            state.snackBarState?.let {
+                SnackBar(
+                    snackBarUiState = state.snackBarState,
+                    onDismiss = listener::onDismissSnackBar
+                )
+            }
+        }
     }
 }
 
@@ -123,17 +158,25 @@ private fun ScaffoldScope.DeleteShelfConfirmationDialog(
 ) {
     Dialog(
         title = stringResource(state.title),
+        isVisible = state.isDialogVisible,
         message = stringResource(state.description),
-        buttonText = stringResource(state.type.text),
         onDismiss = { listener.onDismissDeleteShelfConfirmationDialog() },
-        onActionClick = {
-            if (state.type == ConfirmDialogType.DISMISS) {
-                listener.onDismissDeleteShelfConfirmationDialog()
-            } else {
-                deletedShelfId?.let { shelfId ->
-                    listener.onDeleteConfirmed(shelfId = shelfId)
+        actionButtons = {
+            TextButton(
+                modifier = Modifier
+                    .align(Alignment.End)
+                    .padding(top = Theme.spacing._24, bottom = Theme.spacing._8),
+                text = stringResource(state.type.text),
+                onClick = {
+                    if (state.type == ConfirmDialogType.DISMISS) {
+                        listener.onDismissDeleteShelfConfirmationDialog()
+                    } else {
+                        deletedShelfId?.let { shelfId ->
+                            listener.onDeleteConfirmed(shelfId = shelfId)
+                        }
+                    }
                 }
-            }
+            )
         },
         onCancelClick = { listener.onDismissDeleteShelfConfirmationDialog() }
     )

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/manageDukan/content/ManageDukanContent.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/manageDukan/content/ManageDukanContent.kt
@@ -37,6 +37,7 @@ import net.thechance.mena.dukan.presentation.viewModel.manageDukan.DeleteShelfCo
 import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ManageDukanInteractionListener
 import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ManageDukanUiState
 import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ProductUiState
+import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ShelvesState
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -58,12 +59,16 @@ fun ManageDukanContent(
             modifier = Modifier.fillMaxSize()
         ) {
             Column {
-                AnimatedContent(state.shelves.isNotEmpty()) {
-                    if (it) {
-                        ManageDukanHeader(
-                            state = state,
-                            listener = listener
-                        )
+                AnimatedContent(state.shelvesState) {
+                    when (it) {
+                        ShelvesState.LOADING -> {}
+                        ShelvesState.LOADED ->
+                            ManageDukanHeader(
+                                state = state,
+                                listener = listener
+                            )
+
+                        ShelvesState.EMPTY -> {}
                     }
                 }
 

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/manageDukan/content/ManageDukanContent.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/manageDukan/content/ManageDukanContent.kt
@@ -37,7 +37,6 @@ import net.thechance.mena.dukan.presentation.viewModel.manageDukan.DeleteShelfCo
 import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ManageDukanInteractionListener
 import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ManageDukanUiState
 import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ProductUiState
-import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ShelvesState
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -59,29 +58,19 @@ fun ManageDukanContent(
             modifier = Modifier.fillMaxSize()
         ) {
             Column {
-                AnimatedContent(state.shelvesState) {
-                    when (it) {
-                        ShelvesState.LOADING -> {}
-                        ShelvesState.LOADED ->
-                            ManageDukanHeader(
-                                state = state,
-                                listener = listener
-                            )
-
-                        ShelvesState.EMPTY -> {}
-                    }
-                }
+                ManageDukanHeader(
+                    state = state,
+                    listener = listener
+                )
 
                 if (state.shelves.isEmpty() || state.products.items.isEmpty()) {
                     Spacer(modifier = Modifier.weight(1f))
                 }
-
                 ManageDukanProducts(
                     state = state,
                     onProductClick = listener::onProductClick,
                     pager = pager
                 )
-
                 Spacer(modifier = Modifier.weight(1f))
             }
             FabButton(

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/manageDukan/content/ManageDukanHeader.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/manageDukan/content/ManageDukanHeader.kt
@@ -1,9 +1,16 @@
 package net.thechance.mena.dukan.presentation.screen.manageDukan.content
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
@@ -11,8 +18,12 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import mena.dukan_presentation.generated.resources.Res
 import mena.dukan_presentation.generated.resources.add_product
+import mena.dukan_presentation.generated.resources.approved_dukan
+import mena.dukan_presentation.generated.resources.dukan_approved_body
+import mena.dukan_presentation.generated.resources.dukan_approved_header
 import mena.dukan_presentation.generated.resources.edit_shelf
 import mena.dukan_presentation.generated.resources.ic_package_add
 import mena.dukan_presentation.generated.resources.ic_pencil_edit
@@ -23,8 +34,10 @@ import net.thechance.mena.designsystem.presentation.component.chip.Chip
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.dukan.presentation.component.ImageWithTextContainer
 import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ManageDukanInteractionListener
 import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ManageDukanUiState
+import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ShelvesState
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -34,29 +47,41 @@ fun ManageDukanHeader(
     listener: ManageDukanInteractionListener
 ) {
     Column {
-        Text(
-            text = stringResource(Res.string.shelves),
-            style = Theme.typography.title.small,
-            color = Theme.colorScheme.shadePrimary,
-            modifier = Modifier.padding(
-                horizontal = Theme.spacing._16,
-                vertical = Theme.spacing._8
-            )
-        )
-
-        LazyRow(
-            contentPadding = PaddingValues(horizontal = Theme.spacing._16),
-            horizontalArrangement = Arrangement.spacedBy(Theme.spacing._8)
+        AnimatedVisibility(
+            visible = state.shelvesState != ShelvesState.EMPTY
         ) {
-            items(
-                items = state.shelves,
-                key = { item -> item.id }
-            ) { item ->
-                Chip(
-                    text = item.name,
-                    isSelected = listener.isShelfSelected(item),
-                    onClick = { listener.onShelfSelected(item) },
+            when (state.shelvesState) {
+                ShelvesState.EMPTY -> {}
+                else -> Text(
+                    text = stringResource(Res.string.shelves),
+                    style = Theme.typography.title.small,
+                    color = Theme.colorScheme.shadePrimary,
+                    modifier = Modifier.padding(
+                        horizontal = Theme.spacing._16,
+                        vertical = Theme.spacing._8
+                    )
                 )
+            }
+        }
+
+        AnimatedContent(
+            targetState = state.shelvesState,
+            transitionSpec = {
+                fadeIn(tween()) togetherWith fadeOut(tween())
+            }
+        ) {
+            when (it) {
+                ShelvesState.LOADING -> LoadingShelvesRow()
+
+                ShelvesState.LOADED -> LoadedShelvesRow(state, listener)
+
+                ShelvesState.EMPTY -> {
+                    Column {
+                        Spacer(modifier = Modifier.weight(1f))
+                        NoShelvesContent()
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
+                }
             }
         }
 
@@ -64,6 +89,61 @@ fun ManageDukanHeader(
             productCount = state.totalProducts,
             listener = listener
         )
+    }
+}
+
+@Composable
+private fun NoShelvesContent() {
+    ImageWithTextContainer(
+        foregroundImageRes = Res.drawable.approved_dukan,
+        header = {
+            Text(
+                text = stringResource(Res.string.dukan_approved_header),
+                style = Theme.typography.title.small,
+                color = Theme.colorScheme.shadePrimary,
+                textAlign = TextAlign.Center
+            )
+        },
+        bodyText = stringResource(Res.string.dukan_approved_body)
+    )
+}
+
+@Composable
+private fun LoadedShelvesRow(
+    state: ManageDukanUiState,
+    listener: ManageDukanInteractionListener
+) {
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = Theme.spacing._16),
+        horizontalArrangement = Arrangement.spacedBy(Theme.spacing._8)
+    ) {
+        items(
+            items = state.shelves,
+            key = { it.id }
+        ) { item ->
+            Chip(
+                text = item.name,
+                isSelected = listener.isShelfSelected(item),
+                onClick = { listener.onShelfSelected(item) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadingShelvesRow() {
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = Theme.spacing._16),
+        horizontalArrangement = Arrangement.spacedBy(Theme.spacing._8)
+    ) {
+        items(count = 8) {
+            Chip(
+                text = "             ",
+                isSelected = false,
+                isEnabled = false,
+                onClick = { }
+            )
+        }
     }
 }
 
@@ -79,11 +159,18 @@ private fun ProductCountRow(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(
-            text = stringResource(Res.string.products_count, productCount),
-            style = Theme.typography.label.medium,
-            color = Theme.colorScheme.shadeSecondary
-        )
+        AnimatedContent(
+            targetState = productCount,
+            transitionSpec = {
+                fadeIn(tween()) togetherWith fadeOut(tween())
+            }
+        ) {
+            Text(
+                text = stringResource(Res.string.products_count, it),
+                style = Theme.typography.label.medium,
+                color = Theme.colorScheme.shadeSecondary
+            )
+        }
 
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/manageDukan/content/ManageDukanProducts.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/manageDukan/content/ManageDukanProducts.kt
@@ -5,18 +5,22 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import mena.dukan_presentation.generated.resources.Res
-import mena.dukan_presentation.generated.resources.approved_dukan
-import mena.dukan_presentation.generated.resources.dukan_approved_body
-import mena.dukan_presentation.generated.resources.dukan_approved_header
 import mena.dukan_presentation.generated.resources.empty_shelf
 import mena.dukan_presentation.generated.resources.shelf_empty_body
 import mena.dukan_presentation.generated.resources.shelf_empty_title
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.dukan.presentation.component.ImageWithTextContainer
+import net.thechance.mena.dukan.presentation.component.productCard.LoadingProductCard
 import net.thechance.mena.dukan.presentation.screen.manageDukan.compnent.ProductsList
 import net.thechance.mena.dukan.presentation.util.pagination.Pager
 import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ManageDukanUiState
@@ -33,37 +37,38 @@ fun ManageDukanProducts(
     AnimatedContent(
         targetState = state.productState,
         transitionSpec = {
-            fadeIn(animationSpec = tween()) togetherWith
-                    fadeOut(animationSpec = tween())
+            fadeIn(animationSpec = tween(300)) togetherWith
+                    fadeOut(animationSpec = tween(300))
         },
         label = "ContentAnimation"
     ) { target ->
         when (target) {
-            ProductsState.LOADING -> {}
+            ProductsState.LOADING -> {
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth()
+                        .padding(top = Theme.spacing._8),
+                    verticalArrangement = Arrangement.spacedBy(Theme.spacing._8),
+                    contentPadding = PaddingValues(
+                        horizontal = Theme.spacing._16,
+                        vertical = Theme.spacing._8
+                    ),
+                ) {
+                    items(8) {
+                        LoadingProductCard()
+                    }
+                }
+            }
+
             ProductsState.LOADED -> ProductsList(
                 products = state.products.items,
                 onProductClick = onProductClick,
                 pager = pager
             )
+
             ProductsState.EMPTY -> EmptyStateContent()
+
         }
     }
-}
-
-@Composable
-private fun NoShelvesContent() {
-    ImageWithTextContainer(
-        foregroundImageRes = Res.drawable.approved_dukan,
-        header = {
-            Text(
-                text = stringResource(Res.string.dukan_approved_header),
-                style = Theme.typography.title.small,
-                color = Theme.colorScheme.shadePrimary,
-                textAlign = TextAlign.Center
-            )
-        },
-        bodyText = stringResource(Res.string.dukan_approved_body)
-    )
 }
 
 @Composable

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/manageDukan/content/ManageDukanProducts.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/manageDukan/content/ManageDukanProducts.kt
@@ -1,5 +1,10 @@
 package net.thechance.mena.dukan.presentation.screen.manageDukan.content
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.style.TextAlign
 import mena.dukan_presentation.generated.resources.Res
@@ -16,6 +21,7 @@ import net.thechance.mena.dukan.presentation.screen.manageDukan.compnent.Product
 import net.thechance.mena.dukan.presentation.util.pagination.Pager
 import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ManageDukanUiState
 import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ProductUiState
+import net.thechance.mena.dukan.presentation.viewModel.manageDukan.ProductsState
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -24,14 +30,23 @@ fun ManageDukanProducts(
     pager: Pager<Int, ProductUiState>,
     onProductClick: (ProductUiState) -> Unit
 ) {
-    when {
-        state.shelves.isEmpty() -> NoShelvesContent()
-        state.products.items.isEmpty() -> EmptyStateContent()
-        else -> ProductsList(
-            products = state.products.items,
-            onProductClick = onProductClick,
-            pager = pager
-        )
+    AnimatedContent(
+        targetState = state.productState,
+        transitionSpec = {
+            fadeIn(animationSpec = tween()) togetherWith
+                    fadeOut(animationSpec = tween())
+        },
+        label = "ContentAnimation"
+    ) { target ->
+        when (target) {
+            ProductsState.LOADING -> {}
+            ProductsState.LOADED -> ProductsList(
+                products = state.products.items,
+                onProductClick = onProductClick,
+                pager = pager
+            )
+            ProductsState.EMPTY -> EmptyStateContent()
+        }
     }
 }
 

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/util/pagination/PagingConfig.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/util/pagination/PagingConfig.kt
@@ -1,8 +1,8 @@
 package net.thechance.mena.dukan.presentation.util.pagination
 
 data class PagingConfig(
-    val pageSize: Int = 10,
-    val prefetchDistance: Int = 1,
+    val pageSize: Int = 20,
+    val prefetchDistance: Int = pageSize / 2,
     val enablePlaceholders: Boolean = false,
     val maxSize: Int = Int.MAX_VALUE
 )

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/mainScreen/MainScreenUiState.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/mainScreen/MainScreenUiState.kt
@@ -6,10 +6,11 @@ data class MainScreenUiState(
 ) {
     data class DukanState(
         val name: String = "",
-        val status: DukanStatusUi = DukanStatusUi.None
+        val status: DukanStatusUi = DukanStatusUi.Loading
     )
 
     enum class DukanStatusUi {
+        Loading,
         Pending,
         None,
         Approved

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/mainScreen/MainViewModel.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/mainScreen/MainViewModel.kt
@@ -56,6 +56,7 @@ class MainViewModel(
             DukanStatusUi.None -> emitEffect(MainEffect.NavigateToAddDukanScreen)
             DukanStatusUi.Pending -> emitEffect(MainEffect.NavigateToPendingDukanScreen)
             DukanStatusUi.Approved -> emitEffect(MainEffect.NavigateToManageDukanScreen)
+            DukanStatusUi.Loading -> {}
         }
     }
 }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/mainScreen/MainViewModel.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/mainScreen/MainViewModel.kt
@@ -22,6 +22,7 @@ class MainViewModel(
 
     private fun getDukanState() {
         tryToExecute(
+            onStart = { updateState { copy(dukanState = MainScreenUiState.DukanState(status = DukanStatusUi.Loading)) } },
             block = ::getDukanStateBlock,
             onSuccess = ::onGetDukanStateSuccess,
             onError = ::onGetDukanStateError
@@ -33,7 +34,9 @@ class MainViewModel(
     }
 
     private fun onGetDukanStateSuccess(dukanState: MainScreenUiState.DukanState?) {
-        dukanState?.let {
+        if (dukanState == null) {
+            updateState { copy(dukanState = MainScreenUiState.DukanState(status = DukanStatusUi.None)) }
+        } else {
             updateState { copy(dukanState = dukanState) }
         }
     }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/manageDukan/ManageDukanUiState.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/manageDukan/ManageDukanUiState.kt
@@ -12,8 +12,8 @@ data class ManageDukanUiState(
     val selectedShelf: ShelfUiState? = null,
     val totalProducts: Long = 0,
     val products: PagingData<ProductUiState> = PagingData(),
-    val isLoading: Boolean = false,
-    val isLoadingProducts: Boolean = false,
+    val shelvesState: ShelvesState = ShelvesState.LOADING,
+    val productState: ProductsState = ProductsState.LOADING,
     val snackBarState: SnackBarUiState? = null,
     val deleteShelfConfirmationDialogUiState: DeleteShelfConfirmationDialogUiState? = null,
     val showDeleteConfirmationDialog: Boolean = false,
@@ -30,6 +30,18 @@ data class DeleteShelfConfirmationDialogUiState(
 enum class ConfirmDialogType(val text: StringResource) {
     DELETE(text = Res.string.delete),
     DISMISS(text = Res.string.dismiss)
+}
+
+enum class ShelvesState {
+    LOADING,
+    LOADED,
+    EMPTY
+}
+
+enum class ProductsState {
+    LOADING,
+    LOADED,
+    EMPTY
 }
 
 data class ShelfUiState(

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/manageDukan/ManageDukanUiState.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/manageDukan/ManageDukanUiState.kt
@@ -23,7 +23,8 @@ data class DeleteShelfConfirmationDialogUiState(
     val title: StringResource,
     val description: StringResource,
     val type: ConfirmDialogType,
-    val shelfId: String
+    val shelfId: String,
+    val isDialogVisible: Boolean = false
 )
 
 enum class ConfirmDialogType(val text: StringResource) {

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/manageDukan/ManageDukanViewModel.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/manageDukan/ManageDukanViewModel.kt
@@ -14,8 +14,8 @@ import mena.dukan_presentation.generated.resources.dismiss_description
 import mena.dukan_presentation.generated.resources.dismiss_title
 import mena.dukan_presentation.generated.resources.error_for_delete_shelf
 import net.thechance.mena.dukan.domain.entity.Shelf
-import net.thechance.mena.dukan.domain.repository.ShelfRepository
 import net.thechance.mena.dukan.domain.repository.ProductRepository
+import net.thechance.mena.dukan.domain.repository.ShelfRepository
 import net.thechance.mena.dukan.presentation.component.SnackBarType
 import net.thechance.mena.dukan.presentation.component.SnackBarUiState
 import net.thechance.mena.dukan.presentation.util.pagination.PagingData
@@ -84,7 +84,13 @@ class ManageDukanViewModel(
 
     override fun onShelfSelected(shelf: ShelfUiState) {
         if (state.value.selectedShelf != shelf) {
-            updateState { copy(selectedShelf = shelf) }
+            updateState {
+                copy(
+                    selectedShelf = shelf,
+                    productState = ProductsState.LOADING,
+                    products = PagingData()
+                )
+            }
             loadProductsForSelectedShelf()
         }
     }
@@ -96,25 +102,38 @@ class ManageDukanViewModel(
 
     private fun loadShelves() {
         tryToExecute(
-            onStart = { updateState { copy(isLoading = true) } },
-            block = { shelfRepository.getMyDukanShelves() },
-            onSuccess = { shelves -> handleShelvesLoaded(shelves) },
+            onStart = {
+                updateState {
+                    copy(
+                        shelvesState = ShelvesState.LOADING,
+                        productState = ProductsState.LOADING,
+                        products = PagingData()
+                    )
+                }
+            },
+            block = shelfRepository::getMyDukanShelves,
+            onSuccess = ::handleShelvesLoaded,
             onError = { handleLoadShelvesError() }
         )
     }
 
     private fun handleLoadShelvesError() {
         updateState {
-            copy(isLoading = false)
+            copy(
+                shelvesState = ShelvesState.EMPTY,
+                productState = ProductsState.EMPTY,
+                products = PagingData()
+            )
         }
     }
 
     private fun handleShelvesLoaded(shelves: List<Shelf>) {
+        val shelvesState = if (shelves.isEmpty()) ShelvesState.EMPTY else ShelvesState.LOADED
         updateState {
             copy(
                 shelves = shelves.map(Shelf::toUiState),
                 selectedShelf = shelves.firstOrNull()?.toUiState(),
-                isLoading = false
+                shelvesState = shelvesState
             )
         }
         loadProductsForSelectedShelf()
@@ -132,8 +151,16 @@ class ManageDukanViewModel(
 
     private fun loadProductsFromRepository() {
         tryToCollect(
+            onStart = {
+                updateState {
+                    copy(
+                        productState = ProductsState.LOADING,
+                        products = PagingData()
+                    )
+                }
+            },
             block = { pager.flow },
-            onCollect = { products -> onProductsLoaded(products) },
+            onCollect = ::onProductsLoaded,
         )
         viewModelScope.launch {
             pager.load()
@@ -164,8 +191,7 @@ class ManageDukanViewModel(
                     isDialogVisible = true
                 ),
                 showDeleteConfirmationDialog = true,
-
-                )
+            )
         }
     }
 
@@ -191,6 +217,7 @@ class ManageDukanViewModel(
 
     private fun onDeleteShelfSuccess(unit: Unit) {
         onDismissDeleteShelfConfirmationDialog()
+        loadShelves()
         onShowSnackBar(type = SnackBarType.SUCCESS, message = Res.string.delete_shelf_success)
     }
 
@@ -200,8 +227,13 @@ class ManageDukanViewModel(
     }
 
     private fun onProductsLoaded(products: PagingData<ProductUiState>) {
+        val productState = if (products.items.isEmpty())
+            ProductsState.EMPTY
+        else
+            ProductsState.LOADED
         updateState {
             copy(
+                productState = productState,
                 products = products,
             )
         }
@@ -213,7 +245,7 @@ class ManageDukanViewModel(
         productRepository.getProductsByShelfId(
             shelfId = state.value.selectedShelf?.id.orEmpty(),
             page = it,
-            size = 10
+            size = 20
         ).also { result ->
             updateState {
                 copy(

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/manageDukan/ManageDukanViewModel.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/manageDukan/ManageDukanViewModel.kt
@@ -49,6 +49,7 @@ class ManageDukanViewModel(
                 )
             )
         }
+        loadShelves()
     }
 
     override fun onDismissSnackBar() {
@@ -227,14 +228,15 @@ class ManageDukanViewModel(
     }
 
     private fun onProductsLoaded(products: PagingData<ProductUiState>) {
-        val productState = if (products.items.isEmpty())
-            ProductsState.EMPTY
-        else
-            ProductsState.LOADED
+        val productState = when {
+            products.isLoading -> ProductsState.LOADING
+            products.items.isEmpty() -> ProductsState.EMPTY
+            else -> ProductsState.LOADED
+        }
         updateState {
             copy(
                 productState = productState,
-                products = products,
+                products = products
             )
         }
     }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/manageDukan/ManageDukanViewModel.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/manageDukan/ManageDukanViewModel.kt
@@ -124,6 +124,9 @@ class ManageDukanViewModel(
         val selectedShelf = state.value.selectedShelf
         selectedShelf?.let { shelf ->
             loadProductsFromRepository()
+            viewModelScope.launch {
+                pager.refresh()
+            }
         }
     }
 
@@ -138,8 +141,12 @@ class ManageDukanViewModel(
     }
 
     override fun onDismissDeleteShelfConfirmationDialog() {
+        val dialogState = state.value.deleteShelfConfirmationDialogUiState
         updateState {
-            copy(showDeleteConfirmationDialog = false)
+            copy(
+                showDeleteConfirmationDialog = false,
+                deleteShelfConfirmationDialogUiState = dialogState?.copy(isDialogVisible = false)
+            )
         }
     }
 
@@ -153,10 +160,12 @@ class ManageDukanViewModel(
                     title = updateDialogTitle(hasProducts),
                     description = updateDialogDescription(hasProducts),
                     type = updateDialogType(hasProducts),
-                    shelfId = shelfId
+                    shelfId = shelfId,
+                    isDialogVisible = true
                 ),
-                showDeleteConfirmationDialog = true
-            )
+                showDeleteConfirmationDialog = true,
+
+                )
         }
     }
 
@@ -175,12 +184,12 @@ class ManageDukanViewModel(
     override fun onDeleteConfirmed(shelfId: String) {
         tryToExecute(
             block = { shelfRepository.deleteShelf(shelfId) },
-            onSuccess = { onDeleteShelfSuccess() },
+            onSuccess = ::onDeleteShelfSuccess,
             onError = ::onDeleteShelfError
         )
     }
 
-    private fun onDeleteShelfSuccess() {
+    private fun onDeleteShelfSuccess(unit: Unit) {
         onDismissDeleteShelfConfirmationDialog()
         onShowSnackBar(type = SnackBarType.SUCCESS, message = Res.string.delete_shelf_success)
     }

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/main/MainViewModelTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/main/MainViewModelTest.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.dukan.presentation.screen.main
+package net.thechance.mena.dukan.presentation.viewModel.main
 
 import app.cash.turbine.test
 import dev.mokkery.MockMode
@@ -16,7 +16,6 @@ import net.thechance.mena.dukan.domain.exceptions.DukanNotFoundException
 import net.thechance.mena.dukan.domain.repository.DukanRepository
 import net.thechance.mena.dukan.presentation.viewModel.mainScreen.MainEffect
 import net.thechance.mena.dukan.presentation.viewModel.mainScreen.MainScreenUiState
-import net.thechance.mena.dukan.presentation.viewModel.mainScreen.MainScreenUiState.DukanStatusUi
 import net.thechance.mena.dukan.presentation.viewModel.mainScreen.MainViewModel
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -38,13 +37,14 @@ class MainViewModelTest {
             )
 
             mainViewModel.state.test {
-                val init = awaitItem()
+                awaitItem() // initial Loading state
+                val updated = awaitItem() // state after repository returns null
                 assertEquals(
                     expected = MainScreenUiState.DukanState(
                         name = "",
-                        status = DukanStatusUi.None
+                        status = MainScreenUiState.DukanStatusUi.None
                     ),
-                    actual = init.dukanState
+                    actual = updated.dukanState
                 )
                 cancelAndIgnoreRemainingEvents()
             }
@@ -69,7 +69,7 @@ class MainViewModelTest {
                 assertEquals(
                     expected = MainScreenUiState.DukanState(
                         name = "Dukan El Sa3ada",
-                        status = DukanStatusUi.Pending
+                        status = MainScreenUiState.DukanStatusUi.Pending
                     ),
                     actual = secondEmit.dukanState
                 )

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/manageDukan/ManageDukanViewModelTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/manageDukan/ManageDukanViewModelTest.kt
@@ -474,7 +474,8 @@ class ManageDukanViewModelTest {
                 title = Res.string.delete_shelf_title,
                 description = Res.string.delete_shelf_description,
                 type = ConfirmDialogType.DELETE,
-                shelfId = "1"
+                shelfId = "1",
+                isDialogVisible = true
             )
             manageDukanViewModel.onShowDeleteShelfDailog(
                 shelfId = "1"


### PR DESCRIPTION
### Fixes in this PR:
- Dismiss on delete shelf with product not working
- Product description limit in products list it should be two lines with text overflow
- Change the shelf not getting the products for the selected shelf 
- Fix the fab button in manage screen get hidden
- Put the snack bar in scaffold
- Change page size and prefetch items in paging data source
- Delete dialog not dismiss after shelf deleted success
- Update shelf list after delete and add new

### New things introduced in this PR:
- Added skiliton loading for shelves and products.
- The button that is responsible for navigating to user dukan only visible after it's state is parsed from the backend 