### PR TITLE
Feature/TRN-72-Implement like and view count functionality for reels

### DIFF
--- a/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/dto/ReelDto.kt
+++ b/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/dto/ReelDto.kt
@@ -24,5 +24,7 @@ internal data class ReelDto(
     @SerialName("username")
     val username: String = "The Chance",
     @SerialName("profilePictureUrl")
-    val profilePictureUrl: String? = null
+    val profilePictureUrl: String? = null,
+    @SerialName("isLiked")
+    val isLiked: Boolean? = null
 )

--- a/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/mapper/ReelMapper.kt
+++ b/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/mapper/ReelMapper.kt
@@ -1,6 +1,7 @@
 package net.thechance.mena.trends.data.mapper
 
 import net.thechance.mena.trends.data.dto.ReelDto
+import net.thechance.mena.trends.data.util.orFalse
 import net.thechance.mena.trends.data.util.orZero
 import net.thechance.mena.trends.data.util.parseDateStringOrNull
 import net.thechance.mena.trends.domain.entity.Reel
@@ -18,5 +19,6 @@ internal fun ReelDto.toEntity(): Reel {
         userName = username,
         profileImageUrl = profilePictureUrl.orEmpty(),
         isCurrentUserOwner = isCurrentUserOwner,
+        isLiked = isLiked.orFalse()
     )
 }

--- a/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/repository/ReelsRepositoryImpl.kt
+++ b/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/repository/ReelsRepositoryImpl.kt
@@ -22,6 +22,7 @@ import net.thechance.mena.trends.data.dto.UploadReelResponse
 import net.thechance.mena.trends.data.mapper.toEntity
 import net.thechance.mena.trends.data.util.NetworkConstants.FEED_ENDPOINT
 import net.thechance.mena.trends.data.util.NetworkConstants.JPEG_EXTENSION
+import net.thechance.mena.trends.data.util.NetworkConstants.LIKE_REEL_ENDPOINT
 import net.thechance.mena.trends.data.util.NetworkConstants.PAGE_PARAMETER
 import net.thechance.mena.trends.data.util.NetworkConstants.REELS_ENDPOINT
 import net.thechance.mena.trends.data.util.NetworkConstants.THUMBNAIL
@@ -30,6 +31,7 @@ import net.thechance.mena.trends.data.util.NetworkConstants.THUMBNAIL_MIME_TYPE
 import net.thechance.mena.trends.data.util.NetworkConstants.TRENDS_PATH
 import net.thechance.mena.trends.data.util.NetworkConstants.USER
 import net.thechance.mena.trends.data.util.NetworkConstants.VIDEO
+import net.thechance.mena.trends.data.util.NetworkConstants.VIEW_REEL_ENDPOINT
 import net.thechance.mena.trends.data.util.VideoFileHandler
 import net.thechance.mena.trends.data.util.getMediaMimeType
 import net.thechance.mena.trends.data.util.observeUploading
