### PR TITLE
refactor/CHT-78-split chatRepository

### DIFF
--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/di/repositoryModule.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/di/repositoryModule.kt
@@ -2,9 +2,11 @@ package net.thechance.mena.core_chat.data.di
 
 import net.thechance.mena.core_chat.data.repository.ChatRepositoryImpl
 import net.thechance.mena.core_chat.data.repository.ContactsRepositoryImpl
+import net.thechance.mena.core_chat.data.repository.MessageRepositoryImpl
 import net.thechance.mena.core_chat.data.repository.UserRepositoryImpl
 import net.thechance.mena.core_chat.domain.repository.ChatRepository
 import net.thechance.mena.core_chat.domain.repository.ContactsRepository
+import net.thechance.mena.core_chat.domain.repository.MessageRepository
 import net.thechance.mena.core_chat.domain.repository.UserRepository
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
@@ -23,13 +25,19 @@ internal val repositoryModule = module {
     single<ChatRepository> {
         ChatRepositoryImpl(
             client = get(named(CHAT_CLIENT)),
-            json = get(named(CHAT_JSON)),
             webSocketManager = get(),
-            messageDao = get(),
             imageDownloader = get()
         )
     }
+   single<MessageRepository>{
+       MessageRepositoryImpl(
+           client = get(named(CHAT_CLIENT)),
+           webSocketManager = get(),
+           messageDao = get(),
+           json = get(named(CHAT_JSON))
+       )
 
+   }
     single<UserRepository> {
         UserRepositoryImpl(
             client = get(named(CHAT_CLIENT)),

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/repository/ChatRepositoryImpl.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/repository/ChatRepositoryImpl.kt
@@ -3,44 +3,18 @@ package net.thechance.mena.core_chat.data.repository
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
 import io.ktor.util.reflect.typeInfo
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.launch
-import kotlinx.serialization.json.Json
-import net.thechance.mena.core_chat.data.source.local.database.MessageDao
-import net.thechance.mena.core_chat.data.source.local.database.MessageLocalDto
 import net.thechance.mena.core_chat.data.source.remote.dto.ChatDto
 import net.thechance.mena.core_chat.data.source.remote.dto.ChatSummaryDto
-import net.thechance.mena.core_chat.data.source.remote.dto.MarkAsReadRequest
-import net.thechance.mena.core_chat.data.source.remote.dto.MessageDto
 import net.thechance.mena.core_chat.data.source.remote.dto.PagedDataDto
-import net.thechance.mena.core_chat.data.source.remote.dto.SendMessageDto
 import net.thechance.mena.core_chat.data.source.remote.mapper.toDomain
-import net.thechance.mena.core_chat.data.source.remote.mapper.toEntity
-import net.thechance.mena.core_chat.data.source.remote.mapper.toLocalDto
 import net.thechance.mena.core_chat.data.source.remote.mapper.toPagedListOfChatSummary
 import net.thechance.mena.core_chat.data.source.remote.network.ImageDownloader
 import net.thechance.mena.core_chat.data.source.remote.network.WebSocketManager
-import net.thechance.mena.core_chat.data.utils.MessageEvent
-import net.thechance.mena.core_chat.data.utils.buildImageMultiPartFormData
 import net.thechance.mena.core_chat.domain.entity.Chat
 import net.thechance.mena.core_chat.domain.entity.ChatSummary
-import net.thechance.mena.core_chat.domain.entity.ImagesSource
-import net.thechance.mena.core_chat.domain.entity.MarkMessageAsReadEvent
-import net.thechance.mena.core_chat.domain.entity.Message
-import net.thechance.mena.core_chat.domain.entity.MessageContent
-import net.thechance.mena.core_chat.domain.entity.MessageStatus
 import net.thechance.mena.core_chat.domain.exception.NotFoundException
 import net.thechance.mena.core_chat.domain.exception.OperationFailedException
-import net.thechance.mena.core_chat.domain.exception.SendMessageFailedException
 import net.thechance.mena.core_chat.domain.model.PagedData
 import net.thechance.mena.core_chat.domain.repository.ChatRepository
 import kotlin.uuid.ExperimentalUuidApi
@@ -50,26 +24,8 @@ import kotlin.uuid.Uuid
 class ChatRepositoryImpl(
     private val client: HttpClient,
     private val webSocketManager: WebSocketManager,
-    private val messageDao: MessageDao,
-    private val json: Json,
     private val imageDownloader: ImageDownloader,
 ) : ChatRepository, BaseRepository {
-
-    private val messageFlows = MutableSharedFlow<Message>()
-    private val markMessagesAsRead = MutableSharedFlow<MarkMessageAsReadEvent>()
-    private val scope = CoroutineScope(Dispatchers.IO)
-
-    override suspend fun loadMessages(chatId: Uuid): List<Message> {
-        return tryNetworkCall<PagedDataDto<MessageDto>>(
-            bodyType = typeInfo<PagedDataDto<MessageDto>>()
-        ) {
-            client.get(CHAT_HISTORY_ENDPOINT) {
-                parameter(CHAT_ID_PARAMETER, chatId)
-                parameter(PAGE_NUMBER_PARAMETER, PAGE_NUMBER)
-                parameter(PAGE_SIZE_PARAMETER, PAGE_SIZE)
-            }
-        }?.data?.mapNotNull { it.toDomain() } ?: emptyList()
-    }
 
     override suspend fun getChatsSummary(pageNumber: Int, pageSize: Int): PagedData<ChatSummary> {
         return tryNetworkCall<PagedDataDto<ChatSummaryDto>>(
@@ -85,14 +41,11 @@ class ChatRepositoryImpl(
     override suspend fun getChatSummaryById(chatId: Uuid): ChatSummary {
         return tryNetworkCall<ChatSummaryDto>(
             bodyType = typeInfo<ChatSummaryDto>()
-        ){
+        ) {
             client.get("$CHAT_SUMMARY_ENDPOINT/$chatId")
         }?.toDomain() ?: throw NotFoundException("Chat not found")
     }
 
-    override suspend fun deleteMessage(message: Message) {
-        messageDao.deleteMessage(message.id.toString())
-    }
 
     override suspend fun getChatByContactUserId(userId: Uuid): Chat {
         return tryNetworkCall<ChatDto>(
@@ -110,161 +63,12 @@ class ChatRepositoryImpl(
         }?.toDomain() ?: throw NotFoundException("Chat not found")
     }
 
-    override fun getLocalMessages(chatId: Uuid): Flow<List<Message>> {
-        val failedEntities = messageDao.getMessagesByChat(chatId.toString())
-        return failedEntities.map { it.toDomain() }
-    }
 
     override suspend fun downloadImage(url: String) {
         val success = imageDownloader.downloadImageToGallery(url)
         if (!success) {
             throw OperationFailedException("Failed to download image")
         }
-    }
-
-    override fun getMessages(chatId: Uuid?): Flow<Message> {
-        if (webSocketManager.isConnected().not()) initializeWebsocketConnection()
-        return messageFlows.filter { chatId == null || it.chatId == chatId }
-    }
-
-    override suspend fun sendMessage(message: Message) {
-        val updatedMessage = message.copy(status = MessageStatus.LOADING).toLocalDto()
-        messageDao.insertMessage(updatedMessage)
-
-        try {
-            when (val content = message.content) {
-                is MessageContent.Text -> {
-                    val sendMessageDto = SendMessageDto(
-                        chatId = message.chatId.toString(),
-                        text = content.text
-                    )
-                    sendTextMessage(sendMessageDto)
-                }
-
-                is MessageContent.Images -> {
-                    val source = content.source
-                    val byteArrays =
-                        if (source is ImagesSource.Local)
-                            source.byteArrays
-                        else throw SendMessageFailedException("Failed to send message: Corrupted images")
-                    var remainingImages = byteArrays.toMutableList()
-                    sendImagesMessage(
-                        imageNames = byteArrays.mapIndexed { index, _ -> "image_$index" },
-                        images = byteArrays,
-                        chatId = message.chatId,
-                        onSuccessImage = { image ->
-                            remainingImages = remainingImages.apply { remove(image) }
-                            messageDao.updateMessageImages(
-                                id = updatedMessage.id,
-                                images = remainingImages
-                            )
-                        }
-                    )
-                }
-            }
-        } catch (e: Exception) {
-            messageDao.updateMessageStatus(
-                updatedMessage.id,
-                MessageLocalDto.MessageStatus.FAILED
-            )
-            throw SendMessageFailedException("Failed to send message: ${e.message}")
-        }
-        messageDao.deleteMessage(updatedMessage.id)
-    }
-
-    private suspend fun sendTextMessage(sendMessageDto: SendMessageDto) {
-        if (webSocketManager.isConnected()) {
-            val messageJson = json.encodeToString(
-                SendMessageDto.serializer(),
-                sendMessageDto
-            )
-            webSocketManager.sendTextFrame(
-                destination = SEND_MESSAGE_DESTINATION,
-                payload = messageJson
-
-            )
-        } else {
-            throw SendMessageFailedException("Failed to send message")
-        }
-    }
-
-    private suspend fun sendImagesMessage(
-        imageNames: List<String>,
-        images: List<ByteArray>,
-        chatId: Uuid,
-        onSuccessImage: suspend (ByteArray) -> Unit = {}
-    ) {
-        if (images.size != imageNames.size)
-            throw SendMessageFailedException("imageNames and images must have the same size.")
-
-        val files = imageNames.zip(images)
-
-        var messageId: String? = null
-
-        files.forEachIndexed { index, imageFile ->
-            val multipart = imageFile.buildImageMultiPartFormData(
-                fieldName = IMAGES_FILES_PARAM,
-                chatId = chatId.toString(),
-                messageId = messageId
-            )
-
-            val messageResponse = tryNetworkCall<MessageDto>(
-                bodyType = typeInfo<MessageDto>()
-            ) {
-                client.post(IMAGES_ENDPOINT) {
-                    setBody(multipart)
-                }
-            }
-
-            if (messageResponse != null ) onSuccessImage(imageFile.second)
-
-            if (messageId == null && messageResponse != null) {
-                messageId = messageResponse.id
-            }
-        }
-
-    }
-
-    override fun observeReadMessages(): Flow<MarkMessageAsReadEvent> {
-        return markMessagesAsRead
-    }
-
-    private fun initializeWebsocketConnection() {
-        scope.launch {
-            webSocketManager.connect(
-                onConnected = ::onConnectedWebSocket
-            )
-
-            webSocketManager.incomingMessages.collect { handleIncomingAsEvent(it) }
-        }
-    }
-
-    private suspend fun onConnectedWebSocket() {
-        webSocketManager.subscribe(WEB_SOCKETS_USER_DESTINATION_PREFIX + PRIVATE_MESSAGES)
-    }
-
-    private suspend fun handleIncomingAsEvent(
-        incomingText: String
-    ) {
-        val jsonBody = incomingText.substringAfter("\n\n").trimEnd('\u0000')
-        val event = json.decodeFromString<MessageEvent>(jsonBody)
-
-        when (event) {
-            is MessageEvent.MarkAsRead -> {
-                markMessagesAsRead.emit(event.dto.toEntity())
-            }
-
-            is MessageEvent.Message -> {
-                event.dto.toDomain()?.let { messageFlows.emit(it) }
-            }
-        }
-    }
-
-    override suspend fun markMessagesAsRead(chatId: Uuid) {
-        webSocketManager.sendTextFrame(
-            destination = MARK_AS_READ_DESTINATION,
-            payload = json.encodeToString<MarkAsReadRequest>(MarkAsReadRequest(chatId = chatId.toString()))
-        )
     }
 
     override suspend fun disconnect() {
@@ -274,18 +78,8 @@ class ChatRepositoryImpl(
     private companion object {
         const val PAGE_NUMBER_PARAMETER = "page"
         const val PAGE_SIZE_PARAMETER = "size"
-        const val CHAT_ID_PARAMETER = "chatId"
         const val RECEIVER_ID_PARAMETER = "receiverId"
-        const val PAGE_SIZE = 1000
-        const val PAGE_NUMBER = 0
-        const val MARK_AS_READ_DESTINATION = "/app/chat.markAsRead"
-        const val SEND_MESSAGE_DESTINATION = "/app/chat.privateMessage"
-        const val WEB_SOCKETS_USER_DESTINATION_PREFIX = "/user"
-        const val PRIVATE_MESSAGES = "/private/messages"
         const val CHAT_ENDPOINT = "/chat"
-        const val IMAGES_ENDPOINT = "/chat/image"
-        const val IMAGES_FILES_PARAM = "image"
-        const val CHAT_HISTORY_ENDPOINT = "/chat/history"
         const val CHAT_SUMMARY_ENDPOINT = "/chat/chatsSummary"
     }
 }

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/repository/MessageRepositoryImpl.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/repository/MessageRepositoryImpl.kt
@@ -1,0 +1,234 @@
+package net.thechance.mena.core_chat.data.repository
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.util.reflect.typeInfo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import net.thechance.mena.core_chat.data.source.local.database.MessageDao
+import net.thechance.mena.core_chat.data.source.local.database.MessageLocalDto
+import net.thechance.mena.core_chat.data.source.remote.dto.MarkAsReadRequest
+import net.thechance.mena.core_chat.data.source.remote.dto.MessageDto
+import net.thechance.mena.core_chat.data.source.remote.dto.PagedDataDto
+import net.thechance.mena.core_chat.data.source.remote.dto.SendMessageDto
+import net.thechance.mena.core_chat.data.source.remote.mapper.toDomain
+import net.thechance.mena.core_chat.data.source.remote.mapper.toEntity
+import net.thechance.mena.core_chat.data.source.remote.mapper.toLocalDto
+import net.thechance.mena.core_chat.data.source.remote.network.WebSocketManager
+import net.thechance.mena.core_chat.data.utils.MessageEvent
+import net.thechance.mena.core_chat.data.utils.buildImageMultiPartFormData
+import net.thechance.mena.core_chat.domain.entity.ImagesSource
+import net.thechance.mena.core_chat.domain.entity.MarkMessageAsReadEvent
+import net.thechance.mena.core_chat.domain.entity.Message
+import net.thechance.mena.core_chat.domain.entity.MessageContent
+import net.thechance.mena.core_chat.domain.entity.MessageStatus
+import net.thechance.mena.core_chat.domain.exception.SendMessageFailedException
+import net.thechance.mena.core_chat.domain.repository.MessageRepository
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalUuidApi::class)
+class MessageRepositoryImpl(
+    private val client: HttpClient,
+    private val webSocketManager: WebSocketManager,
+    private val messageDao: MessageDao,
+    private val json: Json,
+) : BaseRepository, MessageRepository {
+    private val messageFlows = MutableSharedFlow<Message>()
+    private val markMessagesAsRead = MutableSharedFlow<MarkMessageAsReadEvent>()
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+
+    override suspend fun loadMessages(chatId: Uuid): List<Message> {
+        return tryNetworkCall<PagedDataDto<MessageDto>>(
+            bodyType = typeInfo<PagedDataDto<MessageDto>>()
+        ) {
+            client.get(CHAT_HISTORY_ENDPOINT) {
+                parameter(CHAT_ID_PARAMETER, chatId)
+                parameter(PAGE_NUMBER_PARAMETER, PAGE_NUMBER)
+                parameter(PAGE_SIZE_PARAMETER, PAGE_SIZE)
+            }
+        }?.data?.mapNotNull { it.toDomain() } ?: emptyList()
+    }
+
+    override suspend fun deleteMessage(message: Message) {
+        messageDao.deleteMessage(message.id.toString())
+    }
+
+    override fun getLocalMessages(chatId: Uuid): Flow<List<Message>> {
+        val failedEntities = messageDao.getMessagesByChat(chatId.toString())
+        return failedEntities.map { it.toDomain() }
+    }
+
+    override fun getMessages(chatId: Uuid?): Flow<Message> {
+        if (webSocketManager.isConnected().not()) initializeWebsocketConnection()
+        return messageFlows.filter { chatId == null || it.chatId == chatId }
+    }
+
+    override suspend fun sendMessage(message: Message) {
+        val updatedMessage = message.copy(status = MessageStatus.LOADING).toLocalDto()
+        messageDao.insertMessage(updatedMessage)
+
+        try {
+            when (val content = message.content) {
+                is MessageContent.Text -> {
+                    val sendMessageDto = SendMessageDto(
+                        chatId = message.chatId.toString(),
+                        text = content.text
+                    )
+                    sendTextMessage(sendMessageDto)
+                }
+
+                is MessageContent.Images -> {
+                    val source = content.source
+                    val byteArrays =
+                        if (source is ImagesSource.Local)
+                            source.byteArrays
+                        else throw SendMessageFailedException("Failed to send message: Corrupted images")
+                    var remainingImages = byteArrays.toMutableList()
+                    sendImagesMessage(
+                        imageNames = byteArrays.mapIndexed { index, _ -> "image_$index" },
+                        images = byteArrays,
+                        chatId = message.chatId,
+                        onSuccessImage = { image ->
+                            remainingImages = remainingImages.apply { remove(image) }
+                            messageDao.updateMessageImages(
+                                id = updatedMessage.id,
+                                images = remainingImages
+                            )
+                        }
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            messageDao.updateMessageStatus(
+                updatedMessage.id,
+                MessageLocalDto.MessageStatus.FAILED
+            )
+            throw SendMessageFailedException("Failed to send message: ${e.message}")
+        }
+        messageDao.deleteMessage(updatedMessage.id)
+    }
+
+    private suspend fun sendTextMessage(sendMessageDto: SendMessageDto) {
+        if (webSocketManager.isConnected()) {
+            val messageJson = json.encodeToString(
+                SendMessageDto.serializer(),
+                sendMessageDto
+            )
+            webSocketManager.sendTextFrame(
+                destination = SEND_MESSAGE_DESTINATION,
+                payload = messageJson
+
+            )
+        } else {
+            throw SendMessageFailedException("Failed to send message")
+        }
+    }
+
+    private suspend fun sendImagesMessage(
+        imageNames: List<String>,
+        images: List<ByteArray>,
+        chatId: Uuid,
+        onSuccessImage: suspend (ByteArray) -> Unit = {}
+    ) {
+        if (images.size != imageNames.size)
+            throw SendMessageFailedException("imageNames and images must have the same size.")
+
+        val files = imageNames.zip(images)
+
+        var messageId: String? = null
+
+        files.forEachIndexed { index, imageFile ->
+            val multipart = imageFile.buildImageMultiPartFormData(
+                fieldName = IMAGES_FILES_PARAM,
+                chatId = chatId.toString(),
+                messageId = messageId
+            )
+
+            val messageResponse = tryNetworkCall<MessageDto>(
+                bodyType = typeInfo<MessageDto>()
+            ) {
+                client.post(IMAGES_ENDPOINT) {
+                    setBody(multipart)
+                }
+            }
+
+            if (messageResponse != null) onSuccessImage(imageFile.second)
+
+            if (messageId == null && messageResponse != null) {
+                messageId = messageResponse.id
+            }
+        }
+
+    }
+
+    override fun observeReadMessages(): Flow<MarkMessageAsReadEvent> {
+        return markMessagesAsRead
+    }
+
+    private fun initializeWebsocketConnection() {
+        scope.launch {
+            webSocketManager.connect(
+                onConnected = ::onConnectedWebSocket
+            )
+
+            webSocketManager.incomingMessages.collect { handleIncomingAsEvent(it) }
+        }
+    }
+
+
+    private suspend fun onConnectedWebSocket() {
+        webSocketManager.subscribe(WEB_SOCKETS_USER_DESTINATION_PREFIX + PRIVATE_MESSAGES)
+    }
+
+    private suspend fun handleIncomingAsEvent(
+        incomingText: String
+    ) {
+        val jsonBody = incomingText.substringAfter("\n\n").trimEnd('\u0000')
+        val event = json.decodeFromString<MessageEvent>(jsonBody)
+
+        when (event) {
+            is MessageEvent.MarkAsRead -> {
+                markMessagesAsRead.emit(event.dto.toEntity())
+            }
+
+            is MessageEvent.Message -> {
+                event.dto.toDomain()?.let { messageFlows.emit(it) }
+            }
+        }
+    }
+
+    override suspend fun markMessagesAsRead(chatId: Uuid) {
+        webSocketManager.sendTextFrame(
+            destination = MARK_AS_READ_DESTINATION,
+            payload = json.encodeToString<MarkAsReadRequest>(MarkAsReadRequest(chatId = chatId.toString()))
+        )
+    }
+
+    private companion object {
+        const val PAGE_NUMBER_PARAMETER = "page"
+        const val PAGE_SIZE_PARAMETER = "size"
+        const val PAGE_SIZE = 1000
+        const val PAGE_NUMBER = 0
+        const val MARK_AS_READ_DESTINATION = "/app/chat.markAsRead"
+        const val SEND_MESSAGE_DESTINATION = "/app/chat.privateMessage"
+        const val WEB_SOCKETS_USER_DESTINATION_PREFIX = "/user"
+        const val PRIVATE_MESSAGES = "/private/messages"
+        const val IMAGES_ENDPOINT = "/chat/image"
+        const val IMAGES_FILES_PARAM = "image"
+        const val CHAT_HISTORY_ENDPOINT = "/chat/history"
+        const val CHAT_ID_PARAMETER = "chatId"
+
+    }
+}

--- a/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/chat/ChatRepositoryImplTest.kt
+++ b/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/chat/ChatRepositoryImplTest.kt
@@ -77,56 +77,8 @@ class ChatRepositoryImplTest {
         repository = createChatRepository(
             httpClient = httpClient,
             webSocketManager = webSocketManager,
-            messageDao = messageDao,
             imageDownloader = imageDownloader
         )
-    }
-
-    @Test
-    fun `should return messages when loadMessages is successful`() = runTest {
-        httpClient = createHttpClient(
-            chatHistoryResponse = { defaultChatHistoryResponse() }
-        )
-        repository = createChatRepository(
-            httpClient = httpClient,
-            webSocketManager = webSocketManager,
-            messageDao = messageDao,
-            imageDownloader = imageDownloader
-        )
-
-        val result = repository.loadMessages(chatId)
-
-        assertThat(result).isNotEmpty()
-    }
-
-    @Test
-    fun `should delete message from local database when deleteMessage is called`() = runTest {
-        val message = createMessage(
-            senderId = userId,
-            chatId = chatId,
-        )
-        everySuspend { messageDao.deleteMessage(any()) } returns Unit
-
-        repository.deleteMessage(message)
-
-        verifySuspend { messageDao.deleteMessage(message.id.toString()) }
-    }
-
-    @Test
-    fun `should throw NotFoundException when loadMessages returns error`() = runTest {
-        httpClient = createHttpClient(
-            chatHistoryResponse = { mockErrorPagedResponse<MessageDto>(HttpStatusCode.NotFound) }
-        )
-        repository = createChatRepository(
-            httpClient = httpClient,
-            webSocketManager = webSocketManager,
-            messageDao = messageDao,
-            imageDownloader = imageDownloader
-        )
-
-        assertFailsWith<NotFoundException> {
-            repository.loadMessages(chatId)
-        }
     }
 
 
@@ -136,7 +88,6 @@ class ChatRepositoryImplTest {
         repository = createChatRepository(
             httpClient = httpClient,
             webSocketManager = webSocketManager,
-            messageDao = messageDao,
             imageDownloader = imageDownloader
         )
 
@@ -153,7 +104,6 @@ class ChatRepositoryImplTest {
         repository = createChatRepository(
             httpClient = httpClient,
             webSocketManager = webSocketManager,
-            messageDao = messageDao,
             imageDownloader = imageDownloader
         )
 
@@ -179,7 +129,6 @@ class ChatRepositoryImplTest {
         repository = createChatRepository(
             httpClient = httpClient,
             webSocketManager = webSocketManager,
-            messageDao = messageDao,
             imageDownloader = imageDownloader
         )
 
@@ -201,7 +150,6 @@ class ChatRepositoryImplTest {
         repository = createChatRepository(
             httpClient = httpClient,
             webSocketManager = webSocketManager,
-            messageDao = messageDao,
             imageDownloader = imageDownloader
         )
 
@@ -218,7 +166,6 @@ class ChatRepositoryImplTest {
         repository = createChatRepository(
             httpClient = httpClient,
             webSocketManager = webSocketManager,
-            messageDao = messageDao,
             imageDownloader = imageDownloader
         )
 
@@ -237,7 +184,6 @@ class ChatRepositoryImplTest {
         repository = createChatRepository(
             httpClient = httpClient,
             webSocketManager = webSocketManager,
-            messageDao = messageDao,
             imageDownloader = imageDownloader
         )
 
@@ -249,103 +195,6 @@ class ChatRepositoryImplTest {
         }
     }
 
-    @Test
-    fun `should send message successfully when websocket is connected`() = runTest {
-        every { webSocketManager.isConnected() } returns true
-        everySuspend { webSocketManager.sendTextFrame(any(), any()) } returns Unit
-        everySuspend { messageDao.insertMessage(any()) } returns Unit
-        everySuspend { messageDao.deleteMessage(any()) } returns Unit
-
-        val message = createMessage(
-            senderId = userId,
-            chatId = chatId,
-        )
-
-        repository.sendMessage(message)
-
-        verifySuspend {
-            webSocketManager.sendTextFrame(
-                destination = "/app/chat.privateMessage",
-                payload = any()
-            )
-        }
-    }
-
-    @Test
-    fun `should throw SendMessageFailedException when websocket is not connected`() = runTest {
-        every { webSocketManager.isConnected() } returns false
-        everySuspend { messageDao.insertMessage(any()) } returns Unit
-        everySuspend { messageDao.updateMessageStatus(any(), any()) } returns Unit
-
-        val message = createMessage(
-            senderId = userId,
-            chatId = chatId,
-        )
-
-        assertFailsWith<SendMessageFailedException> {
-            repository.sendMessage(message)
-        }
-    }
-
-    @Test
-    fun `should disconnect websocket when disconnect is called`() = runTest {
-        everySuspend { webSocketManager.disconnect() } returns Unit
-        repository.disconnect()
-        verifySuspend { webSocketManager.disconnect() }
-    }
-
-    @Test
-    fun `should observe read messages`() = runTest {
-        val flow = repository.observeReadMessages()
-        assertThat(flow).isNotNull()
-    }
-
-    @Test
-    fun `should return local messages from database when getLocalMessages is called`() = runTest {
-        val message1 = createMessage(senderId = userId, chatId = chatId)
-        val message2 = createMessage(senderId = userId, chatId = chatId)
-        val messageEntities = listOf(
-            message1.toLocalDto(),
-            message2.toLocalDto()
-        )
-
-        everySuspend { messageDao.getMessagesByChat(chatId.toString()) } returns flowOf(messageEntities)
-
-        val result = repository.getLocalMessages(chatId).first()
-
-
-        assertThat(result).isNotEmpty()
-        assertThat(result.size).isEqualTo(2)
-        verifySuspend { messageDao.getMessagesByChat(chatId.toString()) }
-    }
-
-    @Test
-    fun `should return empty list when no local messages exist for chat`() = runTest {
-        everySuspend { messageDao.getMessagesByChat(chatId.toString()) } returns flowOf(emptyList())
-
-        val result = repository.getLocalMessages(chatId).first()
-
-        assertThat(result.isEmpty()).isTrue()
-        verifySuspend { messageDao.getMessagesByChat(chatId.toString()) }
-    }
-
-    @Test
-    fun `should return flow when getMessages is called and websocket is connected`() = runTest {
-        every { webSocketManager.isConnected() } returns true
-        everySuspend { authRepository.getAccessToken() } returns "test-token"
-        everySuspend { webSocketManager.connect(any()) } returns Unit
-        everySuspend { webSocketManager.subscribe(any()) } returns Unit
-        everySuspend { webSocketManager.sendTextFrame(any(), any()) } returns Unit
-        every { webSocketManager.incomingMessages } returns MutableSharedFlow<String>().apply {
-            tryEmit(
-                "test-message"
-            )
-        }
-
-        val flow = repository.getMessages(chatId)
-
-        assertThat(flow).isNotNull()
-    }
 
     @Test
     fun `downloadImage should call imageDownloader and run successfully when downloadImageToGallery return true`() =
@@ -384,7 +233,6 @@ class ChatRepositoryImplTest {
         repository = createChatRepository(
             httpClient = httpClient,
             webSocketManager = webSocketManager,
-            messageDao = messageDao,
             imageDownloader = imageDownloader
         )
 
@@ -404,7 +252,6 @@ class ChatRepositoryImplTest {
         repository = createChatRepository(
             httpClient = httpClient,
             webSocketManager = webSocketManager,
-            messageDao = messageDao,
             imageDownloader = imageDownloader
         )
 
@@ -413,74 +260,8 @@ class ChatRepositoryImplTest {
         }
     }
 
-    @Test
-    fun `should send image message successfully when websocket connected and images uploaded`() = runTest {
-        every { webSocketManager.isConnected() } returns true
-        everySuspend { messageDao.insertMessage(any()) } returns Unit
-        everySuspend { messageDao.updateMessageImages(any(), any()) } returns Unit
-        everySuspend { messageDao.deleteMessage(any()) } returns Unit
-
-        httpClient = createHttpClient(
-            imagesResponse = { defaultUploadImagesResponse() }
-        )
-        repository = createChatRepository(
-            httpClient = httpClient,
-            webSocketManager = webSocketManager,
-            messageDao = messageDao,
-            imageDownloader = imageDownloader
-        )
-
-        val byteArrays = listOf(ByteArray(10), ByteArray(20))
-        val message = createMessage(
-            senderId = userId,
-            chatId = chatId,
-            content = MessageContent.Images(ImagesSource.Local(byteArrays))
-        )
-
-        repository.sendMessage(message)
-
-        verifySuspend { messageDao.insertMessage(any()) }
-        verifySuspend { messageDao.updateMessageImages(any(), any()) }
-        verifySuspend { messageDao.deleteMessage(any()) }
-    }
-
-
-    @Test
-    fun `should mark message as FAILED when image upload throws exception`() = runTest {
-        every { webSocketManager.isConnected() } returns true
-        everySuspend { messageDao.insertMessage(any()) } returns Unit
-        everySuspend { messageDao.updateMessageStatus(any(), any()) } returns Unit
-
-        // Simulate failed upload
-        httpClient = createHttpClient(
-            imagesResponse = { respondError(HttpStatusCode.InternalServerError) }
-        )
-        repository = createChatRepository(
-            httpClient = httpClient,
-            webSocketManager = webSocketManager,
-            messageDao = messageDao,
-            imageDownloader = imageDownloader
-        )
-
-        val byteArrays = listOf(ByteArray(10))
-        val message = createMessage(
-            senderId = userId,
-            chatId = chatId,
-            content = MessageContent.Images(ImagesSource.Local(byteArrays))
-        )
-
-        assertFailsWith<SendMessageFailedException> {
-            repository.sendMessage(message)
-        }
-
-        verifySuspend { messageDao.updateMessageStatus(any(), MessageLocalDto.MessageStatus.FAILED) }
-    }
-
-
     private companion object {
-        private val chatId = Uuid.random()
         private val userId = Uuid.random()
-
         const val IMAGE_URL = "http://test.com/image.jpg"
     }
 

--- a/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/chat/MessageRepositoryImplTest.kt
+++ b/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/chat/MessageRepositoryImplTest.kt
@@ -1,0 +1,274 @@
+@file:OptIn(ExperimentalUuidApi::class, ExperimentalTime::class)
+
+package net.thechance.mena.core_chat.data.chat
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isNotNull
+import assertk.assertions.isTrue
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import net.thechance.mena.core_chat.data.contacts.fakes.createMessage
+import net.thechance.mena.core_chat.data.createHttpClient
+import net.thechance.mena.core_chat.data.createMessageRepository
+import net.thechance.mena.core_chat.data.defaultChatHistoryResponse
+import net.thechance.mena.core_chat.data.defaultUploadImagesResponse
+import net.thechance.mena.core_chat.data.mockErrorPagedResponse
+import net.thechance.mena.core_chat.data.repository.MessageRepositoryImpl
+import net.thechance.mena.core_chat.data.source.local.database.MessageDao
+import net.thechance.mena.core_chat.data.source.local.database.MessageLocalDto
+import net.thechance.mena.core_chat.data.source.remote.dto.MessageDto
+import net.thechance.mena.core_chat.data.source.remote.mapper.toLocalDto
+import net.thechance.mena.core_chat.data.source.remote.network.WebSocketManager
+import net.thechance.mena.core_chat.domain.entity.ImagesSource
+import net.thechance.mena.core_chat.domain.entity.MessageContent
+import net.thechance.mena.core_chat.domain.exception.NotFoundException
+import net.thechance.mena.core_chat.domain.exception.SendMessageFailedException
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.time.ExperimentalTime
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+class MessageRepositoryImplTest {
+
+    private lateinit var httpClient: HttpClient
+    private lateinit var repository: MessageRepositoryImpl
+    private lateinit var webSocketManager: WebSocketManager
+    private lateinit var messageDao: MessageDao
+
+    @BeforeTest
+    fun setUp() {
+        httpClient = createHttpClient()
+        webSocketManager = mock<WebSocketManager>()
+        messageDao = mock<MessageDao>()
+
+        repository = createMessageRepository(
+            webSocketManager = webSocketManager,
+            messageDao = messageDao,
+            httpClient = httpClient
+        )
+    }
+
+    @Test
+    fun `should return messages when loadMessages is successful`() = runTest {
+        httpClient = createHttpClient(
+            chatHistoryResponse = { defaultChatHistoryResponse() }
+        )
+        repository = createMessageRepository(
+            webSocketManager = mock<WebSocketManager>(),
+            messageDao = mock<MessageDao>(),
+            httpClient = httpClient
+        )
+
+        val result = repository.loadMessages(chatId)
+
+        assertThat(result).isNotEmpty()
+    }
+
+    @Test
+    fun `should delete message from local database when deleteMessage is called`() = runTest {
+        val message = createMessage(
+            senderId = userId,
+            chatId = chatId,
+        )
+        everySuspend { messageDao.deleteMessage(any()) } returns Unit
+
+        repository.deleteMessage(message)
+
+        verifySuspend { messageDao.deleteMessage(message.id.toString()) }
+    }
+
+    @Test
+    fun `should throw NotFoundException when loadMessages returns error`() = runTest {
+        httpClient = createHttpClient(
+            chatHistoryResponse = { mockErrorPagedResponse<MessageDto>(HttpStatusCode.NotFound) }
+        )
+        repository = createMessageRepository(
+            httpClient = httpClient,
+            webSocketManager = webSocketManager,
+            messageDao = messageDao,
+        )
+
+        assertFailsWith<NotFoundException> {
+            repository.loadMessages(chatId)
+        }
+    }
+
+    @Test
+    fun `should send message successfully when websocket is connected`() = runTest {
+        every { webSocketManager.isConnected() } returns true
+        everySuspend { webSocketManager.sendTextFrame(any(), any()) } returns Unit
+        everySuspend { messageDao.insertMessage(any()) } returns Unit
+        everySuspend { messageDao.deleteMessage(any()) } returns Unit
+
+        val message = createMessage(
+            senderId = userId,
+            chatId = chatId,
+        )
+
+        repository.sendMessage(message)
+
+        verifySuspend {
+            webSocketManager.sendTextFrame(
+                destination = "/app/chat.privateMessage",
+                payload = any()
+            )
+        }
+    }
+
+    @Test
+    fun `should throw SendMessageFailedException when websocket is not connected`() = runTest {
+        every { webSocketManager.isConnected() } returns false
+        everySuspend { messageDao.insertMessage(any()) } returns Unit
+        everySuspend { messageDao.updateMessageStatus(any(), any()) } returns Unit
+
+        val message = createMessage(
+            senderId = userId,
+            chatId = chatId,
+        )
+
+        assertFailsWith<SendMessageFailedException> {
+            repository.sendMessage(message)
+        }
+    }
+
+
+    @Test
+    fun `should observe read messages`() = runTest {
+        val flow = repository.observeReadMessages()
+        assertThat(flow).isNotNull()
+    }
+
+    @Test
+    fun `should return local messages from database when getLocalMessages is called`() = runTest {
+        val message1 = createMessage(senderId = userId, chatId = chatId)
+        val message2 = createMessage(senderId = userId, chatId = chatId)
+        val messageEntities = listOf(
+            message1.toLocalDto(),
+            message2.toLocalDto()
+        )
+
+        everySuspend { messageDao.getMessagesByChat(chatId.toString()) } returns flowOf(
+            messageEntities
+        )
+
+        val result = repository.getLocalMessages(chatId).first()
+
+
+        assertThat(result).isNotEmpty()
+        assertThat(result.size).isEqualTo(2)
+        verifySuspend { messageDao.getMessagesByChat(chatId.toString()) }
+    }
+
+    @Test
+    fun `should return empty list when no local messages exist for chat`() = runTest {
+        everySuspend { messageDao.getMessagesByChat(chatId.toString()) } returns flowOf(emptyList())
+
+        val result = repository.getLocalMessages(chatId).first()
+
+        assertThat(result.isEmpty()).isTrue()
+        verifySuspend { messageDao.getMessagesByChat(chatId.toString()) }
+    }
+
+    @Test
+    fun `should return flow when getMessages is called and websocket is connected`() = runTest {
+        every { webSocketManager.isConnected() } returns true
+        everySuspend { webSocketManager.connect(any()) } returns Unit
+        everySuspend { webSocketManager.subscribe(any()) } returns Unit
+        everySuspend { webSocketManager.sendTextFrame(any(), any()) } returns Unit
+        every { webSocketManager.incomingMessages } returns MutableSharedFlow<String>().apply {
+            tryEmit(
+                "test-message"
+            )
+        }
+
+        val flow = repository.getMessages(chatId)
+
+        assertThat(flow).isNotNull()
+    }
+
+    @Test
+    fun `should send image message successfully when websocket connected and images uploaded`() =
+        runTest {
+            every { webSocketManager.isConnected() } returns true
+            everySuspend { messageDao.insertMessage(any()) } returns Unit
+            everySuspend { messageDao.updateMessageImages(any(), any()) } returns Unit
+            everySuspend { messageDao.deleteMessage(any()) } returns Unit
+
+            httpClient = createHttpClient(
+                imagesResponse = { defaultUploadImagesResponse() }
+            )
+            repository = createMessageRepository(
+                httpClient = httpClient,
+                webSocketManager = webSocketManager,
+                messageDao = messageDao
+            )
+
+            val byteArrays = listOf(ByteArray(10), ByteArray(20))
+            val message = createMessage(
+                senderId = userId,
+                chatId = chatId,
+                content = MessageContent.Images(ImagesSource.Local(byteArrays))
+            )
+
+            repository.sendMessage(message)
+
+            verifySuspend { messageDao.insertMessage(any()) }
+            verifySuspend { messageDao.updateMessageImages(any(), any()) }
+            verifySuspend { messageDao.deleteMessage(any()) }
+        }
+
+    @Test
+    fun `should mark message as FAILED when image upload throws exception`() = runTest {
+        every { webSocketManager.isConnected() } returns true
+        everySuspend { messageDao.insertMessage(any()) } returns Unit
+        everySuspend { messageDao.updateMessageStatus(any(), any()) } returns Unit
+
+        // Simulate failed upload
+        httpClient = createHttpClient(
+            imagesResponse = { respondError(HttpStatusCode.InternalServerError) }
+        )
+        repository = createMessageRepository(
+            httpClient = httpClient,
+            webSocketManager = webSocketManager,
+            messageDao = messageDao
+        )
+
+        val byteArrays = listOf(ByteArray(10))
+        val message = createMessage(
+            senderId = userId,
+            chatId = chatId,
+            content = MessageContent.Images(ImagesSource.Local(byteArrays))
+        )
+
+        assertFailsWith<SendMessageFailedException> {
+            repository.sendMessage(message)
+        }
+
+        verifySuspend {
+            messageDao.updateMessageStatus(
+                any(),
+                MessageLocalDto.MessageStatus.FAILED
+            )
+        }
+    }
+
+    private companion object {
+        private val chatId = Uuid.random()
+        private val userId = Uuid.random()
+    }
+}

--- a/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/utils.kt
+++ b/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/utils.kt
@@ -26,6 +26,7 @@ import net.thechance.mena.core_chat.data.contacts.fakes.createMessageDto
 import net.thechance.mena.core_chat.data.contacts.fakes.sampleContactDto
 import net.thechance.mena.core_chat.data.repository.ChatRepositoryImpl
 import net.thechance.mena.core_chat.data.repository.ContactsRepositoryImpl
+import net.thechance.mena.core_chat.data.repository.MessageRepositoryImpl
 import net.thechance.mena.core_chat.data.source.local.database.MessageDao
 import net.thechance.mena.core_chat.data.source.remote.dto.ChatDto
 import net.thechance.mena.core_chat.data.source.remote.dto.ChatSummaryDto
@@ -172,7 +173,6 @@ fun createRepository(
 fun createChatRepository(
     httpClient: HttpClient? = null,
     webSocketManager: WebSocketManager,
-    messageDao: MessageDao,
     imageDownloader: ImageDownloader,
     chatHistoryResponse: (suspend MockRequestHandleScope.() -> HttpResponseData)? = null,
     chatResponse: (suspend MockRequestHandleScope.() -> HttpResponseData)? = null,
@@ -188,12 +188,22 @@ fun createChatRepository(
     return ChatRepositoryImpl(
         client = httpClient ?: defaultClient,
         webSocketManager = webSocketManager,
-        messageDao = messageDao,
-        json = jsonSerialization,
         imageDownloader = imageDownloader
     )
-}
 
+}
+fun createMessageRepository(
+    httpClient: HttpClient,
+    webSocketManager: WebSocketManager,
+    messageDao: MessageDao,
+): MessageRepositoryImpl {
+    return MessageRepositoryImpl(
+        webSocketManager = webSocketManager,
+        messageDao = messageDao,
+        client =httpClient,
+        json = jsonSerialization
+    )
+}
 
 fun createHttpClient(
     contactsResponse: (suspend MockRequestHandleScope.() -> HttpResponseData)? = null,

--- a/core_chat_domain/src/commonMain/kotlin/net/thechance/mena/core_chat/domain/repository/ChatRepository.kt
+++ b/core_chat_domain/src/commonMain/kotlin/net/thechance/mena/core_chat/domain/repository/ChatRepository.kt
@@ -1,27 +1,17 @@
 package net.thechance.mena.core_chat.domain.repository
 
-import kotlinx.coroutines.flow.Flow
 import net.thechance.mena.core_chat.domain.entity.Chat
 import net.thechance.mena.core_chat.domain.entity.ChatSummary
-import net.thechance.mena.core_chat.domain.entity.MarkMessageAsReadEvent
-import net.thechance.mena.core_chat.domain.entity.Message
 import net.thechance.mena.core_chat.domain.model.PagedData
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 @ExperimentalUuidApi
 interface ChatRepository {
-    suspend fun sendMessage(message: Message)
-    suspend fun loadMessages(chatId: Uuid): List<Message>
-    suspend fun deleteMessage(message: Message)
-    fun getMessages(chatId: Uuid? = null): Flow<Message>
-    fun observeReadMessages(): Flow<MarkMessageAsReadEvent>
     suspend fun getChatByContactUserId(userId: Uuid): Chat
-    suspend fun getChatById(chatId : Uuid): Chat
+    suspend fun getChatById(chatId: Uuid): Chat
     suspend fun disconnect()
-    fun getLocalMessages(chatId: Uuid): Flow<List<Message>>
     suspend fun getChatsSummary(pageNumber: Int, pageSize: Int): PagedData<ChatSummary>
     suspend fun getChatSummaryById(chatId: Uuid): ChatSummary
     suspend fun downloadImage(url: String)
-    suspend fun markMessagesAsRead(chatId: Uuid)
 }

--- a/core_chat_domain/src/commonMain/kotlin/net/thechance/mena/core_chat/domain/repository/MessageRepository.kt
+++ b/core_chat_domain/src/commonMain/kotlin/net/thechance/mena/core_chat/domain/repository/MessageRepository.kt
@@ -1,0 +1,18 @@
+package net.thechance.mena.core_chat.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+import net.thechance.mena.core_chat.domain.entity.MarkMessageAsReadEvent
+import net.thechance.mena.core_chat.domain.entity.Message
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@ExperimentalUuidApi
+interface MessageRepository {
+    suspend fun sendMessage(message: Message)
+    suspend fun loadMessages(chatId: Uuid): List<Message>
+    suspend fun deleteMessage(message: Message)
+    fun getMessages(chatId: Uuid? = null): Flow<Message>
+    fun observeReadMessages(): Flow<MarkMessageAsReadEvent>
+    fun getLocalMessages(chatId: Uuid): Flow<List<Message>>
+    suspend fun markMessagesAsRead(chatId: Uuid)
+}

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/di/viewModelModule.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/di/viewModelModule.kt
@@ -17,7 +17,8 @@ internal val viewModelModule = module {
             contactsRepository = get(),
             effector = get(),
             chatRepository = get(),
-            balanceRepository = get()
+            balanceRepository = get(),
+            messageRepository = get()
         )
     }
     viewModel {
@@ -33,5 +34,5 @@ internal val viewModelModule = module {
             dispatcher = get(named(CHAT_IO_DISPATCHER))
         )
     }
-    viewModel { ChatViewModel(chatRepository = get(), userRepository =  get(), chatArgs =  get(), effector = get(), permissionsController = get(), dispatcher = get(named(CHAT_IO_DISPATCHER))) }
+    viewModel { ChatViewModel(chatRepository = get(), userRepository =  get(), chatArgs =  get(), effector = get(), permissionsController = get(), dispatcher = get(named(CHAT_IO_DISPATCHER)), messageRepository = get()) }
 }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModel.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModel.kt
@@ -27,6 +27,7 @@ import net.thechance.mena.core_chat.domain.entity.MessageContent
 import net.thechance.mena.core_chat.domain.entity.MessageStatus
 import net.thechance.mena.core_chat.domain.entity.User
 import net.thechance.mena.core_chat.domain.repository.ChatRepository
+import net.thechance.mena.core_chat.domain.repository.MessageRepository
 import net.thechance.mena.core_chat.domain.repository.UserRepository
 import net.thechance.mena.core_chat.presentation.components.SnackBarData
 import net.thechance.mena.core_chat.presentation.navigation.ChatEffector
@@ -40,6 +41,7 @@ import kotlin.uuid.Uuid
 
 class ChatViewModel(
     private val chatRepository: ChatRepository,
+    private val messageRepository: MessageRepository,
     private val userRepository: UserRepository,
     chatArgs: ChatArgs,
     effector: ChatEffector,
@@ -56,7 +58,6 @@ class ChatViewModel(
     private var newMessages: List<Message> = emptyList()
 
     private var hasResentPendingMessages = false
-
 
 
     init {
@@ -80,7 +81,7 @@ class ChatViewModel(
         }
     }
 
-    private fun getUserInfo(){
+    private fun getUserInfo() {
         tryToExecute(
             execute = { userRepository.getUserInfo() },
             onSuccess = ::onGetUserDataSuccess,
@@ -89,12 +90,17 @@ class ChatViewModel(
     }
 
     private fun onGetUserDataSuccess(user: User) {
-        updateState { state -> state.copy(userData = UserData(
-            firstName = user.firstName,
-            lastName = user.lastName,
-            imageUrl = user.imageUrl.orEmpty()
-        )) }
+        updateState { state ->
+            state.copy(
+                userData = UserData(
+                    firstName = user.firstName,
+                    lastName = user.lastName,
+                    imageUrl = user.imageUrl.orEmpty()
+                )
+            )
+        }
     }
+
     private fun onGetUserDataError(t: Throwable) {
         showSnackBar(
             titleStringResource = Res.string.error,
@@ -102,6 +108,7 @@ class ChatViewModel(
             isError = true
         )
     }
+
     private fun onGetChatSuccess(chat: Chat) {
         updateState { state ->
             state.copy(
@@ -151,7 +158,7 @@ class ChatViewModel(
         )
 
         tryToExecute(
-            execute = { chatRepository.sendMessage(message.toEntity()) },
+            execute = { messageRepository.sendMessage(message.toEntity()) },
             onSuccess = { onSendMessageSuccess(message) }
         )
     }
@@ -180,7 +187,7 @@ class ChatViewModel(
         updateState { state -> state.copy(inputMessage = "") }
 
         tryToExecute(
-            execute = { chatRepository.sendMessage(message.toEntity()) },
+            execute = { messageRepository.sendMessage(message.toEntity()) },
             onSuccess = { onSendMessageSuccess(message) }
         )
     }
@@ -208,7 +215,7 @@ class ChatViewModel(
         val failedMessage = state.value.failedMessageToReSend ?: return
 
         tryToExecute(
-            execute = { chatRepository.deleteMessage(failedMessage.toEntity()) },
+            execute = { messageRepository.deleteMessage(failedMessage.toEntity()) },
             onSuccess = { onDeleteFailedMessageSuccess(failedMessage) }
         )
     }
@@ -243,7 +250,7 @@ class ChatViewModel(
 
     private fun subscribeToNewMessages(chatId: Uuid) {
         tryToCollect(
-            collect = { chatRepository.getMessages(chatId) },
+            collect = { messageRepository.getMessages(chatId) },
             onCollect = ::onCollectNewMessage,
             onError = {
                 showSnackBar(
@@ -260,13 +267,13 @@ class ChatViewModel(
 
         newMessages = newMessages.toMutableList().apply { add(0, message) }
         rebuildUiMessages()
-        chatRepository.markMessagesAsRead(message.chatId)
+        messageRepository.markMessagesAsRead(message.chatId)
 
     }
 
     private fun subscribeToPendingMessages(chatId: Uuid) {
         tryToCollect(
-            collect = { chatRepository.getLocalMessages(chatId) },
+            collect = { messageRepository.getLocalMessages(chatId) },
             onCollect = ::onCollectPendingMessages
         )
     }
@@ -288,7 +295,7 @@ class ChatViewModel(
 
     private fun loadChatHistory(chatId: Uuid) {
         tryToExecute(
-            execute = { chatRepository.loadMessages(chatId) },
+            execute = { messageRepository.loadMessages(chatId) },
             onSuccess = ::onLoadChatHistorySuccess,
             onError = { showSnackBar(Res.string.error, Res.string.error_cant_get_messages, true) }
         )
@@ -297,13 +304,13 @@ class ChatViewModel(
     private suspend fun onLoadChatHistorySuccess(messages: List<Message>) {
         messagesHistoryCache = messages
         rebuildUiMessages()
-        chatRepository.markMessagesAsRead(state.value.chatId ?: return)
+        messageRepository.markMessagesAsRead(state.value.chatId ?: return)
 
     }
 
     private fun observeReadMessages() {
         tryToCollect(
-            collect = { chatRepository.observeReadMessages() },
+            collect = { messageRepository.observeReadMessages() },
             onCollect = ::onCollectReadMessagesEvent
         )
     }
@@ -422,9 +429,11 @@ class ChatViewModel(
     private fun onCameraPermissionGranted() {
         updateState { it.copy(isCameraOpen = true, isAttachmentsOverlayVisible = false) }
     }
+
     override fun onCameraClosed() {
         updateState { it.copy(isCameraOpen = false) }
     }
+
     override fun onCloseAttachmentClicked() {
         updateState { it.copy(isAttachmentsOverlayVisible = false) }
     }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeViewModel.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeViewModel.kt
@@ -15,6 +15,7 @@ import net.thechance.mena.core_chat.domain.entity.MessageContent
 import net.thechance.mena.core_chat.domain.model.PagedData
 import net.thechance.mena.core_chat.domain.repository.ChatRepository
 import net.thechance.mena.core_chat.domain.repository.ContactsRepository
+import net.thechance.mena.core_chat.domain.repository.MessageRepository
 import net.thechance.mena.core_chat.presentation.components.SnackBarData
 import net.thechance.mena.core_chat.presentation.navigation.ChatDetailsRoute
 import net.thechance.mena.core_chat.presentation.navigation.ChatEffector
@@ -33,6 +34,7 @@ import kotlin.uuid.ExperimentalUuidApi
 class HomeViewModel(
     private val contactsRepository: ContactsRepository,
     private val chatRepository: ChatRepository,
+    private val messageRepository: MessageRepository,
     private val balanceRepository: BalanceRepository,
     effector: ChatEffector
 ) : BaseViewModel<HomeScreenState>(HomeScreenState(), effector), HomeScreenInteractionListener {
@@ -58,7 +60,7 @@ class HomeViewModel(
 
     private fun listenToMarkAsReadEvent() {
         tryToCollect(
-            collect = { chatRepository.observeReadMessages() },
+            collect = { messageRepository.observeReadMessages() },
             onCollect = ::onCollectMarkAsReadEvent,
             onError = { },
         )
@@ -78,7 +80,7 @@ class HomeViewModel(
 
     private fun listenToIncomingMessages() {
         tryToCollect(
-            collect = { chatRepository.getMessages() },
+            collect = {messageRepository.getMessages() },
             onCollect = ::onCollectMessage,
             onError = { },
         )

--- a/core_chat_presentation/src/commonTest/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModelTest.kt
+++ b/core_chat_presentation/src/commonTest/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModelTest.kt
@@ -16,7 +16,6 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
-import dev.mokkery.verify
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -35,6 +34,7 @@ import net.thechance.mena.core_chat.domain.entity.MessageContent
 import net.thechance.mena.core_chat.domain.entity.MessageStatus
 import net.thechance.mena.core_chat.domain.entity.User
 import net.thechance.mena.core_chat.domain.repository.ChatRepository
+import net.thechance.mena.core_chat.domain.repository.MessageRepository
 import net.thechance.mena.core_chat.domain.repository.UserRepository
 import net.thechance.mena.core_chat.presentation.components.SnackBarData
 import net.thechance.mena.core_chat.presentation.navigation.ChatEffector
@@ -48,7 +48,8 @@ import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalUuidApi::class, ExperimentalCoroutinesApi::class)
 class ChatViewModelTest {
-    private val repository = mock<ChatRepository>()
+    private val chatRepository = mock<ChatRepository>()
+    private val messageRepository = mock<MessageRepository>()
     private val userRepository = mock<UserRepository>()
     private val chatArgs = mock<ChatArgs>()
     private val permissionsController = mock<PermissionsController>()
@@ -64,13 +65,21 @@ class ChatViewModelTest {
         every { chatArgs.chatId } returns chatId.toString()
         every { chatArgs.chatName } returns chatName
 
-        everySuspend { repository.getChatById(chatId) } returns mockChat
-        everySuspend { repository.loadMessages(chatId) } returns emptyList()
-        everySuspend { repository.getLocalMessages(chatId) } returns flowOf(emptyList())
-        every { repository.getMessages(chatId) } returns flowOf()
-        every { repository.observeReadMessages() } returns flowOf()
+        everySuspend { chatRepository.getChatById(chatId) } returns mockChat
+        everySuspend { messageRepository.loadMessages(chatId) } returns emptyList()
+        everySuspend { messageRepository.getLocalMessages(chatId) } returns flowOf(emptyList())
+        every { messageRepository.getMessages(chatId) } returns flowOf()
+        every { messageRepository.observeReadMessages() } returns flowOf()
 
-        chatViewModel = ChatViewModel(repository, userRepository, chatArgs, effector, permissionsController, testDispatcher)
+        chatViewModel = ChatViewModel(
+            chatRepository,
+            messageRepository,
+            userRepository,
+            chatArgs,
+            effector,
+            permissionsController,
+            testDispatcher
+        )
         testDispatcher.scheduler.advanceUntilIdle()
     }
 
@@ -81,13 +90,21 @@ class ChatViewModelTest {
 
     @Test
     fun `init should update chat list when its loaded messages successfully`() {
-        everySuspend { repository.getChatById(chatId) } returns mockChat
-        everySuspend { repository.loadMessages(chatId) } returns messages
-        everySuspend { repository.getLocalMessages(chatId) } returns flowOf(emptyList())
-        every { repository.getMessages(chatId) } returns flowOf()
-        every { repository.observeReadMessages() } returns flowOf()
+        everySuspend { chatRepository.getChatById(chatId) } returns mockChat
+        everySuspend { messageRepository.loadMessages(chatId) } returns messages
+        everySuspend { messageRepository.getLocalMessages(chatId) } returns flowOf(emptyList())
+        every { messageRepository.getMessages(chatId) } returns flowOf()
+        every { messageRepository.observeReadMessages() } returns flowOf()
 
-        chatViewModel = ChatViewModel(repository, userRepository, chatArgs, effector, permissionsController, testDispatcher)
+        chatViewModel = ChatViewModel(
+            chatRepository,
+            messageRepository,
+            userRepository,
+            chatArgs,
+            effector,
+            permissionsController,
+            testDispatcher
+        )
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(
@@ -99,13 +116,21 @@ class ChatViewModelTest {
 
     @Test
     fun `init should send snack bar effect when its LOADING the messages failed`() {
-        everySuspend { repository.getChatById(chatId) } returns mockChat
-        everySuspend { repository.loadMessages(chatId) } throws Exception()
-        everySuspend { repository.getLocalMessages(chatId) } returns flowOf(emptyList())
-        every { repository.getMessages(chatId) } returns flowOf()
-        every { repository.observeReadMessages() } returns flowOf()
+        everySuspend { chatRepository.getChatById(chatId) } returns mockChat
+        everySuspend { messageRepository.loadMessages(chatId) } throws Exception()
+        everySuspend { messageRepository.getLocalMessages(chatId) } returns flowOf(emptyList())
+        every { messageRepository.getMessages(chatId) } returns flowOf()
+        every { messageRepository.observeReadMessages() } returns flowOf()
 
-        chatViewModel = ChatViewModel(repository, userRepository, chatArgs, effector, permissionsController, testDispatcher)
+        chatViewModel = ChatViewModel(
+            chatRepository,
+            messageRepository,
+            userRepository,
+            chatArgs,
+            effector,
+            permissionsController,
+            testDispatcher
+        )
         testDispatcher.scheduler.advanceUntilIdle()
 
         verifySuspend {
@@ -120,13 +145,21 @@ class ChatViewModelTest {
 
     @Test
     fun `init should update uiMessage and chatListItems when receive new message`() {
-        everySuspend { repository.getChatById(chatId) } returns mockChat
-        everySuspend { repository.loadMessages(chatId) } returns emptyList()
-        everySuspend { repository.getLocalMessages(chatId) } returns flowOf(emptyList())
-        every { repository.getMessages(chatId) } returns flowOf(messages.first())
-        every { repository.observeReadMessages() } returns flowOf()
-
-        chatViewModel = ChatViewModel(repository, userRepository, chatArgs, effector, permissionsController, testDispatcher)
+        everySuspend { chatRepository.getChatById(chatId) } returns mockChat
+        everySuspend { messageRepository.loadMessages(chatId) } returns emptyList()
+        everySuspend { messageRepository.getLocalMessages(chatId) } returns flowOf(emptyList())
+        every { messageRepository.getMessages(chatId) } returns flowOf(messages.first())
+        every { messageRepository.observeReadMessages() } returns flowOf()
+        messageRepository
+        chatViewModel = ChatViewModel(
+            chatRepository,
+            messageRepository,
+            userRepository,
+            chatArgs,
+            effector,
+            permissionsController,
+            testDispatcher
+        )
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(
@@ -136,11 +169,20 @@ class ChatViewModelTest {
             listOf(messages.first().toUi(chatRequesterId))
         )
     }
+
     @Test
     fun `init should update user data when receive user data from repository`() {
 
-        everySuspend {userRepository.getUserInfo() } returns user
-        chatViewModel = ChatViewModel(repository, userRepository, chatArgs, effector, permissionsController, testDispatcher)
+        everySuspend { userRepository.getUserInfo() } returns user
+        chatViewModel = ChatViewModel(
+            chatRepository,
+            messageRepository,
+            userRepository,
+            chatArgs,
+            effector,
+            permissionsController,
+            testDispatcher
+        )
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(chatViewModel.state.value.userData.firstName).isEqualTo(user.firstName)
@@ -187,7 +229,7 @@ class ChatViewModelTest {
                 inputMessage = inputMessage
             )
         }
-        everySuspend { repository.sendMessage(any()) } returns Unit
+        everySuspend { messageRepository.sendMessage(any()) } returns Unit
 
         chatViewModel.onSendMessageClicked()
         testDispatcher.scheduler.advanceUntilIdle()
@@ -206,7 +248,7 @@ class ChatViewModelTest {
             )
         }
 
-        everySuspend { repository.sendMessage(any()) } throws Exception("Send failed")
+        everySuspend { messageRepository.sendMessage(any()) } throws Exception("Send failed")
 
         chatViewModel.onSendMessageClicked()
         testDispatcher.scheduler.advanceUntilIdle()
@@ -239,7 +281,7 @@ class ChatViewModelTest {
             )
         }
 
-        everySuspend { repository.deleteMessage(any()) } returns Unit
+        everySuspend { messageRepository.deleteMessage(any()) } returns Unit
 
         chatViewModel.onDeleteFailedMessageClicked()
         testDispatcher.scheduler.advanceUntilIdle()
@@ -261,14 +303,14 @@ class ChatViewModelTest {
             )
         }
 
-        everySuspend { repository.sendMessage(any()) } returns Unit
+        everySuspend { messageRepository.sendMessage(any()) } returns Unit
 
         chatViewModel.onResendMessageClicked()
         testDispatcher.scheduler.advanceUntilIdle()
 
         val finalMessages = chatViewModel.state.value.chatListItems.currentUiMessages()
         assertThat(finalMessages.isEmpty()).isTrue()
-        verifySuspend { repository.sendMessage(any()) }
+        verifySuspend { messageRepository.sendMessage(any()) }
     }
 
     @Test
@@ -321,19 +363,19 @@ class ChatViewModelTest {
 
     @Test
     fun `onDownloadImageClicked should call repository and show success snackbar on success`() {
-        everySuspend { repository.downloadImage(imageUrl) } returns Unit
+        everySuspend { chatRepository.downloadImage(imageUrl) } returns Unit
 
         chatViewModel.onDownloadImageClicked(imageUrl)
         testDispatcher.scheduler.advanceUntilIdle()
 
-        verifySuspend { repository.downloadImage(imageUrl) }
+        verifySuspend { chatRepository.downloadImage(imageUrl) }
         verifySuspend { effector.showSnackBar(any()) }
     }
 
     @Test
     fun `onDownloadImageClicked should show error snackbar on failure`() {
 
-        everySuspend { repository.downloadImage(imageUrl) } throws Exception()
+        everySuspend { chatRepository.downloadImage(imageUrl) } throws Exception()
 
         chatViewModel.onDownloadImageClicked(imageUrl)
         testDispatcher.scheduler.advanceUntilIdle()
@@ -362,15 +404,15 @@ class ChatViewModelTest {
 
 
     @Test
-    fun `onCameraClicked should start getting camera permission when user click it`(){
+    fun `onCameraClicked should start getting camera permission when user click it`() {
         chatViewModel.onCameraClicked()
         testDispatcher.scheduler.advanceUntilIdle()
-        verifySuspend {permissionsController.providePermission(permission = Permission.CAMERA)}
+        verifySuspend { permissionsController.providePermission(permission = Permission.CAMERA) }
     }
 
     @Test
-    fun `onCameraClicked should open camera when permission is granted`(){
-        everySuspend {  permissionsController.providePermission(permission = Permission.CAMERA)} returns Unit
+    fun `onCameraClicked should open camera when permission is granted`() {
+        everySuspend { permissionsController.providePermission(permission = Permission.CAMERA) } returns Unit
         chatViewModel.onCameraClicked()
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -378,8 +420,10 @@ class ChatViewModelTest {
     }
 
     @Test
-    fun `onCameraClicked should not open camera when camera permission is declined by user`(){
-        everySuspend {  permissionsController.providePermission(permission = Permission.CAMERA)} throws DeniedException(Permission.CAMERA)
+    fun `onCameraClicked should not open camera when camera permission is declined by user`() {
+        everySuspend { permissionsController.providePermission(permission = Permission.CAMERA) } throws DeniedException(
+            Permission.CAMERA
+        )
         chatViewModel.onCameraClicked()
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -387,7 +431,7 @@ class ChatViewModelTest {
     }
 
     @Test
-    fun`onCameraClosed should close camera when clicked`(){
+    fun `onCameraClosed should close camera when clicked`() {
         chatViewModel.onCameraClosed()
         testDispatcher.scheduler.advanceUntilIdle()
 


### PR DESCRIPTION
this pr for split chatRepository into two classes ChatRepository and MessageRepository
and update di and viewmodel and test cases