### PR TITLE
feat: enhance image cropper functionality

### DIFF
--- a/identity_presentation/src/commonMain/composeResources/values-ar/strings.xml
+++ b/identity_presentation/src/commonMain/composeResources/values-ar/strings.xml
@@ -80,4 +80,5 @@
     <!--    crop image-->
     <string name="save">حفظ</string>
     <string name="upload_another_image">رفع صورة أخرى</string>
+    <string name="image_preview">عرض الصوره</string>
 </resources>

--- a/identity_presentation/src/commonMain/composeResources/values/strings.xml
+++ b/identity_presentation/src/commonMain/composeResources/values/strings.xml
@@ -128,6 +128,7 @@
     <!--    crop image-->
 
     <string name="upload_another_image">Upload another image</string>
+    <string name="image_preview">Image preview</string>
 
     <string name="edit_profile_information">Edit profile information</string>
     <string name="options">Options</string>

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/imageCropper/ImageCropperScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/imageCropper/ImageCropperScreen.kt
@@ -17,12 +17,15 @@ import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.Navigator
 import mena.identity_presentation.generated.resources.Res
+import mena.identity_presentation.generated.resources.back
 import mena.identity_presentation.generated.resources.ic_arrow_left
+import mena.identity_presentation.generated.resources.image_preview
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.identity.presentation.base.BaseScreen
 import net.thechance.mena.identity.presentation.screen.imageCropper.components.ImageCropperComponent
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
 import org.koin.core.parameter.parametersOf
 import sv.lib.squircleshape.SquircleShape
 
