### PR TITLE
feat: Make PaymentResultScreenRoute serializable

### DIFF
--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/navigation/NavigationHost.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/navigation/NavigationHost.kt
@@ -120,11 +120,13 @@ fun NavigationHost(
                 receiverId = backStackEntry.toRoute<ConfirmPaymentScreenRoute>().id,
                 amount = backStackEntry.toRoute<ConfirmPaymentScreenRoute>().amount,
                 navigateToPaymentResultScreen = { receiverName, amount ->
-                    PaymentResultScreenRoute(
-                        transactionId = "",
-                        submitTransactionResultStatus = SubmitTransactionResultStatus.SUCCESS.name,
-                        amount = amount,
-                        receiverName = receiverName
+                    navController.navigate(
+                        PaymentResultScreenRoute(
+                            transactionId = "",
+                            submitTransactionResultStatus = SubmitTransactionResultStatus.SUCCESS.name,
+                            amount = amount,
+                            receiverName = receiverName
+                        )
                     )
                 }
             )
@@ -137,7 +139,9 @@ fun NavigationHost(
                 amount = backStackEntry.toRoute<PaymentResultScreenRoute>().amount,
                 onNavigateBackClicked = { navController.popBackStack() },
                 onNavigateToTransactionDetailsClicked = { receiverId ->
-                    TransactionDetailsScreenRoute(receiverId)
+                    navController.navigate(
+                        TransactionDetailsScreenRoute(receiverId)
+                    )
                 },
                 onCancelClicked = {
                     navController.popBackStack(

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/navigation/Routes.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/navigation/Routes.kt
@@ -53,6 +53,7 @@ data class ConfirmPaymentScreenRoute(
     }
 }
 
+@Serializable
 data class PaymentResultScreenRoute(
     val transactionId: String,
     val submitTransactionResultStatus: String,


### PR DESCRIPTION
Fix app crashes when opening the wallet