### PR TITLE
feature/TRN-73-enhance navigation

### DIFF
--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/Route.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/Route.kt
@@ -26,4 +26,8 @@ internal sealed interface Route {
 
     @Serializable
     data class CategoriesPublish(val trendId : String, val description : String) : Route
+
+    @Serializable
+    data object ReelHome : Route
+
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/Route.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/Route.kt
@@ -7,9 +7,6 @@ internal sealed interface Route {
     data object Categories : Route
 
     @Serializable
-    data object Trends : Route
-
-    @Serializable
     data class ReelDetails(val reelId: String) : Route
 
     @Serializable

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/TrendsNavGraph.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/TrendsNavGraph.kt
@@ -53,19 +53,6 @@ fun TrendsNavHost() {
                 UserReelScreen()
             }
 
-            composable<Route.Trends> {
-                // TODO: Just a placeholder for navigation until its user story
-                Text(
-                    text = "Trends Screen",
-                    style = Theme.typography.headline.large,
-                    color = Theme.colorScheme.primary.primary,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(top = 100.dp)
-                )
-            }
-
             composable<Route.UploadReel> {
                 UploadReelScreen()
             }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/TrendsNavGraph.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/TrendsNavGraph.kt
@@ -18,6 +18,7 @@ import net.thechance.mena.trends.presentation.screen.category_pick.CategoryPickS
 import net.thechance.mena.trends.presentation.screen.category_publish.CategoryPublishScreen
 import net.thechance.mena.trends.presentation.screen.main_container.MainContainerScreen
 import net.thechance.mena.trends.presentation.screen.manage_my_trends.ManageTrendsScreen
+import net.thechance.mena.trends.presentation.screen.show_real.ReelHomeScreen
 import net.thechance.mena.trends.presentation.screen.upload_reel.UploadReelScreen
 import net.thechance.mena.trends.presentation.screen.user_reel.UserReelScreen
 import net.thechance.mena.trends.presentation.screen.video_description.VideoDescriptionScreen
@@ -75,6 +76,10 @@ fun TrendsNavHost() {
 
             composable<Route.CategoriesPublish> {
                 CategoryPublishScreen()
+            }
+
+            composable<Route.ReelHome> {
+                ReelHomeScreen()
             }
         }
     }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_pick/CategoryPickScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_pick/CategoryPickScreen.kt
@@ -42,7 +42,10 @@ internal fun CategoryPickScreen(
     ObserveAsEffect(effects = viewModel.effect) { effect ->
         when (effect) {
             is CategoryPickScreenEffect.NavigateBack -> navController.popBackStack()
-            is CategoryPickScreenEffect.NavigateToTrends -> navController.navigate(Route.Trends)
+            is CategoryPickScreenEffect.NavigateToHome -> navController.navigate(Route.ReelHome){
+                popUpTo(Route.Categories){ inclusive = true}
+            }
+
         }
     }
 

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_pick/CategoryPickScreenEffect.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_pick/CategoryPickScreenEffect.kt
@@ -2,5 +2,5 @@ package net.thechance.mena.trends.presentation.screen.category_pick
 
 internal sealed interface CategoryPickScreenEffect {
     data object NavigateBack : CategoryPickScreenEffect
-    data object NavigateToTrends : CategoryPickScreenEffect
+    data object NavigateToHome : CategoryPickScreenEffect
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_pick/CategoryPickViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_pick/CategoryPickViewModel.kt
@@ -44,7 +44,7 @@ internal class CategoryPickViewModel(
     override fun onNextClick() {
         tryToExecute(
             block = { saveSelectedCategories() },
-            onSuccess = { sendEffect(CategoryPickScreenEffect.NavigateToTrends) },
+            onSuccess = { sendEffect(CategoryPickScreenEffect.NavigateToHome) },
             onStart = ::startSaving,
             onEnd = ::endSaving,
             onError = { errorState -> updateState { copy(error = errorState) } },

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishEffect.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishEffect.kt
@@ -2,5 +2,5 @@ package net.thechance.mena.trends.presentation.screen.category_publish
 
 internal sealed interface CategoryPublishEffect {
     data object NavigateBack : CategoryPublishEffect
-    data object NavigateToTrends : CategoryPublishEffect
+    data object NavigateToHome : CategoryPublishEffect
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishScreen.kt
@@ -1,8 +1,5 @@
 package net.thechance.mena.trends.presentation.screen.category_publish
 
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,18 +9,12 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mena.trends_presentation.generated.resources.Res
@@ -63,7 +54,7 @@ internal fun CategoryPublishScreen(
     ObserveAsEffect(viewModel.effect) { effect ->
         when (effect) {
             is CategoryPublishEffect.NavigateBack -> navController.popBackStack()
-            is CategoryPublishEffect.NavigateToTrends -> navController.navigate(Route.Trends){
+            is CategoryPublishEffect.NavigateToHome -> navController.navigate(Route.ReelHome){
                 popUpTo(Route.MainContainer)
             }
         }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishViewModel.kt
@@ -51,7 +51,7 @@ internal class CategoryPublishViewModel(
     override fun onPublishClick() {
         tryToExecute(
             block = { updateReel() },
-            onSuccess = { sendEffect(CategoryPublishEffect.NavigateToTrends) },
+            onSuccess = { sendEffect(CategoryPublishEffect.NavigateToHome) },
             onError = { errorState -> updateState { copy(error = errorState) } },
             onStart = { updateState { copy(isPublishButtonLoadingVisible = true) } },
             onEnd = { updateState { copy(isPublishButtonLoadingVisible = false) } },

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/args/CategoryPublishArgsImpl.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/args/CategoryPublishArgsImpl.kt
@@ -3,9 +3,10 @@ package net.thechance.mena.trends.presentation.screen.category_publish.args
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import net.thechance.mena.trends.presentation.navigation.Route
+import org.koin.core.annotation.Factory
 import org.koin.core.annotation.Single
 
-@Single(binds = [CategoryPublishArgs::class])
+@Factory(binds = [CategoryPublishArgs::class])
 class CategoryPublishArgsImpl(
     savedStateHandle: SavedStateHandle
 ) : CategoryPublishArgs {

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/main_container/MainContainerEffect.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/main_container/MainContainerEffect.kt
@@ -1,8 +1,6 @@
 package net.thechance.mena.trends.presentation.screen.main_container
 
 interface MainContainerEffect {
-    data object NavigateToTrends: MainContainerEffect
+    data object NavigateToReelHome: MainContainerEffect
     data object NavigateToCategoryPick: MainContainerEffect
-    data object NavigateToManageTrends: MainContainerEffect
-    data object NavigateToUploadReel: MainContainerEffect
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/main_container/MainContainerScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/main_container/MainContainerScreen.kt
@@ -1,20 +1,14 @@
 package net.thechance.mena.trends.presentation.screen.main_container
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import net.thechance.mena.designsystem.presentation.component.button.Button
 import net.thechance.mena.designsystem.presentation.component.indicator.DotsProgressIndicator
-import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.trends.presentation.navigation.LocalNavController
 import net.thechance.mena.trends.presentation.navigation.Route
@@ -30,76 +24,43 @@ internal fun MainContainerScreen(
 
     ObserveAsEffect(viewModel.effect) { effect ->
         when (effect) {
-            MainContainerEffect.NavigateToTrends -> {
-                navController.navigate(Route.Trends)
+            MainContainerEffect.NavigateToReelHome -> {
+                navController.navigate(Route.ReelHome) {
+                    popUpTo(Route.MainContainer) { inclusive = true }
+                }
             }
 
             MainContainerEffect.NavigateToCategoryPick -> {
-                navController.navigate(Route.Categories)
-            }
-
-            MainContainerEffect.NavigateToManageTrends -> {
-                navController.navigate(Route.ManageReels)
-            }
-
-            MainContainerEffect.NavigateToUploadReel -> {
-                navController.navigate(Route.UploadReel)
+                navController.navigate(Route.Categories) {
+                    popUpTo(Route.MainContainer) { inclusive = true }
+                }
             }
         }
     }
 
-    MainContainerScreenContent(
-        state = state,
-        onClickCategory = viewModel::navigateToCategories,
-        onClickManageTrends = viewModel::navigateToManageTrends,
-        onClickUploadReel = viewModel::navigateToUploadReel
-    )
+    MainContainerScreenContent(state = state)
 }
 
 @Composable
-private fun MainContainerScreenContent(
-    state: MainContainerState,
-    onClickCategory: () -> Unit, // TODO: REMOVE CALLBACK IN FUTURE
-    onClickManageTrends: () -> Unit, // TODO: REMOVE CALLBACK IN FUTURE
-    onClickUploadReel: () -> Unit, // TODO: REMOVE CALLBACK IN FUTURE
-) {
-    if (state.isCategoriesAlreadySelectedByUser != null) {
-        Column(
-            modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceEvenly
+private fun MainContainerScreenContent(state: MainContainerState) {
+    when (state.isCategoriesAlreadySelectedByUser) {
+        null -> {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Theme.colorScheme.background.surface.copy(alpha = 0.7f)),
+                contentAlignment = Alignment.Center
             ) {
-                Button(
-                    onClick = onClickCategory,
-                ) {
-                    Text("Category" , style = Theme.typography.title.medium)
-                }
-
-                Button(
-                    onClick = onClickManageTrends,
-                ) {
-                    Text("Mange Reels", style = Theme.typography.title.medium)
-                }
-
-                Button(
-                    onClick = onClickUploadReel,
-                ) {
-                    Text("Upload Reel", style = Theme.typography.title.medium)
-                }
+                DotsProgressIndicator()
             }
         }
-    } else {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(Theme.colorScheme.background.surface.copy(alpha = 0.7f)),
-            contentAlignment = Alignment.Center
-        ) {
-            DotsProgressIndicator()
+
+        else -> {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Theme.colorScheme.background.surface)
+            )
         }
     }
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/main_container/MainContainerViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/main_container/MainContainerViewModel.kt
@@ -31,21 +31,14 @@ internal class MainContainerViewModel(
 
     fun handleGetIsUserCategorySet(isUserCategorySet: Boolean) {
         updateState { copy(isCategoriesAlreadySelectedByUser = isUserCategorySet) }
+        navigateBasedOnCategoryState(isUserCategorySet)
     }
 
-    fun navigateToCategories() {
-        if (state.value.isCategoriesAlreadySelectedByUser == true) {
-            sendEffect(MainContainerEffect.NavigateToTrends)
+    private fun navigateBasedOnCategoryState(isUserCategorySet: Boolean) {
+        if (isUserCategorySet) {
+            sendEffect(MainContainerEffect.NavigateToReelHome)
         } else {
             sendEffect(MainContainerEffect.NavigateToCategoryPick)
         }
-    }
-
-    fun navigateToManageTrends() {
-        sendEffect(MainContainerEffect.NavigateToManageTrends)
-    }
-
-    fun navigateToUploadReel() {
-        sendEffect(MainContainerEffect.NavigateToUploadReel)
     }
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/main_container/MainContainerViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/main_container/MainContainerViewModel.kt
@@ -15,13 +15,13 @@ internal class MainContainerViewModel(
 ) : BaseViewModel<MainContainerState, MainContainerEffect>(MainContainerState()) {
 
     init {
-        getUserCategoryStatus()
+        checkIfUserSelectedCategories()
     }
 
-    private fun getUserCategoryStatus() {
+    private fun checkIfUserSelectedCategories() {
         tryToExecute(
             block = { repository.isCategoriesAlreadySelectedByUser() },
-            onSuccess = ::handleGetIsUserCategorySet,
+            onSuccess = ::onUserCategoryStatusReceived,
             onError = { errorState ->
                 updateState { copy(error = errorState, isCategoriesAlreadySelectedByUser = false) }
             },
@@ -29,13 +29,13 @@ internal class MainContainerViewModel(
         )
     }
 
-    fun handleGetIsUserCategorySet(isUserCategorySet: Boolean) {
+    fun onUserCategoryStatusReceived(isUserCategorySet: Boolean) {
         updateState { copy(isCategoriesAlreadySelectedByUser = isUserCategorySet) }
         navigateBasedOnCategoryState(isUserCategorySet)
     }
 
-    private fun navigateBasedOnCategoryState(isUserCategorySet: Boolean) {
-        if (isUserCategorySet) {
+    private fun navigateBasedOnCategoryState(hasUserSelectedCategories: Boolean) {
+        if (hasUserSelectedCategories) {
             sendEffect(MainContainerEffect.NavigateToReelHome)
         } else {
             sendEffect(MainContainerEffect.NavigateToCategoryPick)

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/args/UserReelArgsImpl.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/args/UserReelArgsImpl.kt
@@ -3,9 +3,10 @@ package net.thechance.mena.trends.presentation.screen.user_reel.args
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import net.thechance.mena.trends.presentation.navigation.Route
+import org.koin.core.annotation.Factory
 import org.koin.core.annotation.Single
 
-@Single(binds = [UserReelArgs::class])
+@Factory(binds = [UserReelArgs::class])
 class UserReelArgsImpl(
     savedStateHandle: SavedStateHandle
 ) : UserReelArgs {

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/video_description/args/VideoDescriptionArgsImp.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/video_description/args/VideoDescriptionArgsImp.kt
@@ -3,10 +3,11 @@ package net.thechance.mena.trends.presentation.screen.video_description.args
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import net.thechance.mena.trends.presentation.navigation.Route
+import org.koin.core.annotation.Factory
 import org.koin.core.annotation.Single
 
 
-@Single (binds = [VideoDescriptionArgs::class])
+@Factory (binds = [VideoDescriptionArgs::class])
 class VideoDescriptionArgsImp(
     saveSateHandle : SavedStateHandle
 ) : VideoDescriptionArgs {

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/category_pick/CategoryPickViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/category_pick/CategoryPickViewModelTest.kt
@@ -116,7 +116,7 @@ class CategoryPickViewModelTest : TestExtensions() {
 
             viewModel.effect.test {
                 val effect = awaitItem()
-                assertTrue(effect is CategoryPickScreenEffect.NavigateToTrends)
+                assertTrue(effect is CategoryPickScreenEffect.NavigateToHome)
                 cancelAndIgnoreRemainingEvents()
             }
         }

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishViewModelTest.kt
@@ -72,7 +72,7 @@ class CategoryPublishViewModelTest {
         viewModel.effect.test {
             viewModel.onPublishClick()
             val effect = awaitItem()
-            assertTrue(effect is CategoryPublishEffect.NavigateToTrends)
+            assertTrue(effect is CategoryPublishEffect.NavigateToHome)
         }
     }
 

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/main_container/MainContainerViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/main_container/MainContainerViewModelTest.kt
@@ -37,11 +37,35 @@ class MainContainerViewModelTest {
     fun tearDown() {
         Dispatchers.resetMain()
     }
+
     @Test
     fun `handleGetIsUserCategorySet should update state with isUserCategorySet`() = runTest {
-        viewModel.handleGetIsUserCategorySet(isUserCategorySet = true)
+        viewModel.onUserCategoryStatusReceived(isUserCategorySet = true)
         assertThat(viewModel.state.value.isCategoriesAlreadySelectedByUser).isEqualTo(true)
     }
+
+    @Test
+    fun `handleGetIsUserCategorySet should navigate to home screen when isUserCategorySet is true`() =
+        runTest {
+            viewModel.onUserCategoryStatusReceived(isUserCategorySet = true)
+            viewModel.effect.test {
+                val effect = awaitItem()
+                assertThat(effect).isEqualTo(MainContainerEffect.NavigateToReelHome)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `handleGetIsUserCategorySet should navigate to category pick screen when isUserCategorySet is false`() =
+        runTest {
+            val viewModel =
+                MainContainerViewModel(repository = repository, defaultDispatcher = testDispatcher)
+            viewModel.effect.test {
+                viewModel.onUserCategoryStatusReceived(false)
+                assertThat(awaitItem()).isEqualTo(MainContainerEffect.NavigateToCategoryPick)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 
     @Test
     fun `loadCategories should update error state when repository throws exception`() = runTest {

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/main_container/MainContainerViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/main_container/MainContainerViewModelTest.kt
@@ -37,45 +37,6 @@ class MainContainerViewModelTest {
     fun tearDown() {
         Dispatchers.resetMain()
     }
-
-    @Test
-    fun `navigateToUploadReel should navigate to upload reel screen`() = runTest {
-        viewModel.navigateToUploadReel()
-        viewModel.effect.test {
-            assertThat(awaitItem()).isEqualTo(MainContainerEffect.NavigateToUploadReel)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `navigateToManageTrends should navigate to manage trends screen`() = runTest {
-        viewModel.navigateToManageTrends()
-        viewModel.effect.test {
-            assertThat(awaitItem()).isEqualTo(MainContainerEffect.NavigateToManageTrends)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `navigateToCategories should navigate to categories screen when when user categories are not set`() =
-        runTest {
-            viewModel.handleGetIsUserCategorySet(isUserCategorySet = false)
-            viewModel.effect.test {
-                viewModel.navigateToCategories()
-                assertThat(awaitItem()).isEqualTo(MainContainerEffect.NavigateToCategoryPick)
-            }
-        }
-
-    @Test
-    fun `navigateToCategories should navigate to trends screen when user categories are already set`() =
-        runTest {
-            viewModel.handleGetIsUserCategorySet(isUserCategorySet = true)
-            viewModel.effect.test {
-                viewModel.navigateToCategories()
-                assertThat(awaitItem()).isEqualTo(MainContainerEffect.NavigateToTrends)
-            }
-        }
-
     @Test
     fun `handleGetIsUserCategorySet should update state with isUserCategorySet`() = runTest {
         viewModel.handleGetIsUserCategorySet(isUserCategorySet = true)


### PR DESCRIPTION
### What I did in this PR
Refactored `MainContainer` navigation logic to automatically navigate the user based on their category selection status.
- Added navigation to `ReelHome` if categories are already selected.
- Added navigation to `CategoryPick` if it’s the user’s first time.
- Updated `MainContainerEffect` and `MainContainerViewModel` logic for cleaner flow.
- Ensured back navigation from `ReelHome` doesn’t return to `CategoryPick`.
- Added navigation From `CategoryPublish` to `ReelHome` instead of `Trends`
- Added and handled test cases for `MainContainerViewModel`.