### PR TITLE
Refactor/IDN-95 Whitelist Reset Password Endpoints in HttpClient Auth

### DIFF
--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/identityDataModule.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/identityDataModule.kt
@@ -16,7 +16,6 @@ import net.thechance.mena.identity.domain.service.AuthorizationService
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
-import org.koin.dsl.bind
 import org.koin.dsl.module
 
 expect val IdentityPlatformModule: Module
@@ -41,7 +40,11 @@ val identityDataModule = module {
     single { provideDatabaseBuilder() }
     single<IdentityDatabase> { getRoomDatabase(builder = get()) }
     single<UserDao> { get<IdentityDatabase>().getUserDao() }
-    singleOf(::ResetPasswordRepositoryImpl) bind ResetPasswordRepository::class
+    single<ResetPasswordRepository> {
+        ResetPasswordRepositoryImpl(
+            client = get(named("IdentityClient"))
+        )
+    }
 }
 fun getRoomDatabase(builder: RoomDatabase.Builder<IdentityDatabase>): IdentityDatabase {
     return builder

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/provideHttpClient.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/provideHttpClient.kt
@@ -19,6 +19,9 @@ import net.thechance.mena.identity.data.dataSource.local.setting.accessToken
 import net.thechance.mena.identity.data.dataSource.local.setting.refreshToken
 import net.thechance.mena.identity.data.repository.AuthenticationRepositoryImpl.Companion.LOGIN_ENDPOINT
 import net.thechance.mena.identity.data.repository.AuthenticationRepositoryImpl.Companion.REFRESH_ENDPOINT
+import net.thechance.mena.identity.data.repository.ResetPasswordRepositoryImpl.Companion.REQUEST_OTP
+import net.thechance.mena.identity.data.repository.ResetPasswordRepositoryImpl.Companion.RESET_PASSWORD
+import net.thechance.mena.identity.data.repository.ResetPasswordRepositoryImpl.Companion.VERIFY_OTP
 
 internal fun provideHttpClient(
     engine: HttpClientEngine, settings: Settings, baseUrl: String, refreshToken: suspend () -> Unit
@@ -51,7 +54,8 @@ internal fun provideHttpClient(
                     BearerTokens(settings.accessToken, settings.refreshToken)
                 }
                 sendWithoutRequest { request ->
-                    request.url.encodedPath !in whiteListEndPoints
+                    val path = request.url.encodedPath.removePrefix("/")
+                    path !in whiteListEndPoints
                 }
             }
         }
@@ -64,8 +68,5 @@ internal fun provideHttpClient(
 
 const val NETWORK_TIMEOUT_MS = 15_000L
 private val whiteListEndPoints = listOf(
-    LOGIN_ENDPOINT, REFRESH_ENDPOINT
+    LOGIN_ENDPOINT, REFRESH_ENDPOINT, REQUEST_OTP, VERIFY_OTP ,RESET_PASSWORD
 )
-
-
-

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/repository/ResetPasswordRepositoryImpl.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/repository/ResetPasswordRepositoryImpl.kt
@@ -68,7 +68,7 @@ class ResetPasswordRepositoryImpl(
         }
     }
 
-    private companion object {
+    companion object {
         const val REQUEST_OTP = "identity/authentication/request-reset-password-otp"
         const val VERIFY_OTP = "identity/authentication/verify-reset-password-otp"
         const val RESET_PASSWORD = "identity/authentication/reset-password"


### PR DESCRIPTION
Added request-reset-password OTP, verify-OTP, and reset-password endpoints to the HttpClient whitelist to prevent unnecessary refresh token calls. Updated Koin DI to reflect the change.
