### PR TITLE
add Qiblah calculator with tests

### DIFF
--- a/faith_presentation/build.gradle.kts
+++ b/faith_presentation/build.gradle.kts
@@ -84,6 +84,7 @@ kover.reports {
             classes(
                 "*ViewModel",
                 "*MapperKt",
+                "net.thechance.mena.faith.presentation.util.QiblahBearingCalculator",
             )
         }
 

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/util/QiblahBearingCalculator.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/util/QiblahBearingCalculator.kt
@@ -1,0 +1,46 @@
+package net.thechance.mena.faith.presentation.util
+
+
+import kotlin.math.PI
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.round
+import kotlin.math.sin
+
+class QiblahBearingCalculator {
+    val kaabaLatitude = 21.4225
+    val kaabaLongitude = 39.8262
+
+    fun Double.toRadians(): Double = this * PI / 180.0
+    fun Double.toDegrees(): Double = this * 180.0 / PI
+
+    fun calculateQiblahAngle(userLatitude: Double, userLongitude: Double): Double {
+        validateCoordinates(latitude = userLatitude, longitude = userLongitude)
+        val userLatitudeRadians = userLatitude.toRadians()
+        val userLongitudeRadians = userLongitude.toRadians()
+        val kaabaLatitudeRadians = kaabaLatitude.toRadians()
+        val kaabaLongitudeRadians = kaabaLongitude.toRadians()
+
+        val longitudeDifference = kaabaLongitudeRadians - userLongitudeRadians
+
+        val y = sin(longitudeDifference) * cos(kaabaLatitudeRadians)
+        val x =
+            cos(userLatitudeRadians) * sin(kaabaLatitudeRadians) - sin(userLatitudeRadians) * cos(
+                kaabaLatitudeRadians
+            ) * cos(longitudeDifference)
+
+        val bearing = atan2(y, x)
+
+        val qiblaAngle = (bearing.toDegrees() + 360) % 360
+
+        return round(qiblaAngle)
+    }
+
+    private fun validateCoordinates(latitude: Double, longitude: Double) {
+        if (latitude < -90.0 || latitude > 90.0) {
+            throw IllegalArgumentException("Latitude must be between -90 and 90 degrees.")
+        } else if (longitude < -180.0 || longitude > 180.0) {
+            throw IllegalArgumentException("Longitude must be between -180 and 180 degrees.")
+        }
+    }
+}

--- a/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/util/QiblahBearingCalculatorTest.kt
+++ b/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/util/QiblahBearingCalculatorTest.kt
@@ -1,0 +1,114 @@
+package net.thechance.mena.faith.presentation.util
+
+import kotlin.math.round
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class QiblahBearingCalculatorTest {
+
+    private val calculator: QiblahBearingCalculator = QiblahBearingCalculator()
+
+    @Test
+    fun `calculateQiblahAngle should return zero angle when User at Kaaba exact location`() {
+        val result = calculator.calculateQiblahAngle(
+            userLatitude = calculator.kaabaLatitude,
+            userLongitude = calculator.kaabaLongitude
+        )
+        assertEquals(0.0, result)
+    }
+
+    @Test
+    fun `calculateQiblahAngle should return 153,30 angle when User at Gaza exact location`() {
+        val result = calculator.calculateQiblahAngle(
+            userLatitude = 31.5017,
+            userLongitude = 34.4668
+        )
+        assertEquals(round(153.3), result)
+    }
+
+    @Test
+    fun `calculateQiblahAngle should return 136,14 angle when User at Cairo exact location`() {
+        val result = calculator.calculateQiblahAngle(
+            userLatitude = 30.0444,
+            userLongitude = 31.2357
+        )
+        assertEquals(round(136.14), result)
+    }
+
+    @Test
+    fun `calculateQiblahAngle should return 199,80 angle when User at Baghdad exact location`() {
+        val result = calculator.calculateQiblahAngle(
+            userLatitude = 33.3128,
+            userLongitude = 44.3615
+        )
+        assertEquals(round(199.80), result)
+    }
+
+    @Test
+    fun `calculateQiblahAngle Maximum valid when latitude is -90°`() {
+        val result = calculator.calculateQiblahAngle(-90.0, 0.0)
+        assertTrue(result in 0.0..360.0)
+    }
+
+    @Test
+    fun `calculateQiblahAngle Maximum valid when latitude is +90°`() {
+        val result = calculator.calculateQiblahAngle(90.0, 0.0)
+        assertTrue(result in 0.0..360.0)
+    }
+
+    @Test
+    fun `calculateQiblahAngle Maximum invalid when latitude is +100°`() {
+        assertFailsWith<IllegalArgumentException>(
+            "Latitude > 90 should throw exception"
+        ) {
+            calculator.calculateQiblahAngle(100.0, 0.0)
+        }
+    }
+
+    @Test
+    fun `calculateQiblahAngle Maximum invalid when latitude is -91°`() {
+        assertFailsWith<IllegalArgumentException>(
+            "Latitude < -90 should throw exception"
+        ) {
+            calculator.calculateQiblahAngle(-91.0, 0.0)
+        }
+    }
+
+    @Test
+    fun `calculateQiblahAngle Maximum valid when longitude is -180°`() {
+        val result = calculator.calculateQiblahAngle(0.0, -180.0)
+        assertTrue(result in 0.0..360.0)
+    }
+
+    @Test
+    fun `calculateQiblahAngle Maximum valid when longitude is +180°`() {
+        val result = calculator.calculateQiblahAngle(0.0, 180.0)
+        assertTrue(result in 0.0..360.0)
+    }
+
+    @Test
+    fun `calculateQiblahAngle Maximum invalid when longitude is +200°`() {
+        assertFailsWith<IllegalArgumentException>(
+            "longitude > 180 should throw exception"
+        ) {
+            calculator.calculateQiblahAngle(0.0, 200.0)
+        }
+    }
+
+    @Test
+    fun `calculateQiblahAngle Maximum invalid when longitude is -320°`() {
+        assertFailsWith<IllegalArgumentException>(
+            "longitude < -180 should throw exception"
+        ) {
+            calculator.calculateQiblahAngle(0.0, -320.0)
+        }
+    }
+
+    @Test
+    fun `calculateQiblahAngle should angle between 0 to 360`() {
+        val result = calculator.calculateQiblahAngle(31.0, 39.0)
+        assertTrue(result in 0.0..360.0)
+    }
+}


### PR DESCRIPTION
Add the implementation for calculating the Qiblah angle using the user’s location and the Kaaba’s location, and create test cases to achieve 100% test coverage

Gaza Location

<img width="325" height="189" alt="image" src="https://github.com/user-attachments/assets/46247722-580b-42a1-952a-212114ff397c" />
