### PR TITLE
Feature/FTH-59-integrate-prayer-times-with-api

### DIFF
--- a/faith_data/build.gradle.kts
+++ b/faith_data/build.gradle.kts
@@ -68,10 +68,6 @@ kover.reports {
         }
 
         excludes {
-
-                classes(
-                    "net.thechance.mena.faith.data.repository.PrayerTimeRepositoryImpl"
-                )
             annotatedBy("net.thechance.mena.faith.domain.annotation.KoverIgnore")
         }
     }

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/di/faithDataModule.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/di/faithDataModule.kt
@@ -1,12 +1,15 @@
 package net.thechance.mena.faith.data.di
 
 import de.jensklingenberg.ktorfit.Ktorfit
+import de.jensklingenberg.ktorfit.converter.ResponseConverterFactory
 import io.ktor.client.HttpClient
 import net.thechance.mena.faith.data.database.AyahDao
 import net.thechance.mena.faith.data.database.QuranDatabase
 import net.thechance.mena.faith.data.remote.client.NetworkClient
 import net.thechance.mena.faith.data.remote.service.BookmarkApiService
+import net.thechance.mena.faith.data.remote.service.PrayerTimeApiService
 import net.thechance.mena.faith.data.remote.service.createBookmarkApiService
+import net.thechance.mena.faith.data.remote.service.createPrayerTimeApiService
 import net.thechance.mena.faith.data.repository.BookmarkRepositoryImpl
 import net.thechance.mena.faith.data.repository.PrayerTimeRepositoryImpl
 import net.thechance.mena.faith.data.repository.QuranRepositoryImpl