@@ -159,6 +161,18 @@ internal class ReelsRepositoryImpl(
 
     override suspend fun getReelThumbnail(filePath: String, timeMs: Long): ByteArray? {
         return videoFileHandler.extractVideoFrame(filePath, timeMs)
+    }
+
+    override suspend fun toggleReelLike(reelId: String): Reel {
+        return safeApiCall<ReelDto> {
+            networkClient.post(urlString = "${LIKE_REEL_ENDPOINT}/$reelId")
+        }.toEntity()
+    }
+
+    override suspend fun addReelView(reelId: String) {
+        safeApiCall<Unit> {
+            networkClient.post(urlString = "${VIEW_REEL_ENDPOINT}/$reelId")
+        }
     }
 
     private fun createRequestBody(

--- a/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/util/NetworkConstants.kt
+++ b/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/util/NetworkConstants.kt
@@ -7,6 +7,8 @@ internal object NetworkConstants {
     const val REELS_ENDPOINT = "reels"
     const val USER_STATUS_ENDPOINT = "user/categories/status"
     const val THUMBNAIL_ENDPOINT = "$TRENDS_PATH/$REELS_ENDPOINT/thumbnail"
+    const val LIKE_REEL_ENDPOINT = "trends/reels/like"
+    const val VIEW_REEL_ENDPOINT = "trends/reels/view"
     const val FEED_ENDPOINT = "feed"
 
     const val IDENTITY_PATH = "identity"

--- a/trends_data/src/commonTest/kotlin/net/thechance/mena/trends/data/repository/ReelRepositoryImplTest.kt
+++ b/trends_data/src/commonTest/kotlin/net/thechance/mena/trends/data/repository/ReelRepositoryImplTest.kt
@@ -9,14 +9,15 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.test.runTest
 import net.thechance.mena.trends.data.client.NetworkClient
 import net.thechance.mena.trends.data.repository.util.VideoFileHandlerMock
+import net.thechance.mena.trends.data.repository.util.addViewReelResponse
 import net.thechance.mena.trends.data.repository.util.createReelsHttpClient
 import net.thechance.mena.trends.data.repository.util.deleteReelResponse
 import net.thechance.mena.trends.data.repository.util.fakeReelList
 import net.thechance.mena.trends.data.repository.util.getReelsResponse
+import net.thechance.mena.trends.data.repository.util.toggleLikeReelResponse
 import net.thechance.mena.trends.data.repository.util.updateReelResponse
 import net.thechance.mena.trends.data.repository.util.uploadReelResponse
 import net.thechance.mena.trends.data.repository.util.uploadReelThumbnailResponse
-import net.thechance.mena.trends.domain.repository.ReelsRepository
 import kotlin.test.Test
 import kotlin.test.assertFails
 
@@ -170,11 +171,41 @@ internal class ReelRepositoryImplTest {
         assertThat(result.isFailure).isEqualTo(true)
         assertThat(result.exceptionOrNull()?.message).isEqualTo("Network Error")
     }
+
+    @Test
+    fun `should toggle like when toggleLike called successfully`() = runTest {
+        networkClient = createReelsHttpClient {
+            toggleLikeReelResponse()
+        }
+        repository = ReelsRepositoryImpl(networkClient, videoHandler)
+
+        val result = repository.toggleReelLike(REEL_ID)
+
+        assertThat(result).isEqualTo(fakeReelList.first())
+    }
+
+    @Test
+    fun `should add view when addView called successfully`() = runTest {
+        networkClient = createReelsHttpClient {
+            addViewReelResponse()
+        }
+
+        repository = ReelsRepositoryImpl(networkClient, videoHandler)
+
+        val result = runCatching {
+            repository.addReelView(REEL_ID)
+        }
+
+        assertThat(result).isSuccess()
+
+    }
+
     private companion object {
         const val FAKE_SIZE = 1000L
         val FAKE_BYTES = ByteArray(FAKE_SIZE.toInt()) { 1 }
         const val FAKE_FILE_PATH = "path/to/file"
         const val FAKE_FILE_NAME = "fileName"
         const val FAKE_DURATION = 1000L
+        const val REEL_ID = "12345"
     }
 }

--- a/trends_data/src/commonTest/kotlin/net/thechance/mena/trends/data/repository/util/mockReelResponse.kt
+++ b/trends_data/src/commonTest/kotlin/net/thechance/mena/trends/data/repository/util/mockReelResponse.kt
@@ -19,6 +19,7 @@ internal val fakeReelDtoList = RemotePaginationResponse(
             createdAt = "2025-09-16T15:06:57.507394",
             likesCount = 120,
             viewsCount = 1500,
+            isLiked = true
         )
     ),
     totalResults = 1
@@ -57,6 +58,24 @@ internal fun MockRequestHandleScope.uploadReelThumbnailResponse(
     headers = jsonHeaders
 )
 
+internal fun MockRequestHandleScope.toggleLikeReelResponse(
+    status: HttpStatusCode = HttpStatusCode.OK
+) = respond(
+    content = jsonSerialization.encodeToString(
+        ReelDto.serializer(),
+        fakeReelDtoList.results?.first() ?: ReelDto()
+    ),
+    status = status,
+    headers = jsonHeaders
+)
+
+internal fun MockRequestHandleScope.addViewReelResponse(
+) = respond(
+    content = "",
+    status = HttpStatusCode.OK,
+    headers = jsonHeaders
+)
+
 internal fun MockRequestHandleScope.updateReelResponse(
     id: String,
     description: String,
@@ -71,7 +90,10 @@ internal fun MockRequestHandleScope.updateReelResponse(
 internal fun MockRequestHandleScope.uploadReelResponse(
     status: HttpStatusCode = HttpStatusCode.OK
 ) = respond(
-    content = jsonSerialization.encodeToString(UploadReelResponse.serializer(), UploadReelResponse("1")),
+    content = jsonSerialization.encodeToString(
+        UploadReelResponse.serializer(),
+        UploadReelResponse("1")
+    ),
     status = status,
     headers = jsonHeaders
 )

--- a/trends_domain/src/commonMain/kotlin/net/thechance/mena/trends/domain/entity/Reel.kt
+++ b/trends_domain/src/commonMain/kotlin/net/thechance/mena/trends/domain/entity/Reel.kt
@@ -13,4 +13,5 @@ data class Reel(
     val userName: String,
     val profileImageUrl: String,
     val isCurrentUserOwner: Boolean,
+    val isLiked: Boolean
 )

--- a/trends_domain/src/commonMain/kotlin/net/thechance/mena/trends/domain/repository/ReelsRepository.kt
+++ b/trends_domain/src/commonMain/kotlin/net/thechance/mena/trends/domain/repository/ReelsRepository.kt
@@ -13,4 +13,6 @@ interface ReelsRepository {
     suspend fun uploadReelThumbnail(reelId: String, fileName: String, thumbnail: ByteArray)
     suspend fun getReelDuration(filePath: String): Long?
     suspend fun getReelThumbnail(filePath: String, timeMs: Long = 0L): ByteArray?
+    suspend fun toggleReelLike(reelId: String): Reel
+    suspend fun addReelView(reelId: String)
 }

--- a/trends_presentation/src/androidMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.android.kt
+++ b/trends_presentation/src/androidMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.android.kt
@@ -57,6 +57,7 @@ actual fun VideoPlayer(
     url: String,
     isReelVisible: Boolean,
     modifier: Modifier,
+    onVideoPlaying: () -> Unit,
     content: @Composable () -> Unit
 ) {
     val context = LocalContext.current
@@ -111,6 +112,8 @@ actual fun VideoPlayer(
             lastPosition = exoPlayer.currentPosition
             exoPlayer.pause()
         }
+
+        onVideoPlaying()
     }
 
     LaunchedEffect(exoPlayer.isPlaying) {

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/show_real/ReelHomeScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/show_real/ReelHomeScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -62,6 +63,8 @@ internal fun ReelHomeScreen(
         }
     }
 
+    LaunchedEffect(Unit) { viewModel.getFeedReels() }
+
     ReelScreenContent(
         state = state,
         listener = viewModel,
@@ -99,6 +102,7 @@ private fun ReelScreenContent(
                     }
                 }
             }
+
             Icon(
                 painter = painterResource(Res.drawable.ic_add_real),
                 contentDescription = stringResource(Res.string.add_reel),

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/show_real/ReelScreenState.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/show_real/ReelScreenState.kt
@@ -2,6 +2,7 @@ package net.thechance.mena.trends.presentation.screen.show_real
 
 import androidx.paging.PagingData
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import net.thechance.mena.trends.presentation.shared.base.ErrorState
 import net.thechance.mena.trends.presentation.shared.util.TimeAgoValue
@@ -12,6 +13,7 @@ data class ReelScreenState(
     val isLoading: Boolean = true,
     val error: ErrorState? = null,
     val reels: Flow<PagingData<ReelUiState>> = flowOf(),
+    val reelsStateFlow: MutableStateFlow<PagingData<ReelUiState>> = MutableStateFlow(PagingData.empty()),
     val errorMessage: StringResource? = null,
 )
 
@@ -24,5 +26,6 @@ data class ReelUiState(
     val videoUrl: String = "",
     val description: String = "",
     val likes: Int = 0,
-    val views: Int = 0
+    val views: Int = 0,
+    val isLiked: Boolean = false
 )

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/show_real/ReelViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/show_real/ReelViewModel.kt
@@ -8,8 +8,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
-import net.thechance.mena.trends.domain.entity.Reel
 import net.thechance.mena.trends.domain.repository.ReelsRepository
 import net.thechance.mena.trends.presentation.shared.base.BaseViewModel
 import net.thechance.mena.trends.presentation.shared.base.createPager
@@ -27,27 +25,64 @@ internal class ReelViewModel(
         getFeedReels()
     }
 
-    private fun getFeedReels() {
+    fun toggleReelLike(reelId: String) {
         tryToExecute(
-            block = {
-                createPager(
-                    scope = viewModelScope,
-                    loadPage = { page -> repository.getFeedReels(page) }
-                )
+            onStart = { updateLikesOnUi(reelId) },
+            block = { repository.toggleReelLike(reelId) },
+            onError = { error ->
+                updateReelInPagingData(reelId) { reel ->
+                    reel.copy(
+                        isLiked = !reel.isLiked,
+                        likes = if (reel.isLiked) reel.likes - 1 else reel.likes + 1
+                    )
+                }
+                updateState { copy(error = error) }
             },
-            onSuccess = ::onReelLoaded,
-            onError = { error -> updateState { copy(error = error) } },
+            dispatcher = ioDispatcher,
+            scope = viewModelScope,
+            onSuccess = { updatedReel ->
+                updateReelInPagingData(reelId) { updatedReel.toUiState() }
+            }
+        )
+    }
+
+    private fun updateLikesOnUi(reelId: String) {
+        updateReelInPagingData(reelId) { reel ->
+            reel.copy(
+                isLiked = !reel.isLiked,
+                likes = if (reel.isLiked) reel.likes - 1 else reel.likes + 1
+            )
+        }
+    }
+
+    private fun updateReelInPagingData(reelId: String, transform: (ReelUiState) -> ReelUiState) {
+        val currentData = state.value.reelsStateFlow.value
+        val updatedData = currentData.map { reel ->
+            if (reel.id == reelId) transform(reel) else reel
+        }
+        state.value.reelsStateFlow.value = updatedData
+        updateState { copy(reels = state.value.reelsStateFlow) }
+    }
+
+    fun getFeedReels() {
+        tryToCollectFlow(
+            block = ::createPager,
             onStart = { updateState { copy(isLoading = true) } },
+            onNewValue = { uiPagingData ->
+                state.value.reelsStateFlow.value = uiPagingData
+                updateState { copy(reels = reelsStateFlow, isLoading = false) }
+            },
+            onError = { error -> updateState { copy(error = error, isLoading = false) } },
             onEnd = { updateState { copy(isLoading = false) } },
             dispatcher = ioDispatcher
         )
     }
 
-    private fun onReelLoaded(reelsFlow: Flow<PagingData<Reel>>) {
-        val uiReelsFlow = reelsFlow.map { pagingData: PagingData<Reel> ->
-            pagingData.map { reel -> reel.toUiState() }
-        }
-        updateState { copy(isLoading = false, reels = uiReelsFlow) }
+    private fun createPager(): Flow<PagingData<ReelUiState>> {
+        return createPager(
+            scope = viewModelScope,
+            loadPage = { page -> repository.getFeedReels(page) }
+        ).map { pagingData -> pagingData.map { it.toUiState() } }
     }
 
     override fun onAddReelClick() {
@@ -63,18 +98,10 @@ internal class ReelViewModel(
     }
 
     override fun onReelClick(reelId: String) {
-            sendEffect(ReelUiEffect.NavigateToReelDetails(reelId))
+        sendEffect(ReelUiEffect.NavigateToReelDetails(reelId))
     }
 
     override fun onLikeClick(reelId: String) {
-        state.value.reels?.let { reelsFlow ->
-            val updatedFlow = reelsFlow.map { pagingData ->
-                pagingData.map { uiState ->
-                    if (uiState.id == reelId) uiState.copy(likes = uiState.likes + 1) else uiState
-                }
-            }
-            updateState { copy(reels = updatedFlow) }
-        }
-        //TODO will handle it with like Api
+        toggleReelLike(reelId)
     }
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/show_real/component/ReelCard.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/show_real/component/ReelCard.kt
@@ -19,13 +19,11 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import mena.trends_presentation.generated.resources.Res
-import mena.trends_presentation.generated.resources.ic_dots
 import mena.trends_presentation.generated.resources.ic_eye
 import mena.trends_presentation.generated.resources.ic_heart
 import mena.trends_presentation.generated.resources.just_now
 import mena.trends_presentation.generated.resources.likes
 import mena.trends_presentation.generated.resources.likes_suffix
-import mena.trends_presentation.generated.resources.more_options
 import mena.trends_presentation.generated.resources.profile_image
 import mena.trends_presentation.generated.resources.video_thumbnail
 import mena.trends_presentation.generated.resources.views
@@ -79,7 +77,7 @@ private fun ReelHeaderSection(
             verticalAlignment = Alignment.CenterVertically
         ) {
             AsyncImage(
-                model =  reel.profileImageUrl,
+                model = reel.profileImageUrl,
                 contentDescription = stringResource(Res.string.profile_image),
                 modifier = Modifier
                     .size(40.dp)
@@ -107,7 +105,7 @@ private fun ReelHeaderSection(
         }
 
         AsyncImage(
-            model =  reel.thumbnailUrl,
+            model = reel.thumbnailUrl,
             contentDescription = stringResource(Res.string.video_thumbnail),
             contentScale = ContentScale.Crop,
             modifier = Modifier
@@ -151,7 +149,7 @@ private fun ReelFooterSection(
             Icon(
                 painter = painterResource(Res.drawable.ic_heart),
                 contentDescription = stringResource(Res.string.likes),
-                tint = Theme.colorScheme.shadeTertiary,
+                tint = if (reel.isLiked) Theme.colorScheme.error else Theme.colorScheme.shadeTertiary,
                 modifier = Modifier
                     .size(24.dp)
                     .noRippleClickable { onLikeClick() }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/show_real/mapper.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/show_real/mapper.kt
@@ -13,6 +13,7 @@ fun Reel.toUiState(): ReelUiState {
         videoUrl = videoUrl,
         description = description,
         likes = likesCount,
-        views = viewsCount
+        views = viewsCount,
+        isLiked = isLiked
     )
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelInteractionListener.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelInteractionListener.kt
@@ -9,4 +9,6 @@ internal interface UserReelInteractionListener {
     fun onDismissErrorDialog()
     fun onDescriptionClick(isCollapsed: Boolean)
     fun onPublisherInfoClick()
+    fun increaseReelView(reelId: String)
+    fun onLikeClick(reelId: String)
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelMapper.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelMapper.kt
@@ -8,10 +8,11 @@ internal fun Reel.toUserReelUiState() =
         id = id,
         videoUrl = videoUrl,
         description = description,
-        likesCount = likesCount,
+        likes = likesCount,
         viewsCount = viewsCount,
         createdAt = createdAt?.timeAgoValue(),
         isCurrentUserOwner = isCurrentUserOwner,
         username = userName,
-        profileImageUrl = profileImageUrl
+        profileImageUrl = profileImageUrl,
+        isLiked = isLiked
     )

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
@@ -168,7 +168,9 @@ private fun UserReelScreenContent(
                     isDescriptionExpanded = state.isDescriptionExpanded,
                     onDeleteClick = listener::onDeleteClick,
                     onDescriptionClick = listener::onDescriptionClick,
-                    onPublisherInfoClick = listener::onPublisherInfoClick
+                    onPublisherInfoClick = listener::onPublisherInfoClick,
+                    incrementViewsCount = { listener.increaseReelView(reel.id) },
+                    onLikeClick = { listener.onLikeClick(reel.id) }
                 )
             }
         }
@@ -206,18 +208,23 @@ private fun ReelContent(
     onDeleteClick: () -> Unit,
     onDescriptionClick: (isCollapsed: Boolean) -> Unit,
     onPublisherInfoClick: () -> Unit,
+    incrementViewsCount: () -> Unit,
+    onLikeClick: () -> Unit,
 ) {
     VideoPlayer(
         modifier = Modifier.background(Color.Black),
         url = reel.videoUrl,
         isReelVisible = shouldRender,
+        onVideoPlaying = incrementViewsCount
     ) {
         Box(Modifier.fillMaxSize()) {
             UsersReAct(
                 viewCount = reel.viewsCount.toString(),
-                likeCount = reel.likesCount.toString(),
+                likeCount = reel.likes.toString(),
                 isCurrentUserOwner = reel.isCurrentUserOwner,
                 onDeleteClick = onDeleteClick,
+                onLikeClick = onLikeClick,
+                isLiked = reel.isLiked,
                 modifier = Modifier.align(Alignment.BottomEnd)
                     .padding(end = Theme.spacing._16, bottom = 140.dp)
             )
@@ -305,7 +312,9 @@ private fun UsersReAct(
     likeCount: String,
     viewCount: String,
     isCurrentUserOwner: Boolean,
+    isLiked: Boolean,
     onDeleteClick: () -> Unit,
+    onLikeClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -314,11 +323,14 @@ private fun UsersReAct(
     ) {
         ReActIcon(
             icon = painterResource(resource = Res.drawable.ic_like),
+            onClick = onLikeClick,
+            tint = if (isLiked) Color.White else Theme.colorScheme.shadeTertiary,
             label = likeCount
         )
 
         ReActIcon(
             icon = painterResource(resource = Res.drawable.ic_eye),
+            isClickEnabled = false,
             label = viewCount
         )
 
@@ -337,6 +349,8 @@ private fun ReActIcon(
     icon: Painter,
     label: String,
     modifier: Modifier = Modifier,
+    isClickEnabled: Boolean = true,
+    tint: Color = Theme.colorScheme.shadeTertiary,
     onClick: () -> Unit = {}
 ) {
     Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
@@ -345,8 +359,8 @@ private fun ReActIcon(
             contentDescription = stringResource(Res.string.react),
             modifier = Modifier
                 .padding(bottom = Theme.spacing._8)
-                .clickable { onClick() },
-            tint = Theme.colorScheme.shadeTertiary
+                .clickable(enabled = isClickEnabled) { onClick() },
+            tint = tint
         )
         Text(
             text = label,

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelState.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelState.kt
@@ -2,6 +2,7 @@ package net.thechance.mena.trends.presentation.screen.user_reel
 
 import androidx.paging.PagingData
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import net.thechance.mena.trends.presentation.shared.base.ErrorState
 import net.thechance.mena.trends.presentation.shared.util.TimeAgoValue
@@ -13,16 +14,18 @@ internal data class UserReelState(
     val isConfirmationDialogVisible: Boolean = false,
     val isReelDeleted: Boolean? = null,
     val isDescriptionExpanded: Boolean = false,
+    val reelsStateFlow: MutableStateFlow<PagingData<UserReelUiState>> = MutableStateFlow(PagingData.empty())
 )
 
 internal data class UserReelUiState(
-    val id : String = "",
-    val videoUrl: String= "",
+    val id: String = "",
+    val videoUrl: String = "",
     val description: String = "",
-    val likesCount: Int = 0,
+    val likes: Int = 0,
     val viewsCount: Int = 0,
-    val username : String = "",
+    val username: String = "",
     val profileImageUrl: String = "",
     val createdAt: TimeAgoValue? = null,
-    val isCurrentUserOwner: Boolean = false
+    val isCurrentUserOwner: Boolean = false,
+    val isLiked: Boolean = false
 )

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModel.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import net.thechance.mena.trends.domain.entity.Reel
 import net.thechance.mena.trends.domain.repository.ReelsRepository
 import net.thechance.mena.trends.presentation.screen.user_reel.args.UserReelArgs
 import net.thechance.mena.trends.presentation.shared.base.BaseViewModel
@@ -28,26 +27,24 @@ internal class UserReelViewModel(
     }
 
     private fun getFeedReals() {
-        tryToExecute(
-            block = {
-                createPager(
-                    scope = viewModelScope,
-                    loadPage = { page -> reelsRepository.getFeedReels(page, userReelArgs.realId) }
-                )
-            },
-            onSuccess = ::onGetReelsSuccess,
+        tryToCollectFlow(
+            block = ::createPager,
             onStart = { updateState { copy(isLoading = true) } },
+            onNewValue = { uiPagingData ->
+                state.value.reelsStateFlow.value = uiPagingData
+                updateState { copy(reels = reelsStateFlow, isLoading = false) }
+            },
+            onError = { error -> updateState { copy(error = error, isLoading = false) } },
             onEnd = { updateState { copy(isLoading = false) } },
-            dispatcher = ioDispatcher,
-            onError = { error -> updateState { copy(error = error) } }
+            dispatcher = ioDispatcher
         )
     }
 
-    private fun onGetReelsSuccess(reelsFlow: Flow<PagingData<Reel>>) {
-        val uiReelsFlow = reelsFlow.map { pagingData: PagingData<Reel> ->
-            pagingData.map { reel -> reel.toUserReelUiState() }
-        }
-        updateState { copy(reels = uiReelsFlow) }
+    private fun createPager(): Flow<PagingData<UserReelUiState>> {
+        return createPager(
+            scope = viewModelScope,
+            loadPage = { page -> reelsRepository.getFeedReels(page) }
+        ).map { pagingData -> pagingData.map { it.toUserReelUiState() } }
     }
 
     override fun onDescriptionClick(isCollapsed: Boolean) {
@@ -58,6 +55,60 @@ internal class UserReelViewModel(
 
     override fun onPublisherInfoClick() {
         sendEffect(UserReelEffect.NavigateToPublisherProfile)
+    }
+
+    override fun increaseReelView(reelId: String) {
+        tryToExecute(
+            block = { reelsRepository.addReelView(reelId) },
+            onError = { error -> updateState { copy(error = error) } },
+            dispatcher = ioDispatcher,
+        )
+    }
+
+    override fun onLikeClick(reelId: String) {
+        tryToExecute(
+            onStart = { updateLikesOnUi(reelId) },
+            block = { reelsRepository.toggleReelLike(reelId) },
+            onError = { error ->
+                onLikeClickFailed(reelId)
+                updateState { copy(error = error) }
+            },
+            dispatcher = ioDispatcher,
+            scope = viewModelScope,
+            onSuccess = { updatedReel ->
+                updateReelInPagingData(reelId) { updatedReel.toUserReelUiState() }
+            }
+        )
+    }
+
+    private fun onLikeClickFailed(reelId: String) {
+        updateReelInPagingData(reelId) { reel ->
+            reel.copy(
+                isLiked = !reel.isLiked,
+                likes = if (reel.isLiked) reel.likes - 1 else reel.likes + 1
+            )
+        }
+    }
+
+    private fun updateReelInPagingData(
+        reelId: String,
+        transform: (UserReelUiState) -> UserReelUiState
+    ) {
+        val currentData = state.value.reelsStateFlow.value
+        val updatedData = currentData.map { reel ->
+            if (reel.id == reelId) transform(reel) else reel
+        }
+        state.value.reelsStateFlow.value = updatedData
+        updateState { copy(reels = reelsStateFlow) }
+    }
+
+    private fun updateLikesOnUi(reelId: String) {
+        updateReelInPagingData(reelId) { reel ->
+            reel.copy(
+                isLiked = !reel.isLiked,
+                likes = if (reel.isLiked) reel.likes - 1 else reel.likes + 1
+            )
+        }
     }
 
     override fun onBackClick() {

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/base/BaseViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/base/BaseViewModel.kt
@@ -52,8 +52,8 @@ internal abstract class BaseViewModel<State, Effect>(
 
     protected fun <R> tryToExecute(
         block: suspend () -> R,
-        onSuccess: (R) -> Unit,
-        onError: (ErrorState) -> Unit,
+        onSuccess: (R) -> Unit = {},
+        onError: (ErrorState) -> Unit = {},
         onStart: () -> Unit = {},
         onEnd: () -> Unit = {},
         dispatcher: CoroutineDispatcher = Dispatchers.IO,

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.kt
@@ -8,5 +8,6 @@ expect fun VideoPlayer(
     url: String,
     isReelVisible: Boolean,
     modifier: Modifier,
+    onVideoPlaying: () -> Unit,
     content: @Composable () -> Unit
 )

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/manage_my_trends/ManageTrendsViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/manage_my_trends/ManageTrendsViewModelTest.kt
@@ -106,7 +106,8 @@ class ManageTrendsViewModelTest {
             createdAt = LocalDateTime(2002, 2, 22, 2, 22),
             userName = "mTm",
             profileImageUrl = "",
-            isCurrentUserOwner = true
+            isCurrentUserOwner = true,
+            isLiked = false
         )
 
         val reels = listOf(

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/show_real/MapperTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/show_real/MapperTest.kt
@@ -58,6 +58,7 @@ class ReelExtensionTest {
             userName = "Alice",
             profileImageUrl = "https://example.com/alice.jpg",
             isCurrentUserOwner = false,
+            isLiked = false
         )
 
         val testReel2 = Reel(
@@ -71,6 +72,7 @@ class ReelExtensionTest {
             userName = "Bob",
             profileImageUrl = "https://example.com/bob.jpg",
             isCurrentUserOwner = true,
+            isLiked = false
         )
 
         val testReel3 = Reel(
@@ -84,6 +86,7 @@ class ReelExtensionTest {
             userName = "Charlie",
             profileImageUrl = "https://example.com/charlie.jpg",
             isCurrentUserOwner = false,
+            isLiked = false
         )
 
         val testReel4 = Reel(
@@ -97,6 +100,7 @@ class ReelExtensionTest {
             userName = "",
             profileImageUrl = "",
             isCurrentUserOwner = false,
+            isLiked = false
         )
 
 

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/show_real/ReelViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/show_real/ReelViewModelTest.kt
@@ -4,8 +4,10 @@ import androidx.paging.testing.asSnapshot
 import app.cash.turbine.test
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import kotlinx.coroutines.Dispatchers
@@ -25,20 +27,6 @@ class ReelViewModelTest {
     private val repository: ReelsRepository = mock(MockMode.autofill)
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var viewModel: ReelViewModel
-
-    private val testReel = Reel(
-        id = "1",
-        thumbnailUrl = "thumb.jpg",
-        videoUrl = "video.mp4",
-        description = "description",
-        likesCount = 5,
-        viewsCount = 50,
-        createdAt = null,
-        userName = "Test User",
-        profileImageUrl = "https://example.com/profile.jpg",
-        isCurrentUserOwner = false,
-    )
-
 
     @BeforeTest
     fun setup() {
@@ -94,11 +82,63 @@ class ReelViewModelTest {
     @Test
     fun `onLikeClick should increment likes count`() = runTest {
         everySuspend { repository.getFeedReels(1) } returns listOf(testReel)
+        everySuspend { repository.toggleReelLike("1") } returns testReel.copy(
+            isLiked = true,
+            likesCount = testReel.likesCount + 1
+        )
+
         viewModel = ReelViewModel(repository, testDispatcher)
         advanceUntilIdle()
-        val initial = viewModel.state.value.reels?.asSnapshot()?.first()
+
+        val initial = viewModel.state.value.reels.asSnapshot().first()
+
+        viewModel.state.test {
+
+            viewModel.onLikeClick("1")
+            advanceUntilIdle()
+
+            val state = awaitItem()
+            val updated = state.reels.asSnapshot().first()
+
+            assertThat(updated.likes).isEqualTo(initial.likes + 1)
+            assertThat(updated.isLiked).isTrue()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onLikeClick should revert optimistic update when toggleReelLike fails`() = runTest {
+        everySuspend { repository.getFeedReels(1) } returns listOf(testReel)
+        everySuspend { repository.toggleReelLike("1") } throws Exception("Network error")
+
+        advanceUntilIdle()
+        val initial = viewModel.state.value.reels.asSnapshot().first()
+
         viewModel.onLikeClick("1")
-        val updated = viewModel.state.value.reels?.asSnapshot()?.first()
-        assertThat(updated?.likes).isEqualTo(initial!!.likes + 1)
+        advanceUntilIdle()
+
+        val reverted = viewModel.state.value.reels.asSnapshot().first()
+
+        assertThat(reverted.likes).isEqualTo(initial.likes)
+        assertThat(reverted.isLiked).isEqualTo(initial.isLiked)
+
+        assertThat(viewModel.state.value.error != null).isTrue()
+    }
+
+    companion object {
+        private val testReel = Reel(
+            id = "1",
+            thumbnailUrl = "thumb.jpg",
+            videoUrl = "video.mp4",
+            description = "description",
+            likesCount = 5,
+            viewsCount = 50,
+            createdAt = null,
+            userName = "Test User",
+            profileImageUrl = "https://example.com/profile.jpg",
+            isCurrentUserOwner = false,
+            isLiked = false
+        )
     }
 }

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModelTest.kt
@@ -9,10 +9,12 @@ import dev.mokkery.answering.returns
 import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -53,6 +55,7 @@ class UserReelViewModelTest {
     @Test
     fun `should initialize UserReelUiState with default state`() = runTest {
         viewModel.state.test {
+            skipItems(1)
             val initialState = awaitItem()
 
             assertFalse(initialState.isLoading)
@@ -67,11 +70,13 @@ class UserReelViewModelTest {
     @Test
     fun `viewmodel should update state by reels when getFeedReels return data`() =
         runTest(testDispatcher) {
-            everySuspend { mockReelsRepository.getFeedReels(1, "2") } returns feedReels
+            everySuspend { mockReelsRepository.getFeedReels(any()) } returns feedReels
+
+            advanceUntilIdle()
 
             viewModel.state.test {
                 val state = awaitItem()
-                val reelsSnapshot: List<UserReelUiState> = state.reels.asSnapshot()
+                val reelsSnapshot = state.reels.asSnapshot()
                 assertThat(reelsSnapshot).isEqualTo(expectedReelUiStateList)
                 cancelAndIgnoreRemainingEvents()
             }
@@ -200,6 +205,157 @@ class UserReelViewModelTest {
             }
         }
 
+    @Test
+    fun `onPublisherInfoClick should send NavigateToPublisherProfile effect when called`() =
+        runTest {
+            viewModel.onPublisherInfoClick()
+
+            viewModel.effect.test {
+                val effect = awaitItem()
+                assertTrue(effect is UserReelEffect.NavigateToPublisherProfile)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `increaseReelView should update error state when repository throws exception`() = runTest {
+        val reelId = "1"
+        everySuspend { mockReelsRepository.addReelView(reelId) } throws Exception("View failed")
+
+        viewModel.increaseReelView(reelId)
+        advanceUntilIdle()
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNotNull(state.error)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onLikeClick should optimistically update likes count and isLiked state`() = runTest {
+        everySuspend { mockReelsRepository.getFeedReels(any()) } returns feedReels
+        everySuspend { mockReelsRepository.toggleReelLike("2") } returns reel2.copy(
+            isLiked = true,
+            likesCount = 51
+        )
+
+        advanceUntilIdle()
+
+        viewModel.onLikeClick("2")
+        advanceUntilIdle()
+
+        viewModel.state.test {
+            val updatedState = awaitItem()
+            val updatedReel = updatedState.reels.asSnapshot().first()
+
+            assertThat(updatedReel.likes).isEqualTo(reel2.likesCount + 1)
+            assertThat(updatedReel.isLiked).isEqualTo(!reel2.isLiked)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onLikeClick should update reel with server response on success`() = runTest {
+        everySuspend { mockReelsRepository.getFeedReels(any()) } returns feedReels
+        val updatedReel = reel2.copy(isLiked = true, likesCount = 51)
+        everySuspend { mockReelsRepository.toggleReelLike("2") } returns updatedReel
+
+        advanceUntilIdle()
+
+        viewModel.onLikeClick("2")
+        advanceUntilIdle()
+
+        viewModel.state.test {
+            val state = awaitItem()
+            val reel = state.reels.asSnapshot().first()
+
+            assertThat(reel.likes).isEqualTo(51)
+            assertThat(reel.isLiked).isEqualTo(true)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onLikeClick should revert optimistic update when repository throws exception`() = runTest {
+        everySuspend { mockReelsRepository.getFeedReels(any()) } returns feedReels
+        everySuspend { mockReelsRepository.toggleReelLike("2") } throws Exception("Like failed")
+
+        advanceUntilIdle()
+
+        viewModel.state.test {
+            val state = awaitItem()
+            val initialReel = state.reels.asSnapshot().first()
+
+            viewModel.onLikeClick("2")
+
+            advanceUntilIdle()
+
+            val errorState = awaitItem()
+            val revertedReel = errorState.reels.asSnapshot().first()
+
+            assertThat(revertedReel.likes).isEqualTo(initialReel.likes)
+            assertThat(revertedReel.isLiked).isEqualTo(initialReel.isLiked)
+            assertNotNull(errorState.error)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onLikeClick should decrement likes when reel is already liked`() = runTest {
+        val likedReel = reel2.copy(isLiked = true, likesCount = 51)
+        everySuspend { mockReelsRepository.getFeedReels(any()) } returns listOf(likedReel)
+        everySuspend { mockReelsRepository.toggleReelLike("2") } returns likedReel.copy(
+            isLiked = false,
+            likesCount = 50
+        )
+
+        advanceUntilIdle()
+        val initialReel = viewModel.state.value.reels.asSnapshot().first()
+
+        viewModel.onLikeClick("2")
+        advanceUntilIdle()
+
+        val updatedReel = viewModel.state.value.reels.asSnapshot().first()
+
+        assertThat(updatedReel.likes).isEqualTo(initialReel.likes - 1)
+        assertThat(updatedReel.isLiked).isEqualTo(false)
+    }
+
+    @Test
+    fun `updateReelInPagingData should only update the specific reel by id`() = runTest {
+        everySuspend { mockReelsRepository.getFeedReels(any()) } returns feedReels
+        everySuspend { mockReelsRepository.toggleReelLike("2") } returns reel2.copy(
+            isLiked = true,
+            likesCount = 51
+        )
+
+        advanceUntilIdle()
+        viewModel.onLikeClick("2")
+        advanceUntilIdle()
+
+        viewModel.state.test {
+            val state = awaitItem()
+            val reelsSnapshot = state.reels.asSnapshot().first()
+
+            assertThat(reelsSnapshot.likes).isEqualTo(51)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onDismissErrorDialog should clear error and dismiss dialogs when called`() = runTest {
+        viewModel.onDismissErrorDialog()
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertNull(state.error)
+            assertNull(state.isReelDeleted)
+            assertFalse(state.isConfirmationDialogVisible)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     @AfterTest
     fun tearDown() {
         Dispatchers.resetMain()
@@ -217,7 +373,8 @@ class UserReelViewModelTest {
             createdAt = LocalDateTime(2002, 2, 22, 2, 22),
             userName = "Nour",
             profileImageUrl = "",
-            isCurrentUserOwner = true
+            isCurrentUserOwner = true,
+            isLiked = false
         )
 
         val reel2 = Reel(
@@ -230,7 +387,8 @@ class UserReelViewModelTest {
             createdAt = LocalDateTime(2002, 2, 22, 2, 22),
             userName = "hend",
             profileImageUrl = "",
-            isCurrentUserOwner = false
+            isCurrentUserOwner = false,
+            isLiked = false
         )
 
         val feedReels = listOf(reel2, reel1)
@@ -240,7 +398,7 @@ class UserReelViewModelTest {
                 id = "2",
                 videoUrl = "video2.mp4",
                 description = "second reel",
-                likesCount = 50,
+                likes = 50,
                 viewsCount = 100,
                 createdAt = LocalDateTime(2002, 2, 22, 2, 22).timeAgoValue(),
                 isCurrentUserOwner = false,
@@ -251,7 +409,7 @@ class UserReelViewModelTest {
                 id = "1",
                 videoUrl = "video1.mp4",
                 description = "First reel",
-                likesCount = 100,
+                likes = 100,
                 viewsCount = 1000,
                 createdAt = LocalDateTime(2002, 2, 22, 2, 22).timeAgoValue(),
                 isCurrentUserOwner = true,

--- a/trends_presentation/src/iosMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.ios.kt
+++ b/trends_presentation/src/iosMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.ios.kt
@@ -57,6 +57,7 @@ actual fun VideoPlayer(
     url: String,
     isReelVisible: Boolean,
     modifier: Modifier,
+    onVideoPlaying: () -> Unit,
     content: @Composable () -> Unit
 ) {
     var lastPosition by rememberSaveable(url) { mutableStateOf(0.0) }
@@ -90,6 +91,8 @@ actual fun VideoPlayer(
             player.pause()
             isPaused = true
         }
+
+        onVideoPlaying()
     }
 
     LaunchedEffect(player) {


### PR DESCRIPTION
This PR introduces the ability for users to like reels and for the system to track reel views.

**Key Changes:**

- **Like/Unlike Reels**:
    - Implemented `toggleReelLike` in the repository and view models to handle liking and unliking a reel.
    - Added an `isLiked` state to the `Reel` entity and corresponding UI states to reflect the like status.
    - The UI now optimistically updates the like count and icon state, reverting if the API call fails.

- **Increment View Count**:
    - Added `addReelView` to the repository to increment the view count when a reel is played.
    - This is triggered by the `onVideoPlaying` callback in the `VideoPlayer`.

- **ViewModel & UI Refactoring**:
    - Refactored `UserReelViewModel` and `ReelViewModel` to handle the new like and view interactions.
    - Updated the reel UI components (`UserReelScreen`, `ReelCard`) to display the like status and handle like clicks.
    - Enhanced tests for view models to cover optimistic updates, success cases, and error handling for the new features.