### PR TITLE
add needed permissions for chat feature

### DIFF
--- a/core_chat_presentation/src/androidMain/AndroidManifest.xml
+++ b/core_chat_presentation/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_CONTACTS"/>
+    <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
+    <uses-permission android:name="android.permission.CAMERA"/>
+
+</manifest>

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -10,5 +10,9 @@
     <string>$(CFBundleShortVersionString)</string>
     <key>NSContactsUsageDescription</key>
     <string>We need access to your contacts.</string>
+    <key>NSCameraUsageDescription</key>
+    <string>We need access to your camera.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>We need access to your photo library.</string>
 </dict>
 </plist>


### PR DESCRIPTION
# What have been done
Add needed permission to run chat feature on ios and android
- camera permission
- gallery permission

Note: also added contacts permission for android in our module to not depend on the composeApp manifest 