@@ -35,11 +38,16 @@ val faithDataModule = module {
         Ktorfit.Builder()
             .httpClient(get<HttpClient>(named("faithHttpClient")))
             .baseUrl(get<String>(named("baseUrl")))
+            .converterFactories(ResponseConverterFactory())
             .build()
     }
 
     single<BookmarkApiService> {
         get<Ktorfit>(named("faithKtorfit")).createBookmarkApiService()
+    }
+
+    single<PrayerTimeApiService> {
+        get<Ktorfit>(named("faithKtorfit")).createPrayerTimeApiService()
     }
 
     singleOf(::BookmarkRepositoryImpl) bind BookmarkRepository::class

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/dto/prayertime/GregorianDateDto.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/dto/prayertime/GregorianDateDto.kt
@@ -1,0 +1,26 @@
+package net.thechance.mena.faith.data.remote.dto.prayertime
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GregorianDateDto(
+    @SerialName("date")
+    val date: String?,
+    @SerialName("dateFormat")
+    val dateFormat: String?,
+    @SerialName("timestamp")
+    val timestamp: String?,
+    @SerialName("readableDate")
+    val readableDate: String?,
+    @SerialName("day")
+    val day: String?,
+    @SerialName("dayName")
+    val dayName: String?,
+    @SerialName("month")
+    val month: Int?,
+    @SerialName("monthName")
+    val monthName: String?,
+    @SerialName("year")
+    val year: String?
+)

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/dto/prayertime/HijriDateDto.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/dto/prayertime/HijriDateDto.kt
@@ -1,0 +1,28 @@
+package net.thechance.mena.faith.data.remote.dto.prayertime
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HijriDateDto(
+    @SerialName("date")
+    val date: String?,
+    @SerialName("dateFormat")
+    val dateFormat: String?,
+    @SerialName("readableDate")
+    val readableDate: String?,
+    @SerialName("day")
+    val day: String?,
+    @SerialName("dayName")
+    val dayName: String?,
+    @SerialName("dayArabicName")
+    val dayArabicName: String?,
+    @SerialName("month")
+    val month: Int?,
+    @SerialName("monthName")
+    val monthName: String?,
+    @SerialName("monthArabicName")
+    val monthArabicName: String?,
+    @SerialName("year")
+    val year: String?
+)

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/dto/prayertime/PrayerDateDto.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/dto/prayertime/PrayerDateDto.kt
@@ -1,0 +1,12 @@
+package net.thechance.mena.faith.data.remote.dto.prayertime
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PrayerDateDto(
+    @SerialName("hijri")
+    val hijri: HijriDateDto?,
+    @SerialName("gregorian")
+    val gregorian: GregorianDateDto?
+)

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/dto/prayertime/PrayerTimesDto.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/dto/prayertime/PrayerTimesDto.kt
@@ -1,0 +1,23 @@
+package net.thechance.mena.faith.data.remote.dto.prayertime
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import net.thechance.mena.faith.data.remote.mapper.prayertime.StringHoursAndMinutesToInstantMapper
+
+@Serializable
+data class PrayerTimesDto(
+    @SerialName("sunrise")
+    val sunrise: String?,
+    @SerialName("fajr")
+    val fajr: String?,
+    @SerialName("dhuhr")
+    val dhuhr: String?,
+    @SerialName("asr")
+    val asr: String?,
+    @SerialName("maghrib")
+    val maghrib: String?,
+    @SerialName("isha")
+    val isha: String?,
+    @SerialName("date")
+    val date: PrayerDateDto?
+) : StringHoursAndMinutesToInstantMapper

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/StringHoursAndMinutesToInstantMapper.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/StringHoursAndMinutesToInstantMapper.kt
@@ -11,16 +11,27 @@ import kotlin.time.Instant
 @OptIn(ExperimentalTime::class)
 interface StringHoursAndMinutesToInstantMapper {
 
-    fun String?.toInstant(startOfDayTimeStamp: Long): Instant = runCatching {
-        stringTimeToInstant(this, startOfDayTimeStamp)
+    fun String?.toInstant(
+        startOfDayTimeStamp: Long,
+        timeZone: TimeZone = TimeZone.currentSystemDefault()
+    ): Instant = runCatching {
+        stringTimeToInstant(
+            hoursAndMinutes = this,
+            startOfDayTimeStamp = startOfDayTimeStamp,
+            timeZone = timeZone
+        )
     }.getOrDefault(Instant.fromEpochMilliseconds(startOfDayTimeStamp))
 
-    private fun stringTimeToInstant(hoursAndMinutes: String?, startOfDayTimeStamp: Long): Instant {
+    private fun stringTimeToInstant(
+        hoursAndMinutes: String?,
+        startOfDayTimeStamp: Long,
+        timeZone: TimeZone
+    ): Instant {
         val parts = hoursAndMinutes?.split(":").orEmpty()
         val hour = parts[0].toInt()
         val minute = parts[1].toInt()
         val startOfDayInstant = Instant.fromEpochSeconds(startOfDayTimeStamp)
-        val localDate = startOfDayInstant.toLocalDateTime(TimeZone.currentSystemDefault()).date
+        val localDate = startOfDayInstant.toLocalDateTime(timeZone).date
         val dateTime = LocalDateTime(
             year = localDate.year,
             month = localDate.month.number,
@@ -29,6 +40,6 @@ interface StringHoursAndMinutesToInstantMapper {
             minute = minute
         )
 
-        return dateTime.toInstant(TimeZone.currentSystemDefault())
+        return dateTime.toInstant(timeZone = timeZone)
     }
 }

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/StringHoursAndMinutesToInstantMapper.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/StringHoursAndMinutesToInstantMapper.kt
@@ -1,0 +1,34 @@
+package net.thechance.mena.faith.data.remote.mapper.prayertime
+
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.number
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+@OptIn(ExperimentalTime::class)
+interface StringHoursAndMinutesToInstantMapper {
+
+    fun String?.toInstant(startOfDayTimeStamp: Long): Instant = runCatching {
+        stringTimeToInstant(this, startOfDayTimeStamp)
+    }.getOrDefault(Instant.fromEpochMilliseconds(startOfDayTimeStamp))
+
+    private fun stringTimeToInstant(hoursAndMinutes: String?, startOfDayTimeStamp: Long): Instant {
+        val parts = hoursAndMinutes?.split(":").orEmpty()
+        val hour = parts[0].toInt()
+        val minute = parts[1].toInt()
+        val startOfDayInstant = Instant.fromEpochSeconds(startOfDayTimeStamp)
+        val localDate = startOfDayInstant.toLocalDateTime(TimeZone.currentSystemDefault()).date
+        val dateTime = LocalDateTime(
+            year = localDate.year,
+            month = localDate.month.number,
+            day = localDate.day,
+            hour = hour,
+            minute = minute
+        )
+
+        return dateTime.toInstant(TimeZone.currentSystemDefault())
+    }
+}

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/prayerTimesDtoMapper.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/prayerTimesDtoMapper.kt
@@ -8,36 +8,37 @@ import kotlin.time.ExperimentalTime
 @OptIn(ExperimentalTime::class)
 fun PrayerTimesDto.toDomain(): List<PrayerTime> {
     val startOfDayTimeStamp: Long = this.date?.gregorian?.timestamp.toSafeLong()
+    val hijriReadableDate = this.date?.hijri?.readableDate.orEmpty()
     return listOf(
         PrayerTime(
             name = PrayerName.SUNRISE,
             time = sunrise.toInstant(startOfDayTimeStamp),
-            hijriDate = date?.hijri?.readableDate.orEmpty()
+            hijriDate = hijriReadableDate
         ),
         PrayerTime(
             name = PrayerName.FAJR,
             time = fajr.toInstant(startOfDayTimeStamp),
-            hijriDate = date?.hijri?.readableDate.orEmpty()
+            hijriDate = hijriReadableDate
         ),
         PrayerTime(
             name = PrayerName.DHUHR,
             time = dhuhr.toInstant(startOfDayTimeStamp),
-            hijriDate = date?.hijri?.readableDate.orEmpty()
+            hijriDate = hijriReadableDate
         ),
         PrayerTime(
             name = PrayerName.ASR,
             time = asr.toInstant(startOfDayTimeStamp),
-            hijriDate = date?.hijri?.readableDate.orEmpty()
+            hijriDate = hijriReadableDate
         ),
         PrayerTime(
             name = PrayerName.MAGHRIB,
             time = maghrib.toInstant(startOfDayTimeStamp),
-            hijriDate = date?.hijri?.readableDate.orEmpty()
+            hijriDate = hijriReadableDate
         ),
         PrayerTime(
             name = PrayerName.ISHA,
             time = isha.toInstant(startOfDayTimeStamp),
-            hijriDate = date?.hijri?.readableDate.orEmpty()
+            hijriDate = hijriReadableDate
         )
     )
 }

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/prayerTimesDtoMapper.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/prayerTimesDtoMapper.kt
@@ -1,0 +1,45 @@
+package net.thechance.mena.faith.data.remote.mapper.prayertime
+
+import net.thechance.mena.faith.data.remote.dto.prayertime.PrayerTimesDto
+import net.thechance.mena.faith.domain.entity.PrayerName
+import net.thechance.mena.faith.domain.entity.PrayerTime
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+fun PrayerTimesDto.toDomain(): List<PrayerTime> {
+    val startOfDayTimeStamp: Long = this.date?.gregorian?.timestamp.toSafeLong()
+    return listOf(
+        PrayerTime(
+            name = PrayerName.SUNRISE,
+            time = sunrise.toInstant(startOfDayTimeStamp),
+            hijriDate = date?.hijri?.readableDate.orEmpty()
+        ),
+        PrayerTime(
+            name = PrayerName.FAJR,
+            time = fajr.toInstant(startOfDayTimeStamp),
+            hijriDate = date?.hijri?.readableDate.orEmpty()
+        ),
+        PrayerTime(
+            name = PrayerName.DHUHR,
+            time = dhuhr.toInstant(startOfDayTimeStamp),
+            hijriDate = date?.hijri?.readableDate.orEmpty()
+        ),
+        PrayerTime(
+            name = PrayerName.ASR,
+            time = asr.toInstant(startOfDayTimeStamp),
+            hijriDate = date?.hijri?.readableDate.orEmpty()
+        ),
+        PrayerTime(
+            name = PrayerName.MAGHRIB,
+            time = maghrib.toInstant(startOfDayTimeStamp),
+            hijriDate = date?.hijri?.readableDate.orEmpty()
+        ),
+        PrayerTime(
+            name = PrayerName.ISHA,
+            time = isha.toInstant(startOfDayTimeStamp),
+            hijriDate = date?.hijri?.readableDate.orEmpty()
+        )
+    )
+}
+
+private fun String?.toSafeLong(): Long = runCatching { this?.toLong() ?: 0L }.getOrDefault(0L)

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/prayerTimesDtoMapper.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/prayerTimesDtoMapper.kt
@@ -1,43 +1,44 @@
 package net.thechance.mena.faith.data.remote.mapper.prayertime
 
+import kotlinx.datetime.TimeZone
 import net.thechance.mena.faith.data.remote.dto.prayertime.PrayerTimesDto
 import net.thechance.mena.faith.domain.entity.PrayerName
 import net.thechance.mena.faith.domain.entity.PrayerTime
 import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalTime::class)
-fun PrayerTimesDto.toDomain(): List<PrayerTime> {
+fun PrayerTimesDto.toDomain(timeZone: TimeZone = TimeZone.currentSystemDefault()): List<PrayerTime> {
     val startOfDayTimeStamp: Long = this.date?.gregorian?.timestamp.toSafeLong()
     val hijriReadableDate = this.date?.hijri?.readableDate.orEmpty()
     return listOf(
         PrayerTime(
             name = PrayerName.SUNRISE,
-            time = sunrise.toInstant(startOfDayTimeStamp),
+            time = sunrise.toInstant(startOfDayTimeStamp, timeZone),
             hijriDate = hijriReadableDate
         ),
         PrayerTime(
             name = PrayerName.FAJR,
-            time = fajr.toInstant(startOfDayTimeStamp),
+            time = fajr.toInstant(startOfDayTimeStamp, timeZone),
             hijriDate = hijriReadableDate
         ),
         PrayerTime(
             name = PrayerName.DHUHR,
-            time = dhuhr.toInstant(startOfDayTimeStamp),
+            time = dhuhr.toInstant(startOfDayTimeStamp, timeZone),
             hijriDate = hijriReadableDate
         ),
         PrayerTime(
             name = PrayerName.ASR,
-            time = asr.toInstant(startOfDayTimeStamp),
+            time = asr.toInstant(startOfDayTimeStamp, timeZone),
             hijriDate = hijriReadableDate
         ),
         PrayerTime(
             name = PrayerName.MAGHRIB,
-            time = maghrib.toInstant(startOfDayTimeStamp),
+            time = maghrib.toInstant(startOfDayTimeStamp, timeZone),
             hijriDate = hijriReadableDate
         ),
         PrayerTime(
             name = PrayerName.ISHA,
-            time = isha.toInstant(startOfDayTimeStamp),
+            time = isha.toInstant(startOfDayTimeStamp, timeZone),
             hijriDate = hijriReadableDate
         )
     )

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/service/PrayerTimeApiService.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/service/PrayerTimeApiService.kt
@@ -1,0 +1,17 @@
+package net.thechance.mena.faith.data.remote.service
+
+import de.jensklingenberg.ktorfit.Response
+import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.Path
+import de.jensklingenberg.ktorfit.http.Query
+import net.thechance.mena.faith.data.remote.dto.prayertime.PrayerTimesDto
+
+interface PrayerTimeApiService {
+
+    @GET("faith/DayPrayerTimes/{date}")
+    suspend fun getPrayerTimes(
+        @Path("date") date: String,
+        @Query("latitude") latitude: Double,
+        @Query("longitude") longitude: Double,
+    ): Response<PrayerTimesDto>
+}

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/repository/PrayerTimeRepositoryImpl.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/repository/PrayerTimeRepositoryImpl.kt
@@ -20,14 +20,15 @@ class PrayerTimeRepositoryImpl(
 
     override suspend fun getPrayerTimes(
         date: Instant,
-        location: Location
+        location: Location,
+        timeZone: TimeZone,
     ): List<PrayerTime> = executeApiSafely<PrayerTimesDto> {
         prayerTimeApiService.getPrayerTimes(
             date = date.toDateString(),
             latitude = location.latitude,
             longitude = location.longitude
         )
-    }.toDomain()
+    }.toDomain(timeZone)
 
     private fun Instant.toDateString(): String {
         val dateTime = this.toLocalDateTime(TimeZone.currentSystemDefault())

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/repository/PrayerTimeRepositoryImpl.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/repository/PrayerTimeRepositoryImpl.kt
@@ -24,14 +24,14 @@ class PrayerTimeRepositoryImpl(
         timeZone: TimeZone,
     ): List<PrayerTime> = executeApiSafely<PrayerTimesDto> {
         prayerTimeApiService.getPrayerTimes(
-            date = date.toDateString(),
+            date = date.toDateString(timeZone = timeZone),
             latitude = location.latitude,
             longitude = location.longitude
         )
     }.toDomain(timeZone)
 
-    private fun Instant.toDateString(): String {
-        val dateTime = this.toLocalDateTime(TimeZone.currentSystemDefault())
+    private fun Instant.toDateString(timeZone: TimeZone): String {
+        val dateTime = this.toLocalDateTime(timeZone = timeZone)
         val month = dateTime.month.number.toString().padStart(2, '0')
         val day = dateTime.day.toString().padStart(2, '0')
         return "$day-$month-${dateTime.year}"

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/repository/PrayerTimeRepositoryImpl.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/repository/PrayerTimeRepositoryImpl.kt
@@ -1,55 +1,38 @@
 package net.thechance.mena.faith.data.repository
 
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.number
+import kotlinx.datetime.toLocalDateTime
+import net.thechance.mena.faith.data.remote.dto.prayertime.PrayerTimesDto
+import net.thechance.mena.faith.data.remote.mapper.prayertime.toDomain
+import net.thechance.mena.faith.data.remote.service.PrayerTimeApiService
+import net.thechance.mena.faith.data.utils.executeApiSafely
 import net.thechance.mena.faith.domain.entity.Location
-import net.thechance.mena.faith.domain.entity.PrayerName
 import net.thechance.mena.faith.domain.entity.PrayerTime
 import net.thechance.mena.faith.domain.repository.PrayerTimeRepository
-import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.minutes
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
-class PrayerTimeRepositoryImpl : PrayerTimeRepository {
+@OptIn(ExperimentalTime::class)
+class PrayerTimeRepositoryImpl(
+    private val prayerTimeApiService: PrayerTimeApiService
+) : PrayerTimeRepository {
 
-    @OptIn(ExperimentalTime::class)
     override suspend fun getPrayerTimes(
         date: Instant,
         location: Location
-    ): List<PrayerTime> {
-        val baseDay = date
-        val hijriDate = "22 Safar 1447H"
-
-        return listOf(
-            PrayerTime(
-                name = PrayerName.FAJR,
-                time = baseDay + 4.hours + 15.minutes,
-                hijriDate = hijriDate
-            ),
-            PrayerTime(
-                name = PrayerName.SUNRISE,
-                time = baseDay + 6.hours + 45.minutes,
-                hijriDate = hijriDate
-            ),
-            PrayerTime(
-                name = PrayerName.DHUHR,
-                time = baseDay + 12.hours + 5.minutes,
-                hijriDate = hijriDate
-            ),
-            PrayerTime(
-                name = PrayerName.ASR,
-                time = baseDay + 15.hours + 32.minutes,
-                hijriDate = hijriDate
-            ),
-            PrayerTime(
-                name = PrayerName.MAGHRIB,
-                time = baseDay + 18.hours + 2.minutes,
-                hijriDate = hijriDate
-            ),
-            PrayerTime(
-                name = PrayerName.ISHA,
-                time = baseDay + 19.hours + 25.minutes,
-                hijriDate = hijriDate
-            )
+    ): List<PrayerTime> = executeApiSafely<PrayerTimesDto> {
+        prayerTimeApiService.getPrayerTimes(
+            date = date.toDateString(),
+            latitude = location.latitude,
+            longitude = location.longitude
         )
+    }.toDomain()
+
+    private fun Instant.toDateString(): String {
+        val dateTime = this.toLocalDateTime(TimeZone.currentSystemDefault())
+        val month = dateTime.month.number.toString().padStart(2, '0')
+        val day = dateTime.day.toString().padStart(2, '0')
+        return "$day-$month-${dateTime.year}"
     }
 }

--- a/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/PrayerTimesDtoToDomainTest.kt
+++ b/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/PrayerTimesDtoToDomainTest.kt
@@ -1,0 +1,74 @@
+package net.thechance.mena.faith.data.remote.mapper.prayertime
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.test.runTest
+import net.thechance.mena.faith.data.repository.getFakePrayerTimesDto
+import net.thechance.mena.faith.data.repository.getPrayerTimesFakeData
+import net.thechance.mena.faith.domain.entity.PrayerTime
+import kotlin.test.Test
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+@OptIn(ExperimentalTime::class)
+class PrayerTimesDtoToDomainTest {
+
+    @Test
+    fun `toDomain should return list of PrayerTime when PrayerTimesDto is valid`() = runTest {
+        //When
+        val result = fakePrayerTimesDto.toDomain()
+        //Then
+        assertThat(result).isEqualTo(fakePrayerTimes)
+    }
+
+    @Test
+    fun `toDomain should return data with defaults when data has nulls`() = runTest {
+        //When
+        val result = fakePrayerTimesDtoWithNulls.toDomain()
+        //Then
+        assertThat(result).isEqualTo(fakePrayerTimesWithDefaults)
+
+    }
+
+    private companion object {
+        val fakePrayerTimesDto = getFakePrayerTimesDto()
+        val fakePrayerTimes: List<PrayerTime> = getPrayerTimesFakeData()
+        val fakePrayerTimesDtoWithNulls = getFakePrayerTimesDto(
+            sunrise = null,
+            fajr = null,
+            dhuhr = null,
+            asr = null,
+            maghrib = null,
+            isha = null,
+            hijriDate = null,
+            hijriDateFormat = null,
+            hijriReadableDate = null,
+            hijriDay = null,
+            hijriDayName = null,
+            hijriDayArabicName = null,
+            hijriMonth = null,
+            hijriMonthName = null,
+            hijriMonthArabicName = null,
+            hijriYear = null,
+            gregorianDate = null,
+            gregorianDateFormat = null,
+            timestamp = null,
+            gregorianReadableDate = null,
+            gregorianDay = null,
+            gregorianDayName = null,
+            gregorianMonth = null,
+            gregorianMonthName = null,
+            gregorianYear = null
+        )
+        val startOfDayInstant: Instant = Instant.fromEpochMilliseconds(0)
+        val fakePrayerTimesWithDefaults: List<PrayerTime> = getPrayerTimesFakeData(
+            sunriseTime = startOfDayInstant,
+            fajrTime = startOfDayInstant,
+            dhuhrTime = startOfDayInstant,
+            asrTime = startOfDayInstant,
+            maghribTime = startOfDayInstant,
+            ishaTime = startOfDayInstant,
+            hijriDate = ""
+        )
+    }
+}

--- a/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/PrayerTimesDtoToDomainTest.kt
+++ b/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/PrayerTimesDtoToDomainTest.kt
@@ -32,8 +32,9 @@ class PrayerTimesDtoToDomainTest {
     }
 
     private companion object {
+        val timeZone = TimeZone.of("Africa/Cairo")
         val fakePrayerTimesDto = getFakePrayerTimesDto()
-        val fakePrayerTimes: List<PrayerTime> = getPrayerTimesFakeData()
+        val fakePrayerTimes: List<PrayerTime> = getPrayerTimesFakeData(timeZone)
         val fakePrayerTimesDtoWithNulls = getFakePrayerTimesDto(
             sunrise = null,
             fajr = null,
@@ -61,7 +62,6 @@ class PrayerTimesDtoToDomainTest {
             gregorianMonthName = null,
             gregorianYear = null
         )
-        val timeZone = TimeZone.of("Africa/Cairo")
         val startOfDayInstant: Instant = Instant.fromEpochMilliseconds(0)
         val fakePrayerTimesWithDefaults: List<PrayerTime> = getPrayerTimesFakeData(
             sunriseTime = startOfDayInstant,

--- a/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/PrayerTimesDtoToDomainTest.kt
+++ b/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/PrayerTimesDtoToDomainTest.kt
@@ -3,6 +3,7 @@ package net.thechance.mena.faith.data.remote.mapper.prayertime
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.TimeZone
 import net.thechance.mena.faith.data.repository.getFakePrayerTimesDto
 import net.thechance.mena.faith.data.repository.getPrayerTimesFakeData
 import net.thechance.mena.faith.domain.entity.PrayerTime
@@ -16,7 +17,7 @@ class PrayerTimesDtoToDomainTest {
     @Test
     fun `toDomain should return list of PrayerTime when PrayerTimesDto is valid`() = runTest {
         //When
-        val result = fakePrayerTimesDto.toDomain()
+        val result = fakePrayerTimesDto.toDomain(timeZone)
         //Then
         assertThat(result).isEqualTo(fakePrayerTimes)
     }
@@ -24,7 +25,7 @@ class PrayerTimesDtoToDomainTest {
     @Test
     fun `toDomain should return data with defaults when data has nulls`() = runTest {
         //When
-        val result = fakePrayerTimesDtoWithNulls.toDomain()
+        val result = fakePrayerTimesDtoWithNulls.toDomain(timeZone)
         //Then
         assertThat(result).isEqualTo(fakePrayerTimesWithDefaults)
 
@@ -60,6 +61,7 @@ class PrayerTimesDtoToDomainTest {
             gregorianMonthName = null,
             gregorianYear = null
         )
+        val timeZone = TimeZone.of("Africa/Cairo")
         val startOfDayInstant: Instant = Instant.fromEpochMilliseconds(0)
         val fakePrayerTimesWithDefaults: List<PrayerTime> = getPrayerTimesFakeData(
             sunriseTime = startOfDayInstant,

--- a/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/StringHoursAndMinutesToInstantMapperTest.kt
+++ b/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/StringHoursAndMinutesToInstantMapperTest.kt
@@ -1,0 +1,46 @@
+package net.thechance.mena.faith.data.remote.mapper.prayertime
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+@OptIn(ExperimentalTime::class)
+class StringHoursAndMinutesToInstantMapperTest : StringHoursAndMinutesToInstantMapper {
+
+    @Test
+    fun `toInstant should map valid time string to correct Instant`() {
+        // Given
+        val time = "05:25"
+        // When
+        val result = time.toInstant(START_OF_DAY_TIMESTAMP)
+        // Then
+        val expected = Instant.parse("2025-10-10T02:25:00Z") // 10-10-2025 05:25
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `toInstant should return startOfDay when time is null`() {
+        // When
+        val result = null.toInstant(START_OF_DAY_TIMESTAMP)
+        // Then
+        val expected = Instant.fromEpochMilliseconds(START_OF_DAY_TIMESTAMP)
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `toInstant should return startOfDay when format invalid`() {
+        // Given
+        val invalidTime = "abc"
+        // When
+        val result = invalidTime.toInstant(START_OF_DAY_TIMESTAMP)
+        // Then
+        val expected = Instant.fromEpochMilliseconds(START_OF_DAY_TIMESTAMP)
+        assertThat(result).isEqualTo(expected)
+    }
+
+    private companion object {
+        const val START_OF_DAY_TIMESTAMP = 1760068800L // 2025-10-10 00:00
+    }
+}

--- a/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/StringHoursAndMinutesToInstantMapperTest.kt
+++ b/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/remote/mapper/prayertime/StringHoursAndMinutesToInstantMapperTest.kt
@@ -2,6 +2,7 @@ package net.thechance.mena.faith.data.remote.mapper.prayertime
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import kotlinx.datetime.TimeZone
 import kotlin.test.Test
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -14,7 +15,8 @@ class StringHoursAndMinutesToInstantMapperTest : StringHoursAndMinutesToInstantM
         // Given
         val time = "05:25"
         // When
-        val result = time.toInstant(START_OF_DAY_TIMESTAMP)
+        val result =
+            time.toInstant(startOfDayTimeStamp = START_OF_DAY_TIMESTAMP, timeZone = timeZone)
         // Then
         val expected = Instant.parse("2025-10-10T02:25:00Z") // 10-10-2025 05:25
         assertThat(result).isEqualTo(expected)
@@ -23,7 +25,8 @@ class StringHoursAndMinutesToInstantMapperTest : StringHoursAndMinutesToInstantM
     @Test
     fun `toInstant should return startOfDay when time is null`() {
         // When
-        val result = null.toInstant(START_OF_DAY_TIMESTAMP)
+        val result =
+            null.toInstant(startOfDayTimeStamp = START_OF_DAY_TIMESTAMP, timeZone = timeZone)
         // Then
         val expected = Instant.fromEpochMilliseconds(START_OF_DAY_TIMESTAMP)
         assertThat(result).isEqualTo(expected)
@@ -34,13 +37,15 @@ class StringHoursAndMinutesToInstantMapperTest : StringHoursAndMinutesToInstantM
         // Given
         val invalidTime = "abc"
         // When
-        val result = invalidTime.toInstant(START_OF_DAY_TIMESTAMP)
+        val result =
+            invalidTime.toInstant(startOfDayTimeStamp = START_OF_DAY_TIMESTAMP, timeZone = timeZone)
         // Then
         val expected = Instant.fromEpochMilliseconds(START_OF_DAY_TIMESTAMP)
         assertThat(result).isEqualTo(expected)
     }
 
     private companion object {
+        val timeZone = TimeZone.of("Africa/Cairo")
         const val START_OF_DAY_TIMESTAMP = 1760068800L // 2025-10-10 00:00
     }
 }

--- a/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/PrayerTimeRepositoryImplTest.kt
+++ b/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/PrayerTimeRepositoryImplTest.kt
@@ -1,0 +1,171 @@
+package net.thechance.mena.faith.data.repository
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import de.jensklingenberg.ktorfit.Response
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import net.thechance.mena.faith.data.remote.dto.prayertime.PrayerTimesDto
+import net.thechance.mena.faith.data.remote.service.PrayerTimeApiService
+import net.thechance.mena.faith.domain.entity.Location
+import net.thechance.mena.faith.domain.entity.PrayerTime
+import net.thechance.mena.faith.domain.exception.FaithException
+import kotlin.test.Test
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+@OptIn(ExperimentalTime::class)
+class PrayerTimeRepositoryImplTest {
+
+    private val prayerTimeApiService: PrayerTimeApiService = mock(MockMode.autofill)
+    private val prayerTimeRepository = PrayerTimeRepositoryImpl(prayerTimeApiService)
+
+    @Test
+    fun `getPrayerTimes should return list of PrayerTime when api service return valid data`() =
+        runTest {
+            //Given
+            everySuspend {
+                prayerTimeApiService.getPrayerTimes(
+                    date = DATE,
+                    latitude = LAT,
+                    longitude = LONG
+                )
+            } returns makeSuccessFakeResponse(
+                body = fakePrayerTimesDto,
+                successStatus = HttpStatusCode.OK
+            )
+            //When
+            val result = prayerTimeRepository.getPrayerTimes(
+                date = dateInstant,
+                location = Location(latitude = LAT, longitude = LONG)
+            )
+            //Then
+            assertThat(result).isEqualTo(fakePrayerTimes)
+        }
+
+    @Test
+    fun `getPrayerTimes should throw NetworkException when error occur in parsing response body is null`() =
+        runTest {
+            //Given
+            everySuspend {
+                prayerTimeApiService.getPrayerTimes(
+                    date = DATE,
+                    latitude = LAT,
+                    longitude = LONG
+                )
+            } returns makeSuccessFakeResponse(
+                body = null,
+                successStatus = HttpStatusCode.OK
+            )
+            //When & Then
+            assertFailure {
+                prayerTimeRepository.getPrayerTimes(
+                    date = dateInstant,
+                    location = Location(latitude = LAT, longitude = LONG)
+                )
+            }.isInstanceOf<FaithException.NetworkException>()
+        }
+
+    @Test
+    fun `getPrayerTimes should throw UnauthorizedException when status code is Unauthorized`() =
+        runTest {
+            //Given
+            everySuspend {
+                prayerTimeApiService.getPrayerTimes(
+                    date = DATE,
+                    latitude = LAT,
+                    longitude = LONG
+                )
+            } returns makeFailFakeResponse(errorStatus = HttpStatusCode.Unauthorized)
+            //When & Then
+            assertFailure {
+                prayerTimeRepository.getPrayerTimes(
+                    date = dateInstant,
+                    location = Location(latitude = LAT, longitude = LONG)
+                )
+            }.isInstanceOf<FaithException.UnauthorizedException>()
+        }
+
+    @Test
+    fun `getPrayerTimes should throw NetworkException when status code is InternalServerError`() =
+        runTest {
+            //Given
+            everySuspend {
+                prayerTimeApiService.getPrayerTimes(
+                    date = DATE,
+                    latitude = LAT,
+                    longitude = LONG
+                )
+            } returns makeFailFakeResponse(errorStatus = HttpStatusCode.InternalServerError)
+            //When & Then
+            assertFailure {
+                prayerTimeRepository.getPrayerTimes(
+                    date = dateInstant,
+                    location = Location(latitude = LAT, longitude = LONG)
+                )
+            }.isInstanceOf<FaithException.NetworkException>()
+        }
+
+    @Test
+    fun `getPrayerTimes should throw UnknownException when status code is not valuable`() =
+        runTest {
+            //Given
+            everySuspend {
+                prayerTimeApiService.getPrayerTimes(
+                    date = DATE,
+                    latitude = LAT,
+                    longitude = LONG
+                )
+            } returns makeFailFakeResponse(errorStatus = HttpStatusCode.Forbidden)
+            //When & Then
+            assertFailure {
+                prayerTimeRepository.getPrayerTimes(
+                    date = dateInstant,
+                    location = Location(latitude = LAT, longitude = LONG)
+                )
+            }.isInstanceOf<FaithException.UnknownException>()
+        }
+
+    private fun makeSuccessFakeResponse(
+        body: PrayerTimesDto? = fakePrayerTimesDto,
+        successStatus: HttpStatusCode = HttpStatusCode.OK
+    ): Response<PrayerTimesDto> {
+        val mockHttpResponse: HttpResponse = mock(MockMode.autofill) {
+            everySuspend { status } returns successStatus
+        }
+
+        return Response.success(
+            body = body,
+            rawResponse = mockHttpResponse
+        ) as Response<PrayerTimesDto>
+    }
+
+    private fun makeFailFakeResponse(
+        errorStatus: HttpStatusCode = HttpStatusCode.InternalServerError
+    ): Response<PrayerTimesDto> {
+        val mockHttpResponse: HttpResponse = mock(MockMode.autofill) {
+            everySuspend { status } returns errorStatus
+        }
+
+        return Response.error<PrayerTimesDto>(
+            rawResponse = mockHttpResponse,
+            body = ""
+        ) as Response<PrayerTimesDto>
+    }
+
+    private companion object {
+        const val LAT = 30.033333
+        const val LONG = 31.233334
+        const val DATE = "10-10-2025"
+        val dateInstant = Instant.parse("2025-10-10T00:00:00Z") //10-10-2025 00:00
+        val fakePrayerTimesDto = getFakePrayerTimesDto()
+        val fakePrayerTimes: List<PrayerTime> = getPrayerTimesFakeData()
+    }
+}

--- a/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/PrayerTimeRepositoryImplTest.kt
+++ b/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/PrayerTimeRepositoryImplTest.kt
@@ -12,6 +12,7 @@ import dev.mokkery.mock
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.TimeZone
 import net.thechance.mena.faith.data.remote.dto.prayertime.PrayerTimesDto
 import net.thechance.mena.faith.data.remote.service.PrayerTimeApiService
 import net.thechance.mena.faith.domain.entity.Location
@@ -44,7 +45,8 @@ class PrayerTimeRepositoryImplTest {
             //When
             val result = prayerTimeRepository.getPrayerTimes(
                 date = dateInstant,
-                location = Location(latitude = LAT, longitude = LONG)
+                location = Location(latitude = LAT, longitude = LONG),
+                timeZone = timeZone
             )
             //Then
             assertThat(result).isEqualTo(fakePrayerTimes)
@@ -68,7 +70,8 @@ class PrayerTimeRepositoryImplTest {
             assertFailure {
                 prayerTimeRepository.getPrayerTimes(
                     date = dateInstant,
-                    location = Location(latitude = LAT, longitude = LONG)
+                    location = Location(latitude = LAT, longitude = LONG),
+                    timeZone = timeZone
                 )
             }.isInstanceOf<FaithException.NetworkException>()
         }
@@ -88,7 +91,8 @@ class PrayerTimeRepositoryImplTest {
             assertFailure {
                 prayerTimeRepository.getPrayerTimes(
                     date = dateInstant,
-                    location = Location(latitude = LAT, longitude = LONG)
+                    location = Location(latitude = LAT, longitude = LONG),
+                    timeZone = timeZone
                 )
             }.isInstanceOf<FaithException.UnauthorizedException>()
         }
@@ -108,7 +112,8 @@ class PrayerTimeRepositoryImplTest {
             assertFailure {
                 prayerTimeRepository.getPrayerTimes(
                     date = dateInstant,
-                    location = Location(latitude = LAT, longitude = LONG)
+                    location = Location(latitude = LAT, longitude = LONG),
+                    timeZone = timeZone
                 )
             }.isInstanceOf<FaithException.NetworkException>()
         }
@@ -128,7 +133,8 @@ class PrayerTimeRepositoryImplTest {
             assertFailure {
                 prayerTimeRepository.getPrayerTimes(
                     date = dateInstant,
-                    location = Location(latitude = LAT, longitude = LONG)
+                    location = Location(latitude = LAT, longitude = LONG),
+                    timeZone = timeZone
                 )
             }.isInstanceOf<FaithException.UnknownException>()
         }
@@ -161,6 +167,7 @@ class PrayerTimeRepositoryImplTest {
     }
 
     private companion object {
+        val timeZone = TimeZone.of("Africa/Cairo")
         const val LAT = 30.033333
         const val LONG = 31.233334
         const val DATE = "10-10-2025"

--- a/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/PrayerTimeRepositoryImplTest.kt
+++ b/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/PrayerTimeRepositoryImplTest.kt
@@ -173,6 +173,6 @@ class PrayerTimeRepositoryImplTest {
         const val DATE = "10-10-2025"
         val dateInstant = Instant.parse("2025-10-10T00:00:00Z") //10-10-2025 00:00
         val fakePrayerTimesDto = getFakePrayerTimesDto()
-        val fakePrayerTimes: List<PrayerTime> = getPrayerTimesFakeData()
+        val fakePrayerTimes: List<PrayerTime> = getPrayerTimesFakeData(timeZone = timeZone)
     }
 }

--- a/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/prayerTimesFakeData.kt
+++ b/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/prayerTimesFakeData.kt
@@ -1,5 +1,8 @@
 package net.thechance.mena.faith.data.repository
 
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 import net.thechance.mena.faith.data.remote.dto.prayertime.GregorianDateDto
 import net.thechance.mena.faith.data.remote.dto.prayertime.HijriDateDto
 import net.thechance.mena.faith.data.remote.dto.prayertime.PrayerDateDto
@@ -11,12 +14,49 @@ import kotlin.time.Instant
 
 @OptIn(ExperimentalTime::class)
 fun getPrayerTimesFakeData(
-    sunriseTime: Instant = Instant.parse("2025-10-10T03:52:00Z"), //10-10-2025 06:52
-    fajrTime: Instant = Instant.parse("2025-10-10T02:25:00Z"), //10-10-2025 05:25
-    dhuhrTime: Instant = Instant.parse("2025-10-10T09:40:00Z"), //10-10-2025 12:40
-    asrTime: Instant = Instant.parse("2025-10-10T12:59:00Z"), //10-10-2025 15:59
-    maghribTime: Instant = Instant.parse("2025-10-10T15:27:00Z"), //10-10-2025 18:27
-    ishaTime: Instant = Instant.parse("2025-10-10T16:45:00Z"), //10-10-2025 19:45
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+    sunriseTime: Instant = LocalDateTime(
+        2025,
+        10,
+        10,
+        6,
+        52
+    ).toInstant(timeZone),
+    fajrTime: Instant = LocalDateTime(
+        year = 2025,
+        month = 10,
+        day = 10,
+        hour = 5,
+        minute = 25
+    ).toInstant(timeZone),
+    dhuhrTime: Instant = LocalDateTime(
+        year = 2025,
+        month = 10,
+        day = 10,
+        hour = 12,
+        minute = 40
+    ).toInstant(timeZone),
+    asrTime: Instant = LocalDateTime(
+        year = 2025,
+        month = 10,
+        day = 10,
+        hour = 15,
+        minute = 59
+    ).toInstant(timeZone),
+    maghribTime: Instant = LocalDateTime(
+        year = 2025,
+        month = 10,
+        day = 10,
+        hour = 18,
+        minute = 27
+    ).toInstant(timeZone),
+    ishaTime: Instant = LocalDateTime(
+        year = 2025,
+        month = 10,
+        day = 10,
+        hour = 19,
+        minute = 45
+    ).toInstant(timeZone),
     hijriDate: String = fakePrayerTimesDto.date?.hijri?.readableDate.orEmpty()
 ): List<PrayerTime> {
     return listOf(

--- a/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/prayerTimesFakeData.kt
+++ b/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/prayerTimesFakeData.kt
@@ -16,11 +16,11 @@ import kotlin.time.Instant
 fun getPrayerTimesFakeData(
     timeZone: TimeZone = TimeZone.currentSystemDefault(),
     sunriseTime: Instant = LocalDateTime(
-        2025,
-        10,
-        10,
-        6,
-        52
+        year = 2025,
+        month = 10,
+        day = 10,
+        hour = 6,
+        minute = 52
     ).toInstant(timeZone),
     fajrTime: Instant = LocalDateTime(
         year = 2025,

--- a/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/prayerTimesFakeData.kt
+++ b/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/prayerTimesFakeData.kt
@@ -1,0 +1,117 @@
+package net.thechance.mena.faith.data.repository
+
+import net.thechance.mena.faith.data.remote.dto.prayertime.GregorianDateDto
+import net.thechance.mena.faith.data.remote.dto.prayertime.HijriDateDto
+import net.thechance.mena.faith.data.remote.dto.prayertime.PrayerDateDto
+import net.thechance.mena.faith.data.remote.dto.prayertime.PrayerTimesDto
+import net.thechance.mena.faith.domain.entity.PrayerName
+import net.thechance.mena.faith.domain.entity.PrayerTime
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+@OptIn(ExperimentalTime::class)
+fun getPrayerTimesFakeData(
+    sunriseTime: Instant = Instant.parse("2025-10-10T03:52:00Z"), //10-10-2025 06:52
+    fajrTime: Instant = Instant.parse("2025-10-10T02:25:00Z"), //10-10-2025 05:25
+    dhuhrTime: Instant = Instant.parse("2025-10-10T09:40:00Z"), //10-10-2025 12:40
+    asrTime: Instant = Instant.parse("2025-10-10T12:59:00Z"), //10-10-2025 15:59
+    maghribTime: Instant = Instant.parse("2025-10-10T15:27:00Z"), //10-10-2025 18:27
+    ishaTime: Instant = Instant.parse("2025-10-10T16:45:00Z"), //10-10-2025 19:45
+    hijriDate: String = fakePrayerTimesDto.date?.hijri?.readableDate.orEmpty()
+): List<PrayerTime> {
+    return listOf(
+        PrayerTime(
+            name = PrayerName.SUNRISE,
+            time = sunriseTime,
+            hijriDate = hijriDate
+        ),
+        PrayerTime(
+            name = PrayerName.FAJR,
+            time = fajrTime,
+            hijriDate = hijriDate
+        ),
+        PrayerTime(
+            name = PrayerName.DHUHR,
+            time = dhuhrTime,
+            hijriDate = hijriDate
+        ),
+        PrayerTime(
+            name = PrayerName.ASR,
+            time = asrTime,
+            hijriDate = hijriDate
+        ),
+        PrayerTime(
+            name = PrayerName.MAGHRIB,
+            time = maghribTime,
+            hijriDate = hijriDate
+        ),
+        PrayerTime(
+            name = PrayerName.ISHA,
+            time = ishaTime,
+            hijriDate = hijriDate
+        )
+    )
+}
+
+private val fakePrayerTimesDto = getFakePrayerTimesDto()
+
+fun getFakePrayerTimesDto(
+    sunrise: String? = "06:52",
+    fajr: String? = "05:25",
+    dhuhr: String? = "12:40",
+    asr: String? = "15:59",
+    maghrib: String? = "18:27",
+    isha: String? = "19:45",
+    hijriDate: String? = "18-04-1447",
+    hijriDateFormat: String? = "dd-MM-YYYY",
+    hijriReadableDate: String? = "18 Rabīʿ al-thānī 1447",
+    hijriDay: String? = "18",
+    hijriDayName: String? = "Al Juma'a",
+    hijriDayArabicName: String? = "الجمعة",
+    hijriMonth: Int? = 4,
+    hijriMonthName: String? = "Rabīʿ al-thānī",
+    hijriMonthArabicName: String? = "رَبيع الثاني",
+    hijriYear: String? = "1447",
+    gregorianDate: String? = "18-04-1447",
+    gregorianDateFormat: String? = "dd-MM-YYYY",
+    timestamp: String? = "1760068800",// 10-10-2025
+    gregorianReadableDate: String? = "18 Rabīʿ al-thānī 1447",
+    gregorianDay: String? = "18",
+    gregorianDayName: String? = "Al Juma'a",
+    gregorianMonth: Int? = 4,
+    gregorianMonthName: String? = "Rabīʿ al-thānī",
+    gregorianYear: String? = "1447"
+
+): PrayerTimesDto = PrayerTimesDto(
+    sunrise = sunrise,
+    fajr = fajr,
+    dhuhr = dhuhr,
+    asr = asr,
+    maghrib = maghrib,
+    isha = isha,
+    date = PrayerDateDto(
+        hijri = HijriDateDto(
+            date = hijriDate,
+            dateFormat = hijriDateFormat,
+            readableDate = hijriReadableDate,
+            day = hijriDay,
+            dayName = hijriDayName,
+            dayArabicName = hijriDayArabicName,
+            month = hijriMonth,
+            monthName = hijriMonthName,
+            monthArabicName = hijriMonthArabicName,
+            year = hijriYear
+        ),
+        gregorian = GregorianDateDto(
+            date = gregorianDate,
+            dateFormat = gregorianDateFormat,
+            timestamp = timestamp,
+            readableDate = gregorianReadableDate,
+            day = gregorianDay,
+            dayName = gregorianDayName,
+            month = gregorianMonth,
+            monthName = gregorianMonthName,
+            year = gregorianYear,
+        )
+    )
+)

--- a/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/repository/PrayerTimeRepository.kt
+++ b/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/repository/PrayerTimeRepository.kt
@@ -1,5 +1,6 @@
 package net.thechance.mena.faith.domain.repository
 
+import kotlinx.datetime.TimeZone
 import net.thechance.mena.faith.domain.entity.Location
 import net.thechance.mena.faith.domain.entity.PrayerTime
 import kotlin.time.ExperimentalTime
@@ -7,5 +8,9 @@ import kotlin.time.Instant
 
 @OptIn(ExperimentalTime::class)
 interface PrayerTimeRepository {
-    suspend fun getPrayerTimes(date: Instant, location: Location): List<PrayerTime>
+    suspend fun getPrayerTimes(
+        date: Instant,
+        location: Location,
+        timeZone: TimeZone = TimeZone.currentSystemDefault(),
+    ): List<PrayerTime>
 }

--- a/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/repository/PrayerTimeRepository.kt
+++ b/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/repository/PrayerTimeRepository.kt
@@ -4,8 +4,8 @@ import net.thechance.mena.faith.domain.entity.Location
 import net.thechance.mena.faith.domain.entity.PrayerTime
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
+
 @OptIn(ExperimentalTime::class)
 interface PrayerTimeRepository {
     suspend fun getPrayerTimes(date: Instant, location: Location): List<PrayerTime>
 }
-

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainViewModel.kt
@@ -35,7 +35,7 @@ class MainViewModel(
     private fun loadPrayerTimes() {
         tryToExecute(
             execute = {
-                val defaultLocation = Location(latitude = 30.0444, longitude = 31.2357)
+                val defaultLocation = Location(latitude = 30.186173, longitude = 31.158446)
                 prayerTimeRepository.getPrayerTimes(
                     date = Clock.System.now(),
                     location = defaultLocation

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/componant/PrayerTimesCard.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/componant/PrayerTimesCard.kt
@@ -3,6 +3,7 @@ package net.thechance.mena.faith.presentation.feature.main.componant
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -82,7 +84,8 @@ fun PrayerTimesCard(
                 .onGloballyPositioned { coordinates ->
                     rowWidth = coordinates.size.width.toFloat()
                 }
-                .padding(horizontal = Theme.spacing._16, vertical = Theme.spacing._12),
+                .padding(horizontal = Theme.spacing._16, vertical = Theme.spacing._12)
+                .horizontalScroll(rememberScrollState()),
             verticalAlignment = Alignment.Bottom,
             horizontalArrangement = Arrangement.SpaceEvenly
         ) {


### PR DESCRIPTION
This pull request implements the full integration for fetching and mapping daily prayer times from the remote API, replacing the previous hardcoded logic.

####  API Integration
- Added `PrayerTimeApiService` to fetch prayer times based on location and date.  
- Updated `faithDataModule` to provide the new API service and response converter.

####  Data & Mapping
- Added DTOs: `PrayerTimesDto`, `PrayerDateDto`, `GregorianDateDto`, and `HijriDateDto` for modeling API responses.  
- Implemented `StringHoursAndMinutesToInstantMapper` for safe time conversion and null handling.  
- Added `prayerTimesDtoMapper` to map DTOs to domain entities.
- Update `PrayerTimeRepositoryImpl` to use the new API-based logic instead of hardcoded data.

####  Testing
- Added unit tests for  `PrayerTimeRepositoryImpl`,  `StringHoursAndMinutesToInstantMapper`, and `prayerTimesDtoMapper`
