### PR TITLE
feat: scroll to a specific ayah when opening a surah

### DIFF
--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahInteractionListener.kt
@@ -8,4 +8,6 @@ interface SurahInteractionListener {
     fun onAyahLongPress(ayahContent: String, ayahIndex: Int)
     fun onSearchClick()
     fun onCopyClick(ayahContent: String)
+    fun onInitialAyahScrolled()
+    fun highlightAyah(ayahNumber: Int)
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreen.kt
@@ -11,14 +11,20 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.launch
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.faith.domain.entity.Ayah
 import net.thechance.mena.faith.presentation.base.ObserveAsEffect
 import net.thechance.mena.faith.presentation.base.snackbar.SnackBarState
 import net.thechance.mena.faith.presentation.component.FaithSnackBar
@@ -125,7 +131,18 @@ private fun AyatOfSurah(
             }
         }
     }
-
+    var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+    var chunkAyat by remember { mutableStateOf(listOf<Ayah>()) }
+    HandleInitialScroll(
+        initialAyahToScroll = state.initialAyahToScroll,
+        selectedAyahIndex = state.selectedAyahIndex,
+        isBasmalaVisible = state.isBasmalaVisible,
+        lazyListState = lazyListState,
+        highlightAyah = listener::highlightAyah,
+        chunkAyat = chunkAyat,
+        textLayoutResult = textLayoutResult,
+        onInitialScrollDone = listener::onInitialAyahScrolled
+    )
     LazyColumn(
         modifier = modifier.fillMaxWidth(),
         state = lazyListState
@@ -140,8 +157,7 @@ private fun AyatOfSurah(
         }
 
         items(preRenderedChunks.size) { chunkIndex ->
-            val chunkAyat = ayahChunks[chunkIndex]
-
+            chunkAyat = ayahChunks[chunkIndex]
             UnifiedChunkText(
                 chunkAyat = chunkAyat,
                 selectedAyahIndex = state.selectedAyahIndex,
@@ -151,7 +167,9 @@ private fun AyatOfSurah(
                         ayahIndex = ayah.number
                     )
                 },
-                onDismiss = { listener.onDismissActionButtons() }
+                onDismiss = { listener.onDismissActionButtons() },
+                textLayoutResult = textLayoutResult,
+                onTextLayoutResultChange = { textLayoutResult = it }
             )
         }
     }