@@ -54,11 +57,11 @@ class ImageCropperScreen(
                 .verticalScroll(rememberScrollState())
         ) {
             AppBar(
-                title = "Image preview",
+                title = stringResource(Res.string.image_preview),
                 leadingContent = {
                     Image(
                         painter = painterResource(Res.drawable.ic_arrow_left),
-                        contentDescription = "back",
+                        contentDescription = stringResource(Res.string.back),
                         modifier = Modifier
                             .clip(SquircleShape(Theme.radius.md))
                             .size(40.dp)
@@ -71,7 +74,6 @@ class ImageCropperScreen(
 
             ImageCropperComponent(
                 image = BitmapPainter(state.imageBitmap),
-                contentDescription = "selected image to crop",
                 onSaveButtonClicked = listener::onCropImage,
                 onUploadAnotherImageClicked = listener::onChangeImage,
             )

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/imageCropper/components/ImageCropperComponent.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/imageCropper/components/ImageCropperComponent.kt
@@ -11,40 +11,35 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toIntSize
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import sv.lib.squircleshape.SquircleShape
 
 @Composable
 fun ImageCropperComponent(
     image: Painter,
-    contentDescription: String,
     onSaveButtonClicked: (imageBitmap: ImageBitmap) -> Unit,
     onUploadAnotherImageClicked: (ImageBitmap) -> Unit,
     modifier: Modifier = Modifier,
-    imagCropperUiState: ImageCropperUiState = rememberImageCropState(),
+    imagCropperUiState: ImageCropperUiState = rememberImageCropState(imageSize = image.intrinsicSize.toIntSize()),
     contentPadding: PaddingValues = PaddingValues(16.dp)
 ) {
     val density = LocalDensity.current
     val direction = LocalLayoutDirection.current
 
-    Column(
-        modifier = modifier
-            .padding(contentPadding)
-            .clipToBounds()
-    ) {
+    Column(modifier.padding(contentPadding)) {
         ImageCropperSection(
             image = image,
-            contentDescription = contentDescription,
             scale = imagCropperUiState.state.scale,
             translation = imagCropperUiState.state.translation,
             onTransformation = imagCropperUiState::zoomBy,
-            updateImageSize = imagCropperUiState::updateImageSize,
+            updateComponentSize = imagCropperUiState::updateComponentSize,
+            updateImageSize = imagCropperUiState::resetAndUpdateImageSize,
             modifier = Modifier
                 .clip(SquircleShape(Theme.radius.lg))
                 .align(Alignment.CenterHorizontally)

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/imageCropper/components/ImageCropperSection.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/imageCropper/components/ImageCropperSection.kt
@@ -1,61 +1,79 @@
 package net.thechance.mena.identity.presentation.screen.imageCropper.components
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.toIntSize
 
 @Composable
 fun ImageCropperSection(
     image: Painter,
-    contentDescription: String,
     scale: Float,
     translation: Offset,
     modifier: Modifier = Modifier,
     onTransformation: (gestureZoom: Float, pan: Offset) -> Unit,
+    updateComponentSize: (IntSize) -> Unit,
     updateImageSize: (IntSize) -> Unit
 ) {
     val density = LocalDensity.current
 
     BoxWithConstraints(modifier) {
 
+        val widthScale = remember(image) {
+            with(density) { maxWidth.roundToPx() / image.intrinsicSize.width }
+        }
+
+        val imageSize = remember(image) {
+            with(density) { image.intrinsicSize.toDpSize() * widthScale }
+        }
+
         LaunchedEffect(Unit) {
             with(density) {
-                updateImageSize(IntSize(maxWidth.roundToPx(), maxHeight.roundToPx()))
+                updateComponentSize(
+                    IntSize(maxWidth.roundToPx(), maxHeight.roundToPx())
+                )
             }
         }
 
-        Image(
-            painter = image,
-            contentDescription = contentDescription,
-            contentScale = ContentScale.FillBounds,
+        LaunchedEffect(image) {
+            with(density) { updateImageSize(imageSize.toSize().toIntSize()) }
+        }
+
+        Canvas(
             modifier = Modifier
-                .fillMaxSize()
-                .graphicsLayer(
-                    scaleX = scale,
-                    scaleY = scale,
-                    translationX = translation.x,
-                    translationY = translation.y
-                )
+                .size(imageSize)
                 .pointerInput(Unit) {
                     detectTransformGestures { _, pan, gestureZoom, _ ->
                         onTransformation(gestureZoom, pan)
                     }
                 }
-        )
+        ) {
+            with(image) {
+                translate(left = translation.x, top = translation.y) {
+                    scale(
+                        scale = scale,
+                        pivot = Offset(imageSize.width.toPx() / 2, imageSize.height.toPx() / 2),
+                        block = { draw(imageSize.toSize()) }
+                    )
+                }
+            }
+        }
 
         OverlayCanvas()
     }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/imageCropper/components/ImageCropperUiState.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/imageCropper/components/ImageCropperUiState.kt
@@ -1,24 +1,22 @@
 package net.thechance.mena.identity.presentation.screen.imageCropper.components
 
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.Saver
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
@@ -41,10 +39,8 @@ class ImageCropperUiState(
     }
 
     fun zoomBy(gestureZoom: Float, pan: Offset) {
-        val scale = (state.scale * gestureZoom).coerceIn(1f, 3f)
-        updateState(
-            state.copy(scale = scale, translation = state.translation + pan)
-        )
+        val scale = (state.scale * gestureZoom).coerceIn(minScale, maxScale)
+        updateState(state.copy(scale = scale, translation = state.translation + pan))
     }
 
     fun zoomIn(value: Float) {
@@ -61,8 +57,13 @@ class ImageCropperUiState(
         updateState(newState = state.copy(scale = minScale, translation = Offset.Zero))
     }
 
-    fun updateImageSize(imageSize: IntSize) {
+    fun resetAndUpdateImageSize(imageSize: IntSize) {
+        reset()
         state = state.copy(imageSize = imageSize)
+    }
+
+    fun updateComponentSize(componentSize: IntSize) {
+        state = state.copy(componentSize = componentSize)
     }
 
     fun cropToBitmap(
@@ -70,107 +71,92 @@ class ImageCropperUiState(
         density: Density,
         layoutDirection: LayoutDirection,
     ): ImageBitmap {
-        val imageBitmap = ImageBitmap(state.imageSize.width, state.imageSize.height)
-        val floatSize = IntSize(state.imageSize.width, state.imageSize.height).toSize()
-        val radius = floatSize.width / 2
+        val imageBitmap = ImageBitmap(state.componentSize.width, state.componentSize.height)
         val canvas = Canvas(imageBitmap)
+        val imageFloatSize = state.imageSize.toSize()
+        val clipPath = createClipPath()
 
         CanvasDrawScope().draw(
             density = density,
             layoutDirection = layoutDirection,
             canvas = canvas,
-            size = floatSize
+            size = imageFloatSize
         ) {
-
-            val path = Path().apply {
-                addOval(
-                    Rect(
-                        left = center.x - radius,
-                        top = center.y - radius,
-                        right = center.x + radius,
-                        bottom = center.y + radius
-                    )
-                )
-            }
-
-            clipPath(
-                path = path
-            ) {
-                with(painter) {
-                    translate(
-                        left = state.translation.x,
-                        top = state.translation.y
-                    ) {
-                        scale(
-                            scale = state.scale
-                        ) {
-                            draw(floatSize)
-                        }
-                    }
-                }
-            }
+            drawOnBitMapCanvas(
+                painter = painter,
+                imageSize = state.imageSize.toSize(),
+                clipPath = clipPath
+            )
         }
 
         return imageBitmap
     }
 
     private fun updateState(newState: ImageCropperUiModel) {
-        val (scale, translation, imageSize) = newState
-        val horizontalBounds = abs((imageSize.width.toFloat() * (scale - 1f)) / 2)
-        val initialVerticalBounds = (imageSize.height - imageSize.width) / 2
-        val newAddedVerticalBounds = (imageSize.height.toFloat() * (scale - 1f)) / 2
-        val verticalBounds = abs(newAddedVerticalBounds + initialVerticalBounds)
-        val maxOffsetOfX = translation.x.coerceIn(-horizontalBounds, horizontalBounds)
-        val maxOffsetOfY = translation.y.coerceIn(-verticalBounds, verticalBounds)
+        val translation = newState.translation
+        val translationXRange = calculateTranslationXRange(newState)
+        val translationYRange = calculateTranslationYRange(newState)
+        val maxOffsetOfX = translation.x.coerceIn(translationXRange)
+        val maxOffsetOfY = translation.y.coerceIn(translationYRange)
 
         state = state.copy(
-            scale = scale,
+            scale = newState.scale,
             translation = translation.copy(maxOffsetOfX, maxOffsetOfY),
-            imageSize = imageSize
+            imageSize = newState.imageSize,
+            componentSize = newState.componentSize
         )
+    }
+
+    private fun createClipPath(): Path {
+        val clipCircleRadius = state.componentSize.width / 2
+        val clipCircleCenter = Offset(
+            x = state.componentSize.width.toFloat() / 2,
+            y = state.componentSize.height.toFloat() / 2
+        )
+        val clipBounds = Rect(
+            left = clipCircleCenter.x - clipCircleRadius,
+            top = clipCircleCenter.y - clipCircleRadius,
+            right = clipCircleCenter.x + clipCircleRadius,
+            bottom = clipCircleCenter.y + clipCircleRadius
+        )
+        return Path().apply { addOval(oval = clipBounds) }
+    }
+
+    private fun DrawScope.drawOnBitMapCanvas(
+        painter: Painter,
+        imageSize: Size,
+        clipPath: Path
+    ) {
+        clipPath(path = clipPath) {
+            with(painter) {
+                translate(left = state.translation.x, top = state.translation.y) {
+                    scale(scale = state.scale, block = { draw(imageSize) })
+                }
+            }
+        }
+    }
+
+    private fun calculateTranslationXRange(newState: ImageCropperUiModel): ClosedFloatingPointRange<Float> {
+        val (scale, _, imageSize, componentSize) = newState
+        val initialHorizontalBounds = abs(imageSize.width - componentSize.width)
+        val newAddedHorizontalBounds = abs(imageSize.width * (scale - 1f)) / 2
+        val minValue = -newAddedHorizontalBounds - initialHorizontalBounds
+        return minValue..newAddedHorizontalBounds
+    }
+
+    private fun calculateTranslationYRange(newState: ImageCropperUiModel): ClosedFloatingPointRange<Float> {
+        val (scale, _, imageSize, componentSize) = newState
+        val initialVerticalBounds = abs(imageSize.height - componentSize.height)
+        val newAddedVerticalBounds = abs(imageSize.height * (scale - 1f)) / 2
+        val minValue = -newAddedVerticalBounds - initialVerticalBounds
+        return minValue..newAddedVerticalBounds
     }
 
     @Stable
     data class ImageCropperUiModel(
         val scale: Float = 1f,
         val translation: Offset = Offset.Zero,
-        val imageSize: IntSize
-    )
-}
-
-val saver = Saver<ImageCropperUiState, Map<String, Any>>(
-    save = { imageState ->
-        mapOf(
-            "scale" to imageState.state.scale,
-            "translation" to imageState.state.translation,
-            "imageSize" to imageState.state.imageSize,
-            "minScale" to imageState.minScale,
-            "maxScale" to imageState.maxScale
-        )
-    },
-    restore = { map ->
-        val uiModel = ImageCropperUiState.ImageCropperUiModel(
-            imageSize = map["imageSize"] as IntSize,
-            scale = map["scale"] as Float,
-            translation = map["translation"] as Offset,
-        )
-
-        ImageCropperUiState(
-            minScale = map["minScale"] as Float,
-            maxScale = map["maxScale"] as Float,
-            initialState = uiModel
-        )
-    }
-)
-
-@Composable
-fun rememberImageCropState(
-    minScale: Float = 1f,
-    maxScale: Float = 3f,
-    imageSize: IntSize = LocalWindowInfo.current.containerSize
-) = rememberSaveable(saver = saver) {
-    ImageCropperUiState(
-        minScale, maxScale,
-        ImageCropperUiState.ImageCropperUiModel(imageSize = imageSize)
+        val imageSize: IntSize,
+        val componentSize: IntSize
     )
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/imageCropper/components/RememberImageCropperComponent.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/imageCropper/components/RememberImageCropperComponent.kt
@@ -1,0 +1,51 @@
+package net.thechance.mena.identity.presentation.screen.imageCropper.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.IntSize
+
+@Composable
+fun rememberImageCropState(
+    minScale: Float = 1f,
+    maxScale: Float = 5f,
+    imageSize: IntSize = LocalWindowInfo.current.containerSize,
+    componentSize: IntSize = imageSize
+) = rememberSaveable(saver = saver) {
+    ImageCropperUiState(
+        minScale, maxScale,
+        ImageCropperUiState.ImageCropperUiModel(
+            imageSize = imageSize,
+            componentSize = componentSize
+        )
+    )
+}
+
+private val saver = Saver<ImageCropperUiState, Map<String, Any>>(
+    save = { imageState ->
+        mapOf(
+            "scale" to imageState.state.scale,
+            "translation" to imageState.state.translation,
+            "imageSize" to imageState.state.imageSize,
+            "componentSize" to imageState.state.componentSize,
+            "minScale" to imageState.minScale,
+            "maxScale" to imageState.maxScale
+        )
+    },
+    restore = { map ->
+        val uiModel = ImageCropperUiState.ImageCropperUiModel(
+            imageSize = map["imageSize"] as IntSize,
+            scale = map["scale"] as Float,
+            translation = map["translation"] as Offset,
+            componentSize = map["componentSize"] as IntSize
+        )
+
+        ImageCropperUiState(
+            minScale = map["minScale"] as Float,
+            maxScale = map["maxScale"] as Float,
+            initialState = uiModel
+        )
+    }
+)


### PR DESCRIPTION
This commit enhances the image cropper component by:
- Replacing the `Image` composable with a `Canvas` for more control over drawing and transformations.
- Improving zoom and pan calculations to ensure the image remains within the circular crop bounds.
- Refactoring the state management to better handle image and component size changes.
- Moving `rememberImageCropState` to its own file.
- Adding localized strings for the "Image preview" title.


https://github.com/user-attachments/assets/b6162704-fe49-4c7e-83f1-7cd10b53544f

