### PR TITLE
feature/FTH-77-integrate-qiblah-compass-with-azimuth-and-bearing-calculator

### DIFF
--- a/composeApp/src/commonMain/kotlin/net/thechance/mena/di/featureModule.kt
+++ b/composeApp/src/commonMain/kotlin/net/thechance/mena/di/featureModule.kt
@@ -6,7 +6,6 @@ import net.thechance.mena.dukan.data.di.dukanDataModule
 import net.thechance.mena.dukan.domain.di.dukanDomainModule
 import net.thechance.mena.dukan.presentation.di.dukanPresentationModule
 import net.thechance.mena.faith.data.di.faithDataModule
-import net.thechance.mena.faith.domain.di.faithDomainModule
 import net.thechance.mena.faith.presentation.di.faithPresentationModule
 import net.thechance.mena.identity.data.di.IdentityPlatformModule
 import net.thechance.mena.identity.data.di.identityDataModule
@@ -39,8 +38,6 @@ val featureModule = module {
 
         faithPresentationModule,
         faithDataModule,
-        faithDomainModule,
-
         WalletDataModule().module,
         WalletDomainModule().module,
         WalletPresentationModule().module,

--- a/composeApp/src/commonMain/kotlin/net/thechance/mena/di/featureModule.kt
+++ b/composeApp/src/commonMain/kotlin/net/thechance/mena/di/featureModule.kt
@@ -6,6 +6,7 @@ import net.thechance.mena.dukan.data.di.dukanDataModule
 import net.thechance.mena.dukan.domain.di.dukanDomainModule
 import net.thechance.mena.dukan.presentation.di.dukanPresentationModule
 import net.thechance.mena.faith.data.di.faithDataModule
+import net.thechance.mena.faith.domain.di.faithDomainModule
 import net.thechance.mena.faith.presentation.di.faithPresentationModule
 import net.thechance.mena.identity.data.di.IdentityPlatformModule
 import net.thechance.mena.identity.data.di.identityDataModule
@@ -38,6 +39,8 @@ val featureModule = module {
 
         faithPresentationModule,
         faithDataModule,
+        faithDomainModule,
+
         WalletDataModule().module,
         WalletDomainModule().module,
         WalletPresentationModule().module,

--- a/faith_domain/build.gradle.kts
+++ b/faith_domain/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(libs.kotlinx.datetime)
+            implementation(libs.koin.core)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/di/faithDomainModule.kt
+++ b/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/di/faithDomainModule.kt
@@ -1,0 +1,9 @@
+package net.thechance.mena.faith.domain.di
+
+import net.thechance.mena.faith.domain.usecase.QiblahBearingCalculatorUseCase
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.module
+
+val faithDomainModule = module {
+    singleOf(::QiblahBearingCalculatorUseCase)
+}

--- a/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/usecase/QiblahBearingCalculatorUseCase.kt
+++ b/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/usecase/QiblahBearingCalculatorUseCase.kt
@@ -9,7 +9,7 @@ import kotlin.math.round
 import kotlin.math.sin
 
 class QiblahBearingCalculatorUseCase {
-    fun calculateQiblahAngle(userLocation: Location): Double {
+    fun calculateQiblahAngle(userLocation: Location = Location(29.0735549, 31.1015618)): Double {
         validateCoordinates(location = userLocation)
         val userLatitudeRadians = userLocation.latitude.toRadians()
         val userLongitudeRadians = userLocation.longitude.toRadians()

--- a/faith_presentation/src/androidMain/kotlin/net/thechance/mena/faith/presentation/util/AzimuthProvider.android.kt
+++ b/faith_presentation/src/androidMain/kotlin/net/thechance/mena/faith/presentation/util/AzimuthProvider.android.kt
@@ -13,19 +13,19 @@ actual class AzimuthProvider(context: Context) {
     private val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
 
     actual fun startListening(): Flow<Float> = callbackFlow {
-        var accelValues = FloatArray(3)
+        var accelerateValues = FloatArray(3)
         var magnetValues = FloatArray(3)
         val listener = object : SensorEventListener {
             override fun onSensorChanged(event: SensorEvent?) {
                 when (event?.sensor?.type) {
-                    Sensor.TYPE_ACCELEROMETER -> accelValues = event.values.clone()
+                    Sensor.TYPE_ACCELEROMETER -> accelerateValues = event.values.clone()
                     Sensor.TYPE_MAGNETIC_FIELD -> magnetValues = event.values.clone()
                     else -> return
                 }
                 val rotationMatrix = FloatArray(9)
                 val orientationValues = FloatArray(3)
                 val isRotationMatrixValid = SensorManager.getRotationMatrix(
-                    rotationMatrix, null, accelValues, magnetValues
+                    rotationMatrix, null, accelerateValues, magnetValues
                 )
                 if (isRotationMatrixValid) {
                     SensorManager.getOrientation(rotationMatrix, orientationValues)

--- a/faith_presentation/src/androidMain/kotlin/net/thechance/mena/faith/presentation/util/AzimuthProvider.android.kt
+++ b/faith_presentation/src/androidMain/kotlin/net/thechance/mena/faith/presentation/util/AzimuthProvider.android.kt
@@ -5,55 +5,46 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.callbackFlow
 
-actual class AzimuthProvider(context: Context) : SensorEventListener {
-    private val _azimuth = MutableStateFlow(0f)
-    actual val azimuthFlow: Flow<Float> = _azimuth
+actual class AzimuthProvider(context: Context) {
+    private val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
 
-    private var sensorManager: SensorManager? = null
-    private var accelValues = FloatArray(3)
-    private var magnetValues = FloatArray(3)
-    private var initialized = false
+    actual fun startListening(): Flow<Float> = callbackFlow {
+        var accelValues = FloatArray(3)
+        var magnetValues = FloatArray(3)
+        val listener = object : SensorEventListener {
+            override fun onSensorChanged(event: SensorEvent?) {
+                when (event?.sensor?.type) {
+                    Sensor.TYPE_ACCELEROMETER -> accelValues = event.values.clone()
+                    Sensor.TYPE_MAGNETIC_FIELD -> magnetValues = event.values.clone()
+                    else -> return
+                }
+                val rotationMatrix = FloatArray(9)
+                val orientationValues = FloatArray(3)
+                val isRotationMatrixValid = SensorManager.getRotationMatrix(
+                    rotationMatrix, null, accelValues, magnetValues
+                )
+                if (isRotationMatrixValid) {
+                    SensorManager.getOrientation(rotationMatrix, orientationValues)
+                    val azimuthInDegrees = Math.toDegrees(orientationValues[0].toDouble()).toFloat()
+                    val normalizedAzimuth = (azimuthInDegrees + 360) % 360
+                    trySend(normalizedAzimuth)
+                }
+            }
 
-    init {
-        sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
-        initialized = true
-    }
-
-    actual fun startListening() {
-        if (!initialized)
-            throw IllegalStateException("AzimuthProvider not initialized — call initialize() first.")
-
-        sensorManager?.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)?.also {
-            sensorManager?.registerListener(this, it, SensorManager.SENSOR_DELAY_UI)
+            override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
         }
-        sensorManager?.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD)?.also {
-            sensorManager?.registerListener(this, it, SensorManager.SENSOR_DELAY_UI)
+        sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)?.also {
+            sensorManager.registerListener(listener, it, SensorManager.SENSOR_DELAY_UI)
         }
-    }
-
-    actual fun stopListening() {
-        sensorManager?.unregisterListener(this)
-    }
-
-    override fun onSensorChanged(event: SensorEvent?) {
-        when (event?.sensor?.type) {
-            Sensor.TYPE_ACCELEROMETER -> accelValues = event.values.clone()
-            Sensor.TYPE_MAGNETIC_FIELD -> magnetValues = event.values.clone()
+        sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD)?.also {
+            sensorManager.registerListener(listener, it, SensorManager.SENSOR_DELAY_UI)
         }
-
-        val rotationMatrix = FloatArray(9)
-        val orientationValues = FloatArray(3)
-
-        if (SensorManager.getRotationMatrix(rotationMatrix, null, accelValues, magnetValues)) {
-            SensorManager.getOrientation(rotationMatrix, orientationValues)
-            val azimuthInDegrees = Math.toDegrees(orientationValues[0].toDouble()).toFloat()
-            val normalized = (azimuthInDegrees + 360) % 360
-            _azimuth.value = normalized
+        awaitClose {
+            sensorManager.unregisterListener(listener)
         }
     }
-
-    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/base/BaseViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/base/BaseViewModel.kt
@@ -9,10 +9,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import mena.faith_presentation.generated.resources.Res
@@ -110,6 +112,28 @@ abstract class BaseViewModel<UI_STATE, UI_EFFECT>(
             onFinally()
         }
     }
+
+    protected fun <T> tryToCollect(
+        onError: (Throwable) -> Unit = ::handleError,
+        onEmitNewValue: (T) -> Unit = {},
+        coroutineScope: CoroutineScope = viewModelScope,
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        block: suspend () -> Flow<T>
+    ) {
+        coroutineScope.launch(dispatcher) {
+            try {
+                block()
+                    .catch {
+                        onError(it)
+                    }.collect {
+                        onEmitNewValue(it)
+                    }
+            } catch (e: Throwable) {
+                onError(e)
+            }
+        }
+    }
+
 
     private fun handleError(error: Throwable) {
         showSnackBar(

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/di/faithViewModelModule.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/di/faithViewModelModule.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.IO
 import net.thechance.mena.faith.presentation.feature.main.MainViewModel
 import net.thechance.mena.faith.presentation.feature.qiblah.compass.CompassViewModel
 import net.thechance.mena.faith.presentation.feature.quran.bookmark.BookmarkViewModel
-import net.thechance.mena.faith.presentation.feature.quran.qiblah.calibratedevice.CalibrateDeviceViewModel
+import net.thechance.mena.faith.presentation.feature.qiblah.calibratedevice.CalibrateDeviceViewModel
 import net.thechance.mena.faith.presentation.feature.quran.search.SearchViewModel
 import net.thechance.mena.faith.presentation.feature.quran.search.args.ISearchArgs
 import net.thechance.mena.faith.presentation.feature.quran.search.args.SearchArgsImpl

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/di/faithViewModelModule.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/di/faithViewModelModule.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import net.thechance.mena.faith.presentation.feature.main.MainViewModel
+import net.thechance.mena.faith.presentation.feature.qiblah.compass.CompassViewModel
 import net.thechance.mena.faith.presentation.feature.quran.bookmark.BookmarkViewModel
 import net.thechance.mena.faith.presentation.feature.quran.qiblah.calibratedevice.CalibrateDeviceViewModel
 import net.thechance.mena.faith.presentation.feature.quran.search.SearchViewModel
@@ -19,19 +20,15 @@ import org.koin.dsl.bind
 import org.koin.dsl.module
 
 internal val faithViewModelModule = module {
-
     factory<CoroutineDispatcher> { Dispatchers.IO }
-
     factoryOf(::SurahArgsImpl) bind ISurahArgs::class
     factoryOf(::SearchArgsImpl) bind ISearchArgs::class
-
     viewModelOf(::SurahViewModel)
     viewModelOf(::SurViewModel)
     viewModelOf(::BookmarkViewModel)
     viewModelOf(::CalibrateDeviceViewModel)
     viewModelOf(::SearchViewModel)
+    viewModelOf(::CompassViewModel)
     viewModelOf(::MainViewModel)
-
-
 }
 

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/calibratedevice/CalibrateDeviceEffect.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/calibratedevice/CalibrateDeviceEffect.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.faith.presentation.feature.quran.qiblah.calibratedevice
+package net.thechance.mena.faith.presentation.feature.qiblah.calibratedevice
 
 sealed interface CalibrateDeviceEffect {
     data object NavigateBack : CalibrateDeviceEffect

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/calibratedevice/CalibrateDeviceInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/calibratedevice/CalibrateDeviceInteractionListener.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.faith.presentation.feature.quran.qiblah.calibratedevice
+package net.thechance.mena.faith.presentation.feature.qiblah.calibratedevice
 
 interface CalibrateDeviceInteractionListener {
     fun onBackClick()

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/calibratedevice/CalibrateDeviceScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/calibratedevice/CalibrateDeviceScreen.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.faith.presentation.feature.quran.qiblah.calibratedevice
+package net.thechance.mena.faith.presentation.feature.qiblah.calibratedevice
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -32,6 +32,7 @@ import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.faith.presentation.base.ObserveAsEffect
 import net.thechance.mena.faith.presentation.component.BackIcon
 import net.thechance.mena.faith.presentation.navigation.LocalNavController
+import net.thechance.mena.faith.presentation.navigation.Route
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -44,7 +45,7 @@ fun CalibrateDeviceScreen(
     ObserveAsEffect(viewModel.uiEffect) { effect ->
         when (effect) {
             is CalibrateDeviceEffect.NavigateBack -> navController.navigateUp()
-            is CalibrateDeviceEffect.NavigateToQiblah -> {}
+            is CalibrateDeviceEffect.NavigateToQiblah -> navController.navigate(Route.CompassRoute)
         }
     }
 

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/calibratedevice/CalibrateDeviceViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/calibratedevice/CalibrateDeviceViewModel.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.faith.presentation.feature.quran.qiblah.calibratedevice
+package net.thechance.mena.faith.presentation.feature.qiblah.calibratedevice
 
 import net.thechance.mena.faith.presentation.base.BaseViewModel
 

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/compass/CompassScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/compass/CompassScreen.kt
@@ -112,7 +112,6 @@ private fun Content(
                     azimuth = uiState.continuousAzimuth,
                     qiblahDirection = uiState.qiblahAngleValue
                 )
-
                 TextAngleToQiblah(
                     qiblahDirection = uiState.angleToQiblah.toInt().toString(),
                     modifier = Modifier.padding(top = Theme.spacing._16)

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/compass/CompassScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/compass/CompassScreen.kt
@@ -20,12 +20,14 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mena.faith_presentation.generated.resources.Res
@@ -39,14 +41,12 @@ import mena.faith_presentation.generated.resources.qiblah
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.component.text.Text
-import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.faith.presentation.base.ObserveAsEffect
 import net.thechance.mena.faith.presentation.component.BackIcon
 import net.thechance.mena.faith.presentation.navigation.LocalNavController
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -101,7 +101,6 @@ private fun Content(
                 contentScale = ContentScale.Fit,
                 colorFilter = ColorFilter.tint(Theme.colorScheme.secondary.secondary)
             )
-
             Column(
                 modifier = Modifier
                     .fillMaxSize()
@@ -109,11 +108,13 @@ private fun Content(
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                CompassView(azimuth = uiState.azimuth, qiblahDirection = uiState.qiblahDirection)
+                CompassView(
+                    azimuth = uiState.continuousAzimuth,
+                    qiblahDirection = uiState.qiblahAngleValue
+                )
 
                 TextAngleToQiblah(
-                    azimuth = uiState.azimuth,
-                    uiState.qiblahDirection,
+                    qiblahDirection = uiState.angleToQiblah.toInt().toString(),
                     modifier = Modifier.padding(top = Theme.spacing._16)
                 )
             }
@@ -131,10 +132,11 @@ private fun CompassView(
         contentAlignment = Alignment.Center
     ) {
         val animatedBearing by animateFloatAsState(
-            targetValue = azimuth,
+            targetValue = -azimuth,
             animationSpec = tween(durationMillis = 300),
             label = "compass_rotation"
         )
+        val rotateModifier = remember(animatedBearing) { Modifier.rotate(animatedBearing) }
         Box(
             modifier = Modifier.size(224.dp).border(
                 width = 3.dp,
@@ -143,27 +145,25 @@ private fun CompassView(
             ),
             contentAlignment = Alignment.Center
         ) {
-            DirectionPlaceHolder()
-
+            DirectionPlaceHolder(modifier = rotateModifier)
             Image(
                 painter = painterResource(Res.drawable.ic_direction),
                 contentDescription = "direction_arrow",
-                modifier = Modifier
+                modifier = rotateModifier
                     .size(128.dp)
-                    .rotate(animatedBearing)
             )
         }
-
-        QiblahImage(qiblahDirection)
-
+        QiblahImage(
+            qiblahDirection = qiblahDirection,
+            compassBearing = animatedBearing
+        )
     }
 }
 
-
 @Composable
-private fun DirectionPlaceHolder() {
+private fun DirectionPlaceHolder(modifier: Modifier = Modifier) {
     Box(
-        modifier = Modifier.fillMaxSize().padding(20.dp),
+        modifier = modifier.fillMaxSize().padding(20.dp),
         contentAlignment = Alignment.Center
     ) {
         Text(
@@ -201,10 +201,9 @@ private fun DirectionPlaceHolder() {
     }
 }
 
-
 @Composable
-private fun CirclesPlaceHolder() {
-    Box(modifier = Modifier.size(116.dp)) {
+private fun CirclesPlaceHolder(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.size(116.dp)) {
         BrownCircle(modifier = Modifier.align(Alignment.TopStart))
         BrownCircle(modifier = Modifier.align(Alignment.TopEnd))
         BrownCircle(modifier = Modifier.align(Alignment.BottomStart))
@@ -214,21 +213,32 @@ private fun CirclesPlaceHolder() {
 
 @Composable
 private fun TextAngleToQiblah(
-    azimuth: Float,
-    qiblahDirection: Float,
+    qiblahDirection: String,
     modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = modifier
-            .fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         Arrangement.Center
     ) {
-        Text(
-            text = "${azimuth - qiblahDirection}°N",
-            style = Theme.typography.title.small,
-            color = Theme.colorScheme.shadePrimary,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
-        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = qiblahDirection,
+                style = Theme.typography.title.small,
+                color = Theme.colorScheme.shadePrimary,
+                textAlign = TextAlign.End,
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                text = "°N",
+                style = Theme.typography.title.small,
+                color = Theme.colorScheme.shadePrimary,
+                modifier = Modifier.weight(1f)
+            )
+        }
         Text(
             text = stringResource(Res.string.device_angle_to_qiblah),
             style = Theme.typography.title.small,
@@ -238,14 +248,13 @@ private fun TextAngleToQiblah(
     }
 }
 
-
 @Composable
-private fun QiblahImage(qiblahDirection: Float) {
+private fun QiblahImage(qiblahDirection: Float, compassBearing: Float) {
     Box(
         modifier = Modifier
             .size(270.dp)
             .graphicsLayer {
-                rotationZ = qiblahDirection
+                rotationZ = compassBearing + qiblahDirection
             },
         contentAlignment = Alignment.TopCenter
     ) {
@@ -265,7 +274,6 @@ private fun QiblahImage(qiblahDirection: Float) {
 
 @Composable
 private fun QiblahTopBar(uiState: CompassScreenState) {
-
     Row(
         modifier = Modifier.background(
             shape = RoundedCornerShape(Theme.radius.full),
@@ -297,12 +305,4 @@ private fun BrownCircle(modifier: Modifier = Modifier) {
         modifier = modifier.size(6.dp)
             .background(color = Theme.colorScheme.secondary.secondaryText, shape = CircleShape)
     )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun CompassScreenPreview() {
-    MenaTheme {
-        Content(uiState = CompassScreenState(), listener = CompassViewModel())
-    }
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/compass/CompassScreenState.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/compass/CompassScreenState.kt
@@ -1,8 +1,9 @@
 package net.thechance.mena.faith.presentation.feature.qiblah.compass
 
 data class CompassScreenState(
-    val azimuth: Float = 0f,
-    val qiblahDirection: Float = 0f,
+    val continuousAzimuth: Float = 0f,
+    val qiblahAngleValue: Float = 0f,
+    val angleToQiblah: Float = 0f,
     val currentLocation: Location = Location(),
 )
 

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/compass/CompassViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/compass/CompassViewModel.kt
@@ -15,6 +15,8 @@ class CompassViewModel(
         getQiblahAngle()
     }
 
+    override fun onBackClick() = sendEffect(CompassEffect.NavigateBack)
+
     private fun getQiblahAngle() {
         tryToExecute(
             execute = bearingCalculatorUseCase::calculateQiblahAngle,
@@ -35,24 +37,34 @@ class CompassViewModel(
     }
 
     private fun onAzimuthValueChange(rawAzimuth: Float) {
-        val oldAngleOnCircle = currentContinuousAzimuth % 360
-        var diff = rawAzimuth - oldAngleOnCircle
-        if (diff > 180f) {
-            diff -= 360f
-        } else if (diff < -180f) {
-            diff += 360f
-        }
-        currentContinuousAzimuth += diff
-        var relativeAngle = uiState.value.qiblahAngleValue - rawAzimuth
-        while (relativeAngle <= -180) relativeAngle += 360
-        while (relativeAngle > 180) relativeAngle -= 360
+        val continuousAzimuth = calculateContinuousAzimuth(rawAzimuth)
+        val relativeAngle =
+            calculateRelativeAngleToQiblah(rawAzimuth, uiState.value.qiblahAngleValue)
         updateState {
             it.copy(
-                continuousAzimuth = currentContinuousAzimuth,
+                continuousAzimuth = continuousAzimuth,
                 angleToQiblah = relativeAngle
             )
         }
     }
 
-    override fun onBackClick() = sendEffect(CompassEffect.NavigateBack)
+    private fun calculateContinuousAzimuth(rawAzimuth: Float): Float {
+        val oldAngleOnCircle = currentContinuousAzimuth % 360
+        val diff = getShortestAngleDifference(from = oldAngleOnCircle, to = rawAzimuth)
+        currentContinuousAzimuth += diff
+        return currentContinuousAzimuth
+    }
+
+    private fun calculateRelativeAngleToQiblah(rawAzimuth: Float, qiblahAngle: Float): Float {
+        return getShortestAngleDifference(from = rawAzimuth, to = qiblahAngle)
+    }
+
+    private fun getShortestAngleDifference(from: Float, to: Float): Float {
+        val diff = (to - from) % 360
+        return when {
+            diff > 180f -> diff - 360f
+            diff < -180f -> diff + 360f
+            else -> diff
+        }
+    }
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/compass/CompassViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/compass/CompassViewModel.kt
@@ -1,9 +1,58 @@
 package net.thechance.mena.faith.presentation.feature.qiblah.compass
 
+import net.thechance.mena.faith.domain.usecase.QiblahBearingCalculatorUseCase
 import net.thechance.mena.faith.presentation.base.BaseViewModel
+import net.thechance.mena.faith.presentation.util.AzimuthProvider
 
-class CompassViewModel() : BaseViewModel<CompassScreenState, CompassEffect>(CompassScreenState()),
+class CompassViewModel(
+    private val bearingCalculatorUseCase: QiblahBearingCalculatorUseCase,
+    private val azimuthProvider: AzimuthProvider
+) : BaseViewModel<CompassScreenState, CompassEffect>(CompassScreenState()),
     CompassInteractionListener {
+    private var currentContinuousAzimuth: Float = 0f
+
+    init {
+        getQiblahAngle()
+    }
+
+    private fun getQiblahAngle() {
+        tryToExecute(
+            execute = bearingCalculatorUseCase::calculateQiblahAngle,
+            onSuccess = ::onGetQiblahSuccess
+        )
+    }
+
+    private fun onGetQiblahSuccess(angle: Double) {
+        updateState { it.copy(qiblahAngleValue = angle.toFloat()) }
+        startListeningOnAzimuth()
+    }
+
+    private fun startListeningOnAzimuth() {
+        tryToCollect(
+            block = azimuthProvider::startListening,
+            onEmitNewValue = ::onAzimuthValueChange,
+        )
+    }
+
+    private fun onAzimuthValueChange(rawAzimuth: Float) {
+        val oldAngleOnCircle = currentContinuousAzimuth % 360
+        var diff = rawAzimuth - oldAngleOnCircle
+        if (diff > 180f) {
+            diff -= 360f
+        } else if (diff < -180f) {
+            diff += 360f
+        }
+        currentContinuousAzimuth += diff
+        var relativeAngle = uiState.value.qiblahAngleValue - rawAzimuth
+        while (relativeAngle <= -180) relativeAngle += 360
+        while (relativeAngle > 180) relativeAngle -= 360
+        updateState {
+            it.copy(
+                continuousAzimuth = currentContinuousAzimuth,
+                angleToQiblah = relativeAngle
+            )
+        }
+    }
 
     override fun onBackClick() = sendEffect(CompassEffect.NavigateBack)
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/navigation/FaithNavGraph.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/navigation/FaithNavGraph.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import net.thechance.mena.faith.presentation.designSystem.theme.QuranTheme
 import net.thechance.mena.faith.presentation.feature.main.MainScreen
+import net.thechance.mena.faith.presentation.feature.qiblah.compass.CompassScreen
 import net.thechance.mena.faith.presentation.feature.quran.bookmark.BookmarkScreen
 import net.thechance.mena.faith.presentation.feature.quran.qiblah.calibratedevice.CalibrateDeviceScreen
 import net.thechance.mena.faith.presentation.feature.quran.search.SearchScreen
@@ -18,7 +19,6 @@ import net.thechance.mena.faith.presentation.feature.quran.surah.SurahScreen
 @Composable
 fun FaithNavigation() {
     val navController = rememberNavController()
-
     CompositionLocalProvider(
         LocalNavController provides navController
     ) {
@@ -27,7 +27,6 @@ fun FaithNavigation() {
                 navController = navController,
                 startDestination = Route.MainRoute
             ) {
-
                 composable<Route.MainRoute> {
                     MainScreen()
                 }
@@ -43,9 +42,11 @@ fun FaithNavigation() {
                 composable<Route.SearchRoute> {
                     SearchScreen()
                 }
-
                 composable<Route.SurahDetailsRoute> {
                     SurahScreen()
+                }
+                composable<Route.CompassRoute> {
+                    CompassScreen()
                 }
             }
         }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/navigation/FaithNavGraph.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/navigation/FaithNavGraph.kt
@@ -11,7 +11,7 @@ import net.thechance.mena.faith.presentation.designSystem.theme.QuranTheme
 import net.thechance.mena.faith.presentation.feature.main.MainScreen
 import net.thechance.mena.faith.presentation.feature.qiblah.compass.CompassScreen
 import net.thechance.mena.faith.presentation.feature.quran.bookmark.BookmarkScreen
-import net.thechance.mena.faith.presentation.feature.quran.qiblah.calibratedevice.CalibrateDeviceScreen
+import net.thechance.mena.faith.presentation.feature.qiblah.calibratedevice.CalibrateDeviceScreen
 import net.thechance.mena.faith.presentation.feature.quran.search.SearchScreen
 import net.thechance.mena.faith.presentation.feature.quran.sur.SurScreen
 import net.thechance.mena.faith.presentation.feature.quran.surah.SurahScreen

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/navigation/Routes.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/navigation/Routes.kt
@@ -21,6 +21,9 @@ internal sealed interface Route {
     data object BookmarksRoute : Route
 
     @Serializable
+    data object CompassRoute : Route
+
+    @Serializable
     data object CalibrateDeviceRoute : Route
 
     @Serializable

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/util/AzimuthProvider.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/util/AzimuthProvider.kt
@@ -4,7 +4,5 @@ import kotlinx.coroutines.flow.Flow
 
 
 expect class AzimuthProvider {
-    val azimuthFlow: Flow<Float>
-    fun startListening()
-    fun stopListening()
+    fun startListening(): Flow<Float>
 }

--- a/faith_presentation/src/iosMain/kotlin/net/thechance/mena/faith/presentation/util/AzimuthProvider.ios.kt
+++ b/faith_presentation/src/iosMain/kotlin/net/thechance/mena/faith/presentation/util/AzimuthProvider.ios.kt
@@ -6,14 +6,8 @@ import platform.CoreLocation.CLLocationManagerDelegateProtocol
 import platform.darwin.NSObject
 
 actual class AzimuthProvider {
-
-    val locationManager = LocationManager()
-
-    actual val azimuthFlow: Flow<Float> = flowOf(0f)
-
-    actual fun startListening() {}
-
-    actual fun stopListening() {}
+    private val locationManager = LocationManager()
+    actual fun startListening(): Flow<Float> = flowOf(0f)
 }
 
-class LocationManager : NSObject(), CLLocationManagerDelegateProtocol
+internal class LocationManager : NSObject(), CLLocationManagerDelegateProtocol


### PR DESCRIPTION
This PR builds the Qiblah Compass feature screen. It integrates the device's real-time hardware sensors with our business logic to provide a functional, animated compass that directs the user to the Qiblah. The CompassViewModel consumes both of these data points to update the UI state.

- Integrates AzimuthProvider and QiblahBearingCalculatorUseCase.
- Manages all state logic, including:
- Calculating the continuous azimuth to prevent the 360°/0° "jump" animation.
- Calculating the relative angle from the top of the device to the Qiblah.
- AzimuthProvider.kt has been refactored and now delivers a streamlined Flow<Float> of sensor data.

https://github.com/user-attachments/assets/5f09ed3d-ccf6-4c67-a5f1-cc75b6560eac