@@ -174,6 +192,58 @@ private fun HideAyahActionButtonsOnScroll(
                     listener.onDismissActionButtons()
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun HandleInitialScroll(
+    initialAyahToScroll: Int?,
+    selectedAyahIndex: Int?,
+    isBasmalaVisible: Boolean,
+    lazyListState: LazyListState,
+    chunkAyat: List<Ayah>,
+    textLayoutResult: TextLayoutResult?,
+    highlightAyah: (Int) -> Unit,
+    onInitialScrollDone: () -> Unit
+) {
+    val navController = LocalNavController.current
+    val coroutineScope = rememberCoroutineScope()
+    LaunchedEffect(
+        navController.currentBackStackEntry?.savedStateHandle?.get<Int>("ayahNumber"),
+        selectedAyahIndex
+    ) {
+        navController.currentBackStackEntry?.savedStateHandle?.get<Int>("ayahNumber")?.let {
+            highlightAyah(it)
+        }
+        if (selectedAyahIndex == null) {
+            navController.currentBackStackEntry?.savedStateHandle?.remove<Int>("ayahNumber")
+        }
+    }
+    LaunchedEffect(initialAyahToScroll) {
+        initialAyahToScroll?.let { ayahNumber ->
+            val chunkIndex = (ayahNumber - 1) / AYAT_PER_PAGE
+            val scrollIndex = if (isBasmalaVisible) chunkIndex + 1 else chunkIndex
+            lazyListState.scrollToItem(scrollIndex)
+        }
+    }
+    LaunchedEffect(textLayoutResult, initialAyahToScroll) {
+        if (textLayoutResult == null || initialAyahToScroll == null) return@LaunchedEffect
+        val targetAyah = chunkAyat.find { it.number == initialAyahToScroll }
+        if (targetAyah != null) {
+            val ayahIndexInChunk = chunkAyat.indexOf(targetAyah)
+            val startCharOffset = chunkAyat.take(ayahIndexInChunk).sumOf { it.content.length + 1 }
+            val lineIndex = textLayoutResult.getLineForOffset(startCharOffset)
+            val lineTopOffset = textLayoutResult.getLineTop(lineIndex).toInt()
+            val chunkIndex = ((targetAyah.number - 1) / AYAT_PER_PAGE)
+            val scrollIndex = if (isBasmalaVisible) chunkIndex + 1 else chunkIndex
+            coroutineScope.launch {
+                lazyListState.animateScrollToItem(
+                    index = scrollIndex,
+                    scrollOffset = lineTopOffset
+                )
+            }
+            onInitialScrollDone()
         }
     }
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreenState.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreenState.kt
@@ -9,6 +9,7 @@ data class SurahScreenState(
     val surahName: String = "",
     val selectedAyah: String = "",
     val selectedAyahIndex: Int? = null,
+    val initialAyahToScroll: Int? = null,
     val isLoading: Boolean = false,
     val isBasmalaVisible: Boolean = false
 )

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import mena.faith_presentation.generated.resources.Res
 import mena.faith_presentation.generated.resources.bookmark_added_successfully
 import mena.faith_presentation.generated.resources.copied_ayah_failed
@@ -13,7 +15,6 @@ import net.thechance.mena.faith.domain.repository.BookmarkRepository
 import net.thechance.mena.faith.domain.repository.QuranRepository
 import net.thechance.mena.faith.presentation.base.BaseViewModel
 import net.thechance.mena.faith.presentation.base.snackbar.SnackBarState
-import net.thechance.mena.faith.presentation.base.snackbar.SnackbarHandler
 import net.thechance.mena.faith.presentation.feature.quran.surah.args.ISurahArgs
 import net.thechance.mena.faith.presentation.util.ClipboardManager
 
@@ -23,13 +24,8 @@ class SurahViewModel(
     private val clipboardManager: ClipboardManager,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val bookmarkRepository: BookmarkRepository,
-    snackbarHandler: SnackbarHandler,
 ) : BaseViewModel<SurahScreenState, SurahScreenEffect>(
-    initialState = SurahScreenState(
-        surahId = surahArgs.surahId,
-        surahName = surahArgs.surahName
-    ),
-    snackbarHandler = snackbarHandler
+    initialState = SurahScreenState(surahId = surahArgs.surahId, surahName = surahArgs.surahName)
 ), SurahInteractionListener {
 
     init {
@@ -43,12 +39,33 @@ class SurahViewModel(
             onSuccess = { ayat ->
                 handleBasmalaVisibility(surahId = surahId)
                 updateState {
-                    it.copy(ayatOfSurah = ayat)
+                    it.copy(
+                        ayatOfSurah = ayat,
+                        initialAyahToScroll = surahArgs.ayahNumber,
+                        selectedAyahIndex = surahArgs.ayahNumber
+                    )
                 }
             },
             onFinally = { updateState { it.copy(isLoading = false) } },
             dispatcher = dispatcher
         )
+    }
+
+    override fun highlightAyah(ayahNumber: Int) {
+        updateState {
+            it.copy(
+                initialAyahToScroll = ayahNumber,
+                selectedAyahIndex = ayahNumber
+            )
+        }
+    }
+
+    override fun onInitialAyahScrolled() {
+        viewModelScope.launch {
+            delay(2000L)
+            updateState { it.copy(selectedAyahIndex = null, initialAyahToScroll = null) }
+        }
+
     }
 
     override fun onAyahLongPress(ayahContent: String, ayahIndex: Int) {
@@ -105,11 +122,13 @@ class SurahViewModel(
         }
     }
 
-    private fun onAddBookmarkSuccess() = showSnackBar(
-        message = Res.string.bookmark_added_successfully,
-        status = SnackBarState.Status.Success,
-        scope = viewModelScope
-    )
+    private fun onAddBookmarkSuccess() {
+        showSnackBar(
+            message = Res.string.bookmark_added_successfully,
+            status = SnackBarState.Status.Success,
+            scope = viewModelScope
+        )
+    }
 
     override fun onShareClick(ayahContent: String) {
         updateState {
@@ -133,17 +152,21 @@ class SurahViewModel(
         }
     }
 
-    private fun showSuccessSnackBar() = showSnackBar(
-        message = Res.string.copied_ayah_successfully,
-        status = SnackBarState.Status.Success,
-        scope = viewModelScope
-    )
+    private fun showSuccessSnackBar() {
+        showSnackBar(
+            message = Res.string.copied_ayah_successfully,
+            status = SnackBarState.Status.Success,
+            scope = viewModelScope
+        )
+    }
 
-    private fun showErrorSnackBar() = showSnackBar(
-        message = Res.string.copied_ayah_failed,
-        status = SnackBarState.Status.Error,
-        scope = viewModelScope
-    )
+    private fun showErrorSnackBar() {
+        showSnackBar(
+            message = Res.string.copied_ayah_failed,
+            status = SnackBarState.Status.Error,
+            scope = viewModelScope
+        )
+    }
 
     private fun handleBasmalaVisibility(surahId: Int) {
         val isTawbah = surahId == Surah.SurahOrder.AtTawbah.order

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
@@ -15,6 +15,7 @@ import net.thechance.mena.faith.domain.repository.BookmarkRepository
 import net.thechance.mena.faith.domain.repository.QuranRepository
 import net.thechance.mena.faith.presentation.base.BaseViewModel
 import net.thechance.mena.faith.presentation.base.snackbar.SnackBarState
+import net.thechance.mena.faith.presentation.base.snackbar.SnackbarHandler
 import net.thechance.mena.faith.presentation.feature.quran.surah.args.ISurahArgs
 import net.thechance.mena.faith.presentation.util.ClipboardManager
 
@@ -24,8 +25,10 @@ class SurahViewModel(
     private val clipboardManager: ClipboardManager,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val bookmarkRepository: BookmarkRepository,
+    snackBarHandler: SnackbarHandler
 ) : BaseViewModel<SurahScreenState, SurahScreenEffect>(
-    initialState = SurahScreenState(surahId = surahArgs.surahId, surahName = surahArgs.surahName)
+    initialState = SurahScreenState(surahId = surahArgs.surahId, surahName = surahArgs.surahName),
+    snackbarHandler = snackBarHandler
 ), SurahInteractionListener {
 
     init {

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/SurahComponents.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/SurahComponents.kt
@@ -12,10 +12,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
@@ -135,11 +131,11 @@ fun getAyahTextStyle() = Theme.typography.quran.large.copy(
 internal fun UnifiedChunkText(
     chunkAyat: List<Ayah>,
     selectedAyahIndex: Int?,
+    textLayoutResult:TextLayoutResult?,
+    onTextLayoutResultChange: (TextLayoutResult?) -> Unit,
     onLongPress: (Ayah) -> Unit,
     onDismiss: () -> Unit
 ) {
-    var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
-
     val styledText = buildAnnotatedString {
         chunkAyat.forEach { ayah ->
             val color = getAyahTextColor(selectedAyahIndex, ayah.number)
@@ -149,11 +145,10 @@ internal fun UnifiedChunkText(
             append(" ")
         }
     }
-
     BasicText(
         text = styledText,
         style = getAyahTextStyle(),
-        onTextLayout = { textLayoutResult = it },
+        onTextLayout = { onTextLayoutResultChange(it) },
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = Theme.spacing._16, vertical = Theme.spacing._8)

--- a/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModelTest.kt
+++ b/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModelTest.kt
@@ -43,6 +43,7 @@ class SurahViewModelTest {
             quranRepository = quranRepository,
             clipboardManager = clipboardManager,
             bookmarkRepository = bookmarkRepository,
+            snackBarHandler = FakeSnackbarHandler()
         )
     }
 

--- a/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModelTest.kt
+++ b/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModelTest.kt
@@ -31,7 +31,6 @@ class SurahViewModelTest {
     private val quranRepository: QuranRepository = mock(mode = MockMode.autofill)
     private val bookmarkRepository: BookmarkRepository = mock(mode = MockMode.autofill)
     private val clipboardManager: ClipboardManager = mock(mode = MockMode.autofill)
-    private val fakeSnackbarHandler = FakeSnackbarHandler()
 
     private val surahArgs = mock<ISurahArgs>(mode = MockMode.autofill)
 
@@ -44,7 +43,6 @@ class SurahViewModelTest {
             quranRepository = quranRepository,
             clipboardManager = clipboardManager,
             bookmarkRepository = bookmarkRepository,
-            snackbarHandler = fakeSnackbarHandler
         )
     }
 
@@ -99,7 +97,7 @@ class SurahViewModelTest {
     }
 
     @Test
-    fun `onAyahLongPress should set selectedAyahIndex to negative value when called with negative index`() =
+    fun `onAyahLongPress should set selectedAyahIndex to zero value when called with negative index`() =
         runTest {
             // Given
             everySuspend { quranRepository.getAyatOfSurah(any()) } returns dummyAyat
@@ -109,7 +107,7 @@ class SurahViewModelTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             // Then
-            assertEquals(NEGATIVE_AYAH_INDEX, testViewModel.uiState.value.selectedAyahIndex)
+            assertEquals(0, testViewModel.uiState.value.selectedAyahIndex)
         }
 
     @Test
@@ -248,7 +246,6 @@ class SurahViewModelTest {
 
     private companion object {
         const val DEFAULT_SURAH_ID = 1
-        const val DEFAULT_SURAH_NAME = "Al-Fatiha"
         const val TEST_AYAH_INDEX = 0
         const val SECOND_AYAH_INDEX = 1
         const val NEGATIVE_AYAH_INDEX = -1


### PR DESCRIPTION
This PR implements automatic scrolling to a specific ayah when navigating to a surah screen, for example, from a SearchScreen.

It introduces logic to:
- Determine the correct chunk and position of the target ayah.
- Scroll the `LazyColumn` to the appropriate item and offset.
- Highlight the ayah upon arrival and then clear the highlight after a short delay.

https://github.com/user-attachments/assets/a52b7ccf-4deb-429b-a836-65e90c84afee