### PR TITLE
Refactor Country Picker And Fix Login Enable Button

### DIFF
--- a/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/forgetPassword/ForgetPasswordScreenViewModelTest.kt
+++ b/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/forgetPassword/ForgetPasswordScreenViewModelTest.kt
@@ -14,7 +14,7 @@ import net.thechance.mena.identity.domain.repository.AuthenticationRepository
 import net.thechance.mena.identity.domain.repository.ResetPasswordRepository
 import net.thechance.mena.identity.domain.useCase.LoginUseCase
 import net.thechance.mena.identity.domain.useCase.validation.mobileNumber.MobileNumberValidator
-import net.thechance.mena.identity.presentation.bottomSheet.countryPicker.menaCountries.MenaCountry
+import net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries.MenaCountry
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test

--- a/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginViewModelTest.kt
+++ b/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginViewModelTest.kt
@@ -14,7 +14,7 @@ import mena.identity_presentation.generated.resources.Res
 import mena.identity_presentation.generated.resources.error_something_went_wrong
 import java.lang.Exception
 import net.thechance.mena.identity.domain.useCase.LoginUseCase
-import net.thechance.mena.identity.presentation.bottomSheet.countryPicker.menaCountries.MenaCountry
+import net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries.MenaCountry
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals

--- a/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginViewModelTest.kt
+++ b/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginViewModelTest.kt
@@ -38,7 +38,7 @@ class LoginViewModelTest {
 
 
     private fun setupValidCountry() {
-        viewModel.onSelectCountryItem(selectedCountry)
+        viewModel.onConfirmCountryItem(selectedCountry)
     }
 
     @Test
@@ -149,7 +149,7 @@ class LoginViewModelTest {
     fun `should login button is disabled when password is empty`() = runTest {
         val phoneNumber = "1100661617"
 
-        viewModel.onSelectCountryItem(selectedCountry)
+        viewModel.onConfirmCountryItem(selectedCountry)
         viewModel.onPhoneChanged(phoneNumber)
 
         testDispatcher.scheduler.advanceUntilIdle()

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/CountrySelectableRowItem.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/CountrySelectableRowItem.kt
@@ -22,7 +22,7 @@ import net.thechance.mena.designsystem.presentation.component.button.radioButton
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
-import net.thechance.mena.identity.presentation.bottomSheet.countryPicker.menaCountries.MenaCountry
+import net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries.MenaCountry
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/countryPicker/CountryPicker.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/countryPicker/CountryPicker.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.bottomSheet.countryPicker
+package net.thechance.mena.identity.presentation.screen.countryPicker
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -31,7 +31,7 @@ import net.thechance.mena.designsystem.presentation.component.scaffold.ScaffoldS
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
-import net.thechance.mena.identity.presentation.bottomSheet.countryPicker.menaCountries.MenaCountry
+import net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries.MenaCountry
 import net.thechance.mena.identity.presentation.components.CountrySelectableRowItem
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/countryPicker/CountryPickerUIState.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/countryPicker/CountryPickerUIState.kt
@@ -1,6 +1,6 @@
-package net.thechance.mena.identity.presentation.bottomSheet.countryPicker
+package net.thechance.mena.identity.presentation.screen.countryPicker
 
-import net.thechance.mena.identity.presentation.bottomSheet.countryPicker.menaCountries.MenaCountry
+import net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries.MenaCountry
 
 data class CountryPickerUIState(
     val selectedCountry: MenaCountry? = MenaCountry.IRAQ,

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/countryPicker/menaCountries/MenaCountry.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/countryPicker/menaCountries/MenaCountry.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.bottomSheet.countryPicker.menaCountries
+package net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries
 
 import mena.identity_presentation.generated.resources.Res
 import mena.identity_presentation.generated.resources.ae_flag

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/countryPicker/selectByCountry.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/countryPicker/selectByCountry.kt
@@ -1,6 +1,6 @@
-package net.thechance.mena.identity.presentation.bottomSheet.countryPicker
+package net.thechance.mena.identity.presentation.screen.countryPicker
 
-import net.thechance.mena.identity.presentation.bottomSheet.countryPicker.menaCountries.MenaCountry
+import net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries.MenaCountry
 
 fun List<SelectableCountryItemUiState>.selectByCountry(country: MenaCountry): List<SelectableCountryItemUiState> {
     return this.map { selectableCountry ->

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/forgetPassword/ForgetPasswordScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/forgetPassword/ForgetPasswordScreen.kt
@@ -21,7 +21,7 @@ import net.thechance.mena.designsystem.presentation.component.button.PrimaryButt
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.identity.presentation.base.BaseScreen
-import net.thechance.mena.identity.presentation.bottomSheet.countryPicker.CountryPicker
+import net.thechance.mena.identity.presentation.screen.countryPicker.CountryPicker
 import net.thechance.mena.identity.presentation.components.AuthAppBar
 import net.thechance.mena.identity.presentation.components.AuthScreenContainer
 import net.thechance.mena.identity.presentation.components.ErrorSnackBar

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/forgetPassword/ForgetPasswordScreenInteractionListener.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/forgetPassword/ForgetPasswordScreenInteractionListener.kt
@@ -1,7 +1,7 @@
 package net.thechance.mena.identity.presentation.screen.forgetPassword
 
 import net.thechance.mena.identity.presentation.base.BaseInteractionListener
-import net.thechance.mena.identity.presentation.bottomSheet.countryPicker.menaCountries.MenaCountry
+import net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries.MenaCountry
 
 interface ForgetPasswordScreenInteractionListener : BaseInteractionListener{
     fun onSelectCountryItem(country: MenaCountry)

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/forgetPassword/ForgetPasswordScreenUIState.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/forgetPassword/ForgetPasswordScreenUIState.kt
@@ -1,6 +1,6 @@
 package net.thechance.mena.identity.presentation.screen.forgetPassword
 
-import net.thechance.mena.identity.presentation.bottomSheet.countryPicker.menaCountries.MenaCountry
+import net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries.MenaCountry
 import org.jetbrains.compose.resources.StringResource
 
 data class ForgetPasswordScreenUIState(

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/forgetPassword/ForgetPasswordScreenViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/forgetPassword/ForgetPasswordScreenViewModel.kt
@@ -8,7 +8,7 @@ import net.thechance.mena.identity.domain.repository.ResetPasswordRepository
 import net.thechance.mena.identity.domain.useCase.LoginUseCase
 import net.thechance.mena.identity.presentation.base.BaseScreenModel
 import net.thechance.mena.identity.presentation.base.error.ErrorState
-import net.thechance.mena.identity.presentation.bottomSheet.countryPicker.menaCountries.MenaCountry
+import net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries.MenaCountry
 import net.thechance.mena.identity.presentation.mapper.mapErrorToMessage
 
 class ForgetPasswordScreenViewModel(

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreen.kt
@@ -67,7 +67,7 @@ class LoginScreen : BaseScreen<
                     CountryPicker(
                         isVisible = showBottomSheet,
                         currentCountry = state.currentCountry,
-                        onClickConfirm = listener::onSelectCountryItem,
+                        onClickConfirm = listener::onConfirmCountryItem,
                         onDismiss = listener::onDismissBottomSheet,
                     )
                 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreen.kt
@@ -28,7 +28,7 @@ import net.thechance.mena.designsystem.presentation.component.button.TextButton
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.identity.presentation.base.BaseScreen
-import net.thechance.mena.identity.presentation.bottomSheet.countryPicker.CountryPicker
+import net.thechance.mena.identity.presentation.screen.countryPicker.CountryPicker
 import net.thechance.mena.identity.presentation.components.AuthPrompt
 import net.thechance.mena.identity.presentation.components.AuthScreenContainer
 import net.thechance.mena.identity.presentation.components.ErrorSnackBar

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreenInteractionListener.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreenInteractionListener.kt
@@ -13,6 +13,6 @@ interface LoginScreenInteractionListener : BaseInteractionListener {
     fun onPasswordChanged(password: String)
     fun onPasswordVisibilityToggled()
     fun clearErrorMessage()
-    fun onSelectCountryItem(country: MenaCountry)
+    fun onConfirmCountryItem(country: MenaCountry)
     fun onDismissBottomSheet()
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreenInteractionListener.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreenInteractionListener.kt
@@ -1,7 +1,7 @@
 package net.thechance.mena.identity.presentation.screen.login
 
 import net.thechance.mena.identity.presentation.base.BaseInteractionListener
-import net.thechance.mena.identity.presentation.bottomSheet.countryPicker.menaCountries.MenaCountry
+import net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries.MenaCountry
 
 interface LoginScreenInteractionListener : BaseInteractionListener {
 

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreenUIState.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreenUIState.kt
@@ -1,6 +1,6 @@
 package net.thechance.mena.identity.presentation.screen.login
 
-import net.thechance.mena.identity.presentation.bottomSheet.countryPicker.menaCountries.MenaCountry
+import net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries.MenaCountry
 import org.jetbrains.compose.resources.StringResource
 
 data class LoginScreenUIState(

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreenViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreenViewModel.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.IO
 import net.thechance.mena.identity.domain.useCase.LoginUseCase
 import net.thechance.mena.identity.presentation.base.BaseScreenModel
 import net.thechance.mena.identity.presentation.base.error.ErrorState
-import net.thechance.mena.identity.presentation.bottomSheet.countryPicker.menaCountries.MenaCountry
+import net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries.MenaCountry
 import net.thechance.mena.identity.presentation.mapper.createNavigateToHomeEffect
 import net.thechance.mena.identity.presentation.mapper.mapErrorToMessage
 

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreenViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreenViewModel.kt
@@ -90,7 +90,7 @@ class LoginScreenViewModel(
     }
 
 
-    override fun onSelectCountryItem(country: MenaCountry) {
+    override fun onConfirmCountryItem(country: MenaCountry) {
         updateState { copy(currentCountry = country, showCountryBottomSheet = false) }
         changeIsLoginEnabled()
     }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreenViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/login/LoginScreenViewModel.kt
@@ -92,6 +92,7 @@ class LoginScreenViewModel(
 
     override fun onSelectCountryItem(country: MenaCountry) {
         updateState { copy(currentCountry = country, showCountryBottomSheet = false) }
+        changeIsLoginEnabled()
     }
 
     override fun onDismissBottomSheet() {


### PR DESCRIPTION
Changes in this PR:

- Move the country picker components and its related files to the screen package.
- Rename `onSelectCountryItem` to `onConfirmCountryItem` in Login interaction listener
- Fix the login button to be enabled when phone number already inserted  and user changes to the corresponding  country 