### PR TITLE
refactor: enhance main screen UI and simplify component logic

### DIFF
--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainInteractionListener.kt
@@ -1,12 +1,8 @@
 package net.thechance.mena.faith.presentation.feature.main
 
-interface FeatureInteractionListener {
+interface MainInteractionListener {
+    fun onContinueTilawahClick(surahId: Int, surahName: String, ayahNumber: Int)
     fun onQuranClick()
     fun onQiblahClick()
     fun onMosquesClick()
-}
-
-
-interface MainInteractionListener : FeatureInteractionListener {
-    fun onContinueTilawahClick(surahId: Int, surahName: String, ayahNumber: Int)
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainInteractionListener.kt
@@ -1,8 +1,12 @@
 package net.thechance.mena.faith.presentation.feature.main
 
-interface MainInteractionListener {
-    fun onContinueTilawahClick(surahId: Int, surahName: String, ayahNumber: Int)
+interface FeatureInteractionListener {
     fun onQuranClick()
     fun onQiblahClick()
     fun onMosquesClick()
+}
+
+
+interface MainInteractionListener : FeatureInteractionListener {
+    fun onContinueTilawahClick(surahId: Int, surahName: String, ayahNumber: Int)
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainScreen.kt
@@ -93,7 +93,7 @@ private fun Content(
     Scaffold(
         topBar = { MainTopBar(locationName = "Cairo, Egypt") }
     ) {
-        val faithFeatureCards = FaithFeatureType.entries.map { it.toFeatureItem(listener) }
+        val faithFeatureCards = faithFeatureCards(listener)
 
         LazyVerticalGrid(
             modifier = Modifier

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainScreen.kt
@@ -1,31 +1,19 @@
 package net.thechance.mena.faith.presentation.feature.main
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -33,29 +21,18 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import mena.faith_presentation.generated.resources.Res
 import mena.faith_presentation.generated.resources.asr
 import mena.faith_presentation.generated.resources.dhuhr
-import mena.faith_presentation.generated.resources.faith_title
 import mena.faith_presentation.generated.resources.fajr
-import mena.faith_presentation.generated.resources.ic_column_mosque
-import mena.faith_presentation.generated.resources.ic_kaaba
-import mena.faith_presentation.generated.resources.ic_location
-import mena.faith_presentation.generated.resources.ic_mosque
-import mena.faith_presentation.generated.resources.ic_quran
 import mena.faith_presentation.generated.resources.ic_sunrise
 import mena.faith_presentation.generated.resources.isha
-import mena.faith_presentation.generated.resources.location
-import mena.faith_presentation.generated.resources.mosque_image_description
-import mena.faith_presentation.generated.resources.nearby_mosques
-import mena.faith_presentation.generated.resources.qiblah_direction
-import mena.faith_presentation.generated.resources.quran_kareem
 import mena.faith_presentation.generated.resources.sunrise_time_label
-import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
-import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.faith.domain.entity.PrayerName
 import net.thechance.mena.faith.presentation.base.ObserveAsEffect
 import net.thechance.mena.faith.presentation.designSystem.theme.QuranTheme
+import net.thechance.mena.faith.presentation.feature.main.components.FaithFeatureCard
+import net.thechance.mena.faith.presentation.feature.main.components.MainTopBar
 import net.thechance.mena.faith.presentation.feature.main.components.PrayerTimesCard
 import net.thechance.mena.faith.presentation.feature.main.components.SunriseTimeRow
 import net.thechance.mena.faith.presentation.feature.main.components.TilawahSection
@@ -82,6 +59,7 @@ fun MainScreen(
 
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
+
     ObserveAsEffect(viewModel.uiEffect) { effect ->
         when (effect) {
             is MainScreenEffect.NavigateToSurah -> {
@@ -113,31 +91,15 @@ private fun Content(
     listener: MainInteractionListener
 ) {
     Scaffold(
-        topBar = { MainTopBar() }
+        topBar = { MainTopBar(locationName = "Cairo, Egypt") }
     ) {
-        val featureCards = listOf(
-            FeatureItem(
-                title = stringResource(Res.string.quran_kareem),
-                icon = painterResource(Res.drawable.ic_quran),
-                onClick = listener::onQuranClick
-            ),
-            FeatureItem(
-                title = stringResource(Res.string.qiblah_direction),
-                icon = painterResource(Res.drawable.ic_kaaba),
-                onClick = listener::onQiblahClick
-            ),
-            FeatureItem(
-                title = stringResource(Res.string.nearby_mosques),
-                icon = painterResource(Res.drawable.ic_mosque),
-                onClick = listener::onMosquesClick
-            )
-        )
+        val faithFeatureCards = FaithFeatureType.entries.map { it.toFeatureItem(listener) }
+
         LazyVerticalGrid(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(
                     bottom = Theme.spacing._8,
-                    top = Theme.spacing._16,
                     start = Theme.spacing._16,
                     end = Theme.spacing._16
                 ),
@@ -146,38 +108,10 @@ private fun Content(
             verticalArrangement = Arrangement.spacedBy(Theme.spacing._8)
         ) {
             item(span = { GridItemSpan(maxLineSpan) }) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    PrayerTimesCard(prayerTimesUiState = uiState.prayerTimesUiState)
-                    Text(
-                        text = uiState.hijriDate,
-                        color = Theme.colorScheme.shadeSecondary,
-                        style = Theme.typography.label.extraSmall
-                    )
-                    SunriseTimeRow(
-                        icon = painterResource(Res.drawable.ic_sunrise),
-                        title = stringResource(Res.string.sunrise_time_label),
-                        time = uiState.sunriseTime
-                    )
-                    TilawahSection(
-                        tilawahUiState = uiState.tilawahUiState,
-                        onContinueTilawahClick = {
-                            uiState.tilawahUiState?.let { tilawah ->
-                                listener.onContinueTilawahClick(
-                                    surahId = tilawah.surahId,
-                                    surahName = tilawah.surahName,
-                                    ayahNumber = tilawah.ayahNumber
-                                )
-                            }
-                        },
-                        modifier = Modifier.padding(bottom = Theme.spacing._8)
-                    )
-                }
+                PrayerSection(uiState, listener)
             }
 
-            items(featureCards) { card ->
+            items(faithFeatureCards) { card ->
                 FaithFeatureCard(
                     icon = card.icon,
                     title = card.title,
@@ -189,94 +123,49 @@ private fun Content(
 }
 
 @Composable
-private fun MainTopBar() {
-    AppBar(
-        title = stringResource(Res.string.faith_title),
-        trailingContent = {
-            Row(
-                modifier = Modifier.background(
-                        color = Theme.colorScheme.background.surfaceLow,
-                        shape = RoundedCornerShape(Theme.radius.full)
-                    )
-                    .padding(horizontal = Theme.spacing._8, vertical = Theme.spacing._4),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(Theme.spacing._4)
-            ) {
-                Icon(
-                    painter = painterResource(Res.drawable.ic_location),
-                    contentDescription = stringResource(Res.string.location),
-                    tint = Theme.colorScheme.shadePrimary,
-                    modifier = Modifier.size(16.dp)
-                )
-                Text(
-                    text = "Cairo, Egypt",
-                    color = Theme.colorScheme.shadePrimary,
-                    style = Theme.typography.label.small
-                )
-            }
-        }
-    )
+private fun PrayerSection(
+    uiState: MainUiState,
+    listener: MainInteractionListener
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(Theme.spacing._8)
+    ) {
+        PrayerTimesCard(prayerTimesUiState = uiState.prayerTimesUiState)
+        Text(
+            text = uiState.hijriDate,
+            color = Theme.colorScheme.shadeSecondary,
+            style = Theme.typography.label.extraSmall
+        )
+        SunriseTimeRow(
+            icon = painterResource(Res.drawable.ic_sunrise),
+            title = stringResource(Res.string.sunrise_time_label),
+            time = uiState.sunriseTime,
+            modifier = Modifier.padding(vertical = Theme.spacing._12)
+        )
+        TilawahSection(
+            tilawahUiState = uiState.tilawahUiState,
+            onContinueTilawahClick = onContinueTilawahClick(uiState, listener),
+            modifier = Modifier.padding(bottom = Theme.spacing._8)
+        )
+    }
 }
 
-@Composable
-private fun FaithFeatureCard(
-    icon: Painter,
-    title: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Box(
-        modifier = modifier
-            .clip(RoundedCornerShape(Theme.radius.md))
-            .background(Theme.colorScheme.background.surfaceLow)
-            .clickable { onClick() },
-        contentAlignment = Alignment.Center,
-
-        ) {
-        Image(
-            painter = painterResource(Res.drawable.ic_column_mosque),
-            stringResource(Res.string.mosque_image_description),
-            modifier = Modifier
-                .align(Alignment.CenterEnd)
-                .fillMaxHeight()
-                .width(100.dp),
-            contentScale = ContentScale.Fit,
+private fun onContinueTilawahClick(
+    uiState: MainUiState,
+    listener: MainInteractionListener
+): () -> Unit = {
+    uiState.tilawahUiState?.let { tilawah ->
+        listener.onContinueTilawahClick(
+            surahId = tilawah.surahId,
+            surahName = tilawah.surahName,
+            ayahNumber = tilawah.ayahNumber
         )
-
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(start = Theme.spacing._12),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-
-            ) {
-            Box(
-                modifier = Modifier
-                    .size(40.dp)
-                    .align(Alignment.Start)
-                    .clip(RoundedCornerShape(Theme.radius.md))
-                    .background(Theme.colorScheme.background.surfaceHigh),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    painter = icon,
-                    contentDescription = title,
-                    tint = Theme.colorScheme.primary.primary,
-                    modifier = Modifier.size(28.dp)
-                        .padding(bottom = Theme.spacing._4)
-                )
-            }
-            Text(
-                text = title,
-                style = Theme.typography.title.small,
-                color = Theme.colorScheme.shadePrimary,
-            )
-        }
     }
 }
 
 @Composable
-@Preview
+@Preview(heightDp = 800, widthDp = 360)
 private fun MainScreenPreview() {
     QuranTheme {
         Content(

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainScreen.kt
@@ -165,8 +165,8 @@ private fun onContinueTilawahClick(
 }
 
 @Composable
-@Preview(heightDp = 800, widthDp = 360)
-private fun MainScreenPreview() {
+@Preview
+private fun Preview() {
     QuranTheme {
         Content(
             uiState = MainUiState(

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainScreen.kt
@@ -93,7 +93,7 @@ private fun Content(
     Scaffold(
         topBar = { MainTopBar(locationName = "Cairo, Egypt") }
     ) {
-        val faithFeatureCards = faithFeatureCards(listener)
+        val faithFeatureCards = faithFeatureCards(listener = listener)
 
         LazyVerticalGrid(
             modifier = Modifier

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainUiState.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainUiState.kt
@@ -11,7 +11,6 @@ import mena.faith_presentation.generated.resources.qiblah_direction
 import mena.faith_presentation.generated.resources.quran_kareem
 import net.thechance.mena.faith.domain.entity.PrayerName
 import net.thechance.mena.faith.domain.entity.PrayerTime
-import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -49,31 +48,23 @@ data class FeatureItem(
     val onClick: () -> Unit
 )
 
-enum class FaithFeatureType(
-    val titleRes: StringResource,
-    val iconRes: DrawableResource,
-    val getAction: (FeatureInteractionListener) -> () -> Unit
-) {
-    QURAN(
-        titleRes = Res.string.quran_kareem,
-        iconRes = Res.drawable.ic_quran,
-        getAction = { it::onQuranClick }
-    ),
-    QIBLAH(
-        titleRes = Res.string.qiblah_direction,
-        iconRes = Res.drawable.ic_kaaba,
-        getAction = { it::onQiblahClick }
-    ),
-    MOSQUES(
-        titleRes = Res.string.nearby_mosques,
-        iconRes = Res.drawable.ic_mosque,
-        getAction = { it::onMosquesClick }
-    );
-
-    @Composable
-    fun toFeatureItem(listener: FeatureInteractionListener) = FeatureItem(
-        title = stringResource(titleRes),
-        icon = painterResource(iconRes),
-        onClick = getAction(listener)
+@Composable
+fun faithFeatureCards(listener: MainInteractionListener): List<FeatureItem> {
+    return listOf(
+        FeatureItem(
+            title = stringResource(Res.string.quran_kareem),
+            icon = painterResource(Res.drawable.ic_quran),
+            onClick = listener::onQuranClick
+        ),
+        FeatureItem(
+            title = stringResource(Res.string.qiblah_direction),
+            icon = painterResource(Res.drawable.ic_kaaba),
+            onClick = listener::onQiblahClick
+        ),
+        FeatureItem(
+            title = stringResource(Res.string.nearby_mosques),
+            icon = painterResource(Res.drawable.ic_mosque),
+            onClick = listener::onMosquesClick
+        )
     )
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainUiState.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainUiState.kt
@@ -1,9 +1,20 @@
 package net.thechance.mena.faith.presentation.feature.main
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.painter.Painter
+import mena.faith_presentation.generated.resources.Res
+import mena.faith_presentation.generated.resources.ic_kaaba
+import mena.faith_presentation.generated.resources.ic_mosque
+import mena.faith_presentation.generated.resources.ic_quran
+import mena.faith_presentation.generated.resources.nearby_mosques
+import mena.faith_presentation.generated.resources.qiblah_direction
+import mena.faith_presentation.generated.resources.quran_kareem
 import net.thechance.mena.faith.domain.entity.PrayerName
 import net.thechance.mena.faith.domain.entity.PrayerTime
+import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
 
 data class MainUiState(
     val isLoading: Boolean = false,
@@ -37,3 +48,32 @@ data class FeatureItem(
     val icon: Painter,
     val onClick: () -> Unit
 )
+
+enum class FaithFeatureType(
+    val titleRes: StringResource,
+    val iconRes: DrawableResource,
+    val getAction: (FeatureInteractionListener) -> () -> Unit
+) {
+    QURAN(
+        titleRes = Res.string.quran_kareem,
+        iconRes = Res.drawable.ic_quran,
+        getAction = { it::onQuranClick }
+    ),
+    QIBLAH(
+        titleRes = Res.string.qiblah_direction,
+        iconRes = Res.drawable.ic_kaaba,
+        getAction = { it::onQiblahClick }
+    ),
+    MOSQUES(
+        titleRes = Res.string.nearby_mosques,
+        iconRes = Res.drawable.ic_mosque,
+        getAction = { it::onMosquesClick }
+    );
+
+    @Composable
+    fun toFeatureItem(listener: FeatureInteractionListener) = FeatureItem(
+        title = stringResource(titleRes),
+        icon = painterResource(iconRes),
+        onClick = getAction(listener)
+    )
+}

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainViewModel.kt
@@ -43,15 +43,14 @@ class MainViewModel(
                 )
             },
             onStart = { updateState { it.copy(isLoading = true) } },
-            onSuccess = { prayerTimes -> onGetPrayerTimesSuccess(prayerTimes) },
+            onSuccess = ::onGetPrayerTimesSuccess,
             onFinally = { updateState { it.copy(isLoading = false) } },
             dispatcher = dispatcher
         )
     }
 
     @OptIn(ExperimentalTime::class)
-    private fun
-            onGetPrayerTimesSuccess(prayerTimes: List<PrayerTime>) {
+    private fun onGetPrayerTimesSuccess(prayerTimes: List<PrayerTime>) {
         updateState { currentState ->
             currentState.copy(
                 prayerTimes = prayerTimes,
@@ -65,24 +64,17 @@ class MainViewModel(
     private fun loadLastAyahForTilawah() {
         tryToExecute(
             execute = { quranRepository.getLastAyahForTilawah() },
-            onSuccess = { ayah -> onGetLastAyahForTilawahSuccess(ayah) },
+            onSuccess = ::onGetLastAyahForTilawahSuccess,
             dispatcher = dispatcher
         )
     }
 
-    private fun onGetLastAyahForTilawahSuccess(ayah: LastAyahForTilawah) {
-        tryToExecute(
-            execute = { ayah.toTilawahUiState() },
-            onSuccess = { tilawahState ->
-                updateState { currentState ->
-                    currentState.copy(tilawahUiState = tilawahState)
-                }
-            },
-            dispatcher = dispatcher
-        )
+    private suspend fun onGetLastAyahForTilawahSuccess(ayah: LastAyahForTilawah) {
+        val tilawahState = ayah.toTilawahUiState()
+        updateState { it.copy(tilawahUiState = tilawahState) }
     }
 
-    override fun onContinueTilawahClick(surahId: Int, surahName: String, ayahNumber: Int) =
+    override fun onContinueTilawahClick(surahId: Int, surahName: String, ayahNumber: Int) {
         sendEffect(
             MainScreenEffect.NavigateToSurah(
                 surahId = surahId,
@@ -90,12 +82,14 @@ class MainViewModel(
                 ayahNumber = ayahNumber
             )
         )
+    }
 
     override fun onQuranClick() = sendEffect(MainScreenEffect.NavigateToQuran)
 
     override fun onQiblahClick() = sendEffect(MainScreenEffect.NavigateToQiblah)
 
     override fun onMosquesClick() = sendEffect(MainScreenEffect.NavigateToMosques)
+
     fun refreshTilawah() {
         loadLastAyahForTilawah()
     }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/CardIcon.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/CardIcon.kt
@@ -37,7 +37,7 @@ fun CardIcon(
 
 @Preview
 @Composable
-fun CardIconPreview() {
+private fun Preview() {
     QuranTheme {
         CardIcon(
             icon = painterResource(Res.drawable.ic_quran),

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/CardIcon.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/CardIcon.kt
@@ -1,0 +1,47 @@
+package net.thechance.mena.faith.presentation.feature.main.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.dp
+import mena.faith_presentation.generated.resources.Res
+import mena.faith_presentation.generated.resources.ic_quran
+import net.thechance.mena.designsystem.presentation.component.icon.Icon
+import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.faith.presentation.designSystem.theme.QuranTheme
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun CardIcon(
+    icon: Painter,
+    contentDescription: String,
+    modifier: Modifier = Modifier
+) {
+    Icon(
+        painter = icon,
+        contentDescription = contentDescription,
+        tint = Theme.colorScheme.primary.primary,
+        modifier = modifier
+            .clip(RoundedCornerShape(Theme.radius.md))
+            .background(Theme.colorScheme.background.surfaceHigh)
+            .padding(Theme.spacing._8)
+            .size(24.dp)
+    )
+}
+
+@Preview
+@Composable
+fun CardIconPreview() {
+    QuranTheme {
+        CardIcon(
+            icon = painterResource(Res.drawable.ic_quran),
+            contentDescription = "Quran Kareem"
+        )
+    }
+}

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/FaithFeatureCard.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/FaithFeatureCard.kt
@@ -71,9 +71,9 @@ fun FaithFeatureCard(
     }
 }
 
-@Preview(widthDp = 160, heightDp = 112)
+@Preview
 @Composable
-private fun FaithFeatureCardPreview() {
+private fun Preview() {
     QuranTheme {
         FaithFeatureCard(
             icon = painterResource(Res.drawable.ic_quran),

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/FaithFeatureCard.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/FaithFeatureCard.kt
@@ -1,0 +1,84 @@
+package net.thechance.mena.faith.presentation.feature.main.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import mena.faith_presentation.generated.resources.Res
+import mena.faith_presentation.generated.resources.ic_column_mosque
+import mena.faith_presentation.generated.resources.ic_quran
+import mena.faith_presentation.generated.resources.mosque_image_description
+import net.thechance.mena.designsystem.presentation.component.text.Text
+import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.faith.presentation.designSystem.theme.QuranTheme
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun FaithFeatureCard(
+    icon: Painter,
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(Theme.radius.md))
+            .background(Theme.colorScheme.background.surfaceLow)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Image(
+            painter = painterResource(Res.drawable.ic_column_mosque),
+            stringResource(Res.string.mosque_image_description),
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .fillMaxHeight()
+                .padding(end = 10.dp),
+            contentScale = ContentScale.Fit,
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .wrapContentHeight()
+                .padding(start = Theme.spacing._12),
+            verticalArrangement = Arrangement.spacedBy(Theme.spacing._12),
+            horizontalAlignment = Alignment.Start,
+        ) {
+            CardIcon(icon = icon, contentDescription = title)
+            Text(
+                text = title,
+                style = Theme.typography.title.small,
+                color = Theme.colorScheme.shadePrimary,
+            )
+        }
+    }
+}
+
+@Preview(widthDp = 160, heightDp = 112)
+@Composable
+private fun FaithFeatureCardPreview() {
+    QuranTheme {
+        FaithFeatureCard(
+            icon = painterResource(Res.drawable.ic_quran),
+            title = "Quran Kareem",
+            onClick = {}
+        )
+    }
+}

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/MainTopBar.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/MainTopBar.kt
@@ -58,9 +58,9 @@ fun MainTopBar(
     )
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
-private fun MainTopBarPreview() {
+private fun Preview() {
     QuranTheme {
         MainTopBar(
             locationName = "Palestine, Gaza"

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/MainTopBar.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/MainTopBar.kt
@@ -1,0 +1,69 @@
+package net.thechance.mena.faith.presentation.feature.main.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import mena.faith_presentation.generated.resources.Res
+import mena.faith_presentation.generated.resources.faith_title
+import mena.faith_presentation.generated.resources.ic_location
+import mena.faith_presentation.generated.resources.location
+import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
+import net.thechance.mena.designsystem.presentation.component.icon.Icon
+import net.thechance.mena.designsystem.presentation.component.text.Text
+import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.faith.presentation.designSystem.theme.QuranTheme
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun MainTopBar(
+    locationName: String,
+    modifier: Modifier = Modifier
+) {
+    AppBar(
+        modifier = modifier,
+        title = stringResource(Res.string.faith_title),
+        trailingContent = {
+            Row(
+                modifier = Modifier
+                    .background(
+                        color = Theme.colorScheme.background.surfaceLow,
+                        shape = RoundedCornerShape(Theme.radius.full)
+                    )
+                    .padding(horizontal = Theme.spacing._8, vertical = Theme.spacing._4),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(Theme.spacing._4)
+            ) {
+                Icon(
+                    painter = painterResource(Res.drawable.ic_location),
+                    contentDescription = stringResource(Res.string.location),
+                    tint = Theme.colorScheme.shadePrimary,
+                    modifier = Modifier.size(16.dp)
+                )
+                Text(
+                    text = locationName,
+                    color = Theme.colorScheme.shadePrimary,
+                    style = Theme.typography.label.small
+                )
+            }
+        }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MainTopBarPreview() {
+    QuranTheme {
+        MainTopBar(
+            locationName = "Palestine, Gaza"
+        )
+    }
+}

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/PrayerTimesCard.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/PrayerTimesCard.kt
@@ -51,8 +51,7 @@ fun PrayerTimesCard(
     if (prayerTimesUiState == null) return
 
     Box(
-        modifier = modifier
-            .aspectRatio(2.65f),
+        modifier = modifier.aspectRatio(2.65f),
     ) {
         Box(
             modifier = Modifier

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/PrayerTimesCard.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/PrayerTimesCard.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
@@ -24,50 +23,54 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import mena.faith_presentation.generated.resources.Res
 import mena.faith_presentation.generated.resources.am_label
+import mena.faith_presentation.generated.resources.asr
+import mena.faith_presentation.generated.resources.dhuhr
+import mena.faith_presentation.generated.resources.fajr
 import mena.faith_presentation.generated.resources.ic_column_mosque
 import mena.faith_presentation.generated.resources.ic_mosque_bg
 import mena.faith_presentation.generated.resources.ic_triangle_down
+import mena.faith_presentation.generated.resources.isha
 import mena.faith_presentation.generated.resources.mosque_image_description
 import mena.faith_presentation.generated.resources.pm_label
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.faith.domain.entity.PrayerName
+import net.thechance.mena.faith.presentation.designSystem.theme.QuranTheme
 import net.thechance.mena.faith.presentation.feature.main.PrayerTimesUiState
 import net.thechance.mena.faith.presentation.feature.main.PrayerUiModel
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-fun PrayerTimesCard(prayerTimesUiState: PrayerTimesUiState?) {
+fun PrayerTimesCard(
+    prayerTimesUiState: PrayerTimesUiState?,
+    modifier: Modifier = Modifier
+) {
     if (prayerTimesUiState == null) return
 
     Box(
-        modifier = Modifier
-            .aspectRatio(2.65f)
-            .clip(RoundedCornerShape(Theme.radius.lg))
-            .background(Theme.colorScheme.background.surfaceLow),
+        modifier = modifier
+            .aspectRatio(2.65f),
     ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .align(Alignment.BottomCenter)
+                .padding(top = Theme.spacing._16)
+                .clip(RoundedCornerShape(Theme.radius.lg))
+                .background(Theme.colorScheme.background.surfaceLow)
+        )
         Image(
             painter = painterResource(Res.drawable.ic_mosque_bg),
             contentDescription = stringResource(Res.string.mosque_image_description),
             modifier = Modifier
                 .align(Alignment.TopEnd)
                 .fillMaxWidth(0.35f)
-                .aspectRatio(1f)
-                .offset(y = (-38).dp, x = (-8).dp),
+                .aspectRatio(1.52f),
             contentScale = ContentScale.Fit,
         )
-
-        Image(
-            painter = painterResource(Res.drawable.ic_column_mosque),
-            contentDescription = stringResource(Res.string.mosque_image_description),
-            modifier = Modifier
-                .align(Alignment.CenterStart)
-                .fillMaxHeight()
-                .padding(start = 22.dp),
-            contentScale = ContentScale.Crop,
-        )
-
         LazyRow(
             modifier = Modifier
                 .fillMaxSize()
@@ -83,8 +86,20 @@ fun PrayerTimesCard(prayerTimesUiState: PrayerTimesUiState?) {
                 )
             }
         }
+
+
+        Image(
+            painter = painterResource(Res.drawable.ic_column_mosque),
+            contentDescription = stringResource(Res.string.mosque_image_description),
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .fillMaxHeight()
+                .padding(start = 22.dp),
+            contentScale = ContentScale.Crop,
+        )
     }
 }
+
 
 @Composable
 private fun PrayerItem(
@@ -131,5 +146,64 @@ private fun PrayerItem(
                     .size(Theme.spacing._16),
             )
         }
+    }
+}
+
+
+@Preview(heightDp = 142)
+@Composable
+private fun PrayerTimesCardPreview() {
+    val samplePrayerTimesUiState = PrayerTimesUiState(
+        prayers = listOf(
+            PrayerUiModel(
+                name = PrayerName.FAJR,
+                displayName = Res.string.fajr,
+                time = "06:00",
+                isAM = true
+            ),
+            PrayerUiModel(
+                name = PrayerName.DHUHR,
+                displayName = Res.string.dhuhr,
+                time = "12:00",
+                isAM = false
+            ),
+            PrayerUiModel(
+                name = PrayerName.ASR,
+                displayName = Res.string.asr,
+                time = "04:00",
+                isAM = false
+            ),
+            PrayerUiModel(
+                name = PrayerName.MAGHRIB,
+                displayName = Res.string.fajr,
+                time = "06:00",
+                isAM = false
+            ),
+            PrayerUiModel(
+                name = PrayerName.ISHA,
+                displayName = Res.string.isha,
+                time = "08:00",
+                isAM = false
+            )
+        ),
+        nextPrayerIndex = 0
+    )
+    QuranTheme {
+        PrayerTimesCard(prayerTimesUiState = samplePrayerTimesUiState)
+    }
+}
+
+
+@Preview
+@Composable
+private fun PrayerItemPreview() {
+    val samplePrayer = PrayerUiModel(
+        name = PrayerName.FAJR,
+        displayName = Res.string.fajr,
+        time = "06:00",
+        isAM = true
+    )
+    QuranTheme {
+        PrayerItem(prayer = samplePrayer, isNextPrayer = true)
     }
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/PrayerTimesCard.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/PrayerTimesCard.kt
@@ -150,7 +150,7 @@ private fun PrayerItem(
 }
 
 
-@Preview(heightDp = 142)
+@Preview
 @Composable
 private fun PrayerTimesCardPreview() {
     val samplePrayerTimesUiState = PrayerTimesUiState(

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/SunriseTimeRow.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/SunriseTimeRow.kt
@@ -28,8 +28,7 @@ fun SunriseTimeRow(
     modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = modifier
-            .fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
 

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/SunriseTimeRow.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/SunriseTimeRow.kt
@@ -9,20 +9,27 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.dp
+import mena.faith_presentation.generated.resources.Res
+import mena.faith_presentation.generated.resources.ic_sunrise
+import mena.faith_presentation.generated.resources.sunrise_time_label
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.faith.presentation.designSystem.theme.QuranTheme
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun SunriseTimeRow(
     icon: Painter,
     title: String,
-    time: String
+    time: String,
+    modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = Theme.spacing._16),
+        modifier = modifier
+            .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
 
@@ -30,7 +37,7 @@ fun SunriseTimeRow(
             painter = icon,
             contentDescription = null,
             tint = Theme.colorScheme.primary.primary,
-            modifier = Modifier.size(20.dp)
+            modifier = Modifier.size(24.dp)
                 .padding(end = Theme.spacing._8)
         )
 
@@ -45,6 +52,18 @@ fun SunriseTimeRow(
             text = time,
             color = Theme.colorScheme.shadePrimary,
             style = Theme.typography.label.medium
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SunriseTimeRowPreview() {
+    QuranTheme {
+        SunriseTimeRow(
+            icon = painterResource(Res.drawable.ic_sunrise),
+            title = stringResource(Res.string.sunrise_time_label),
+            time = "06:55 PM"
         )
     }
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/SunriseTimeRow.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/SunriseTimeRow.kt
@@ -56,9 +56,9 @@ fun SunriseTimeRow(
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
-fun SunriseTimeRowPreview() {
+private fun Preview() {
     QuranTheme {
         SunriseTimeRow(
             icon = painterResource(Res.drawable.ic_sunrise),

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/TilawahSection.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/TilawahSection.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -28,16 +27,18 @@ import mena.faith_presentation.generated.resources.tilawah
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.faith.presentation.designSystem.theme.QuranTheme
 import net.thechance.mena.faith.presentation.feature.main.TilawahUiState
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun TilawahSection(
     tilawahUiState: TilawahUiState?,
     onContinueTilawahClick: () -> Unit,
-    modifier: Modifier
+    modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -49,68 +50,67 @@ fun TilawahSection(
             color = Theme.colorScheme.shadePrimary,
             modifier = Modifier.padding(bottom = Theme.spacing._8)
         )
-
-        Box(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(Theme.radius.md))
                 .clickable { onContinueTilawahClick() }
                 .background(Theme.colorScheme.background.surfaceLow)
-
+                .padding(Theme.spacing._8),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth()
-                    .padding(Theme.spacing._8),
-                verticalAlignment = Alignment.CenterVertically
+            CardIcon(
+                icon = painterResource(Res.drawable.ic_quran_play),
+                contentDescription = stringResource(Res.string.quran_kareem)
+            )
+            Column(
+                modifier = Modifier.padding(start = Theme.spacing._8)
+                    .weight(1f),
+                verticalArrangement = Arrangement.spacedBy(Theme.spacing._4)
             ) {
-                Box(
-                    modifier = Modifier
-                        .size(40.dp)
-                        .clip(RoundedCornerShape(Theme.radius.md))
-                        .background(Theme.colorScheme.background.surfaceHigh),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        painter = painterResource(Res.drawable.ic_quran_play),
-                        contentDescription = stringResource(Res.string.quran_kareem),
-                        tint = Theme.colorScheme.primary.primary,
-                        modifier = Modifier.size(22.dp)
-                    )
-                }
-                Column(
-                    modifier = Modifier.padding(start = Theme.spacing._8)
-                        .weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(Theme.spacing._4)
-                ) {
-                    Text(
-                        text = tilawahUiState?.surahName
-                            ?: stringResource(Res.string.surah_al_fatiha),
-                        style = Theme.typography.label.medium,
-                        color = Theme.colorScheme.shadePrimary
-                    )
-                    Text(
-                        text = stringResource(
-                            Res.string.ayah_number,
-                            tilawahUiState?.ayahNumber ?: "1"
-                        ),
-                        style = Theme.typography.label.small,
-                        color = Theme.colorScheme.shadeSecondary
-                    )
-                }
                 Text(
-                    text = stringResource(Res.string.continue_tilawah),
+                    text = tilawahUiState?.surahName
+                        ?: stringResource(Res.string.surah_al_fatiha),
                     style = Theme.typography.label.medium,
-                    color = Theme.colorScheme.primary.primary,
-
-                    )
-                Icon(
-                    painter = painterResource(Res.drawable.ic_arrow_right),
-                    contentDescription = stringResource(Res.string.navigate_next),
-                    tint = Theme.colorScheme.primary.primary,
-                    modifier = Modifier.size(18.dp)
+                    color = Theme.colorScheme.shadePrimary
+                )
+                Text(
+                    text = stringResource(
+                        Res.string.ayah_number,
+                        tilawahUiState?.ayahNumber ?: "1"
+                    ),
+                    style = Theme.typography.label.small,
+                    color = Theme.colorScheme.shadeSecondary
                 )
             }
+            Text(
+                text = stringResource(Res.string.continue_tilawah),
+                style = Theme.typography.label.medium,
+                color = Theme.colorScheme.primary.primary,
+
+                )
+            Icon(
+                painter = painterResource(Res.drawable.ic_arrow_right),
+                contentDescription = stringResource(Res.string.navigate_next),
+                tint = Theme.colorScheme.primary.primary,
+                modifier = Modifier.size(18.dp)
+            )
         }
+    }
+}
+
+@Preview
+@Composable
+private fun TilawahSectionPreview() {
+    QuranTheme {
+        TilawahSection(
+            tilawahUiState = TilawahUiState(
+                surahId = 1,
+                surahName = "Al-Fatihah",
+                ayahNumber = 3
+            ),
+            onContinueTilawahClick = {},
+        )
     }
 }
 

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/TilawahSection.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/TilawahSection.kt
@@ -101,7 +101,7 @@ fun TilawahSection(
 
 @Preview
 @Composable
-private fun TilawahSectionPreview() {
+private fun Preview() {
     QuranTheme {
         TilawahSection(
             tilawahUiState = TilawahUiState(

--- a/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/main/MainMapperKtTest.kt
+++ b/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/main/MainMapperKtTest.kt
@@ -22,7 +22,6 @@ class MainMapperKtTest {
 
     @Test
     fun `getPrayerDisplayNameResource should return correct string resource id for each prayer`() {
-        // Given
         val expectedMap = mapOf(
             PrayerName.FAJR to Res.string.fajr,
             PrayerName.DHUHR to Res.string.dhuhr,
@@ -32,7 +31,6 @@ class MainMapperKtTest {
             PrayerName.SUNRISE to Res.string.sunrise
         )
 
-        // When & Then
         expectedMap.forEach { (prayer, expectedRes) ->
             assertEquals(expectedRes, getPrayerDisplayNameResource(prayer))
         }
@@ -40,30 +38,24 @@ class MainMapperKtTest {
 
     @Test
     fun `isAM should return true for morning times`() {
-        // Given
         val morningInstant = Instant.fromEpochSeconds(MORNING_EIGHT_AM_SECONDS)
-        // When
+
         val result = isAM(morningInstant)
 
-        // Then
         assertEquals(true, result)
     }
 
     @Test
     fun `isAM should return false for afternoon times`() {
-        // Given
         val afternoonInstant = Instant.fromEpochSeconds(15 * 3600)
 
-        // When
         val result = isAM(afternoonInstant)
 
-        // Then
         assertEquals(false, result)
     }
 
     @Test
     fun `toUi should correctly map, filter and order prayers`() {
-        // Given
         val now = Instant.fromEpochSeconds(10_000)
         val prayers = listOf(
             PrayerTime(PrayerName.ISHA, now + 13.hours, DEFAULT_HIJRI_DATE),
@@ -74,10 +66,8 @@ class MainMapperKtTest {
             PrayerTime(PrayerName.MAGHRIB, now + 11.hours, DEFAULT_HIJRI_DATE)
         )
 
-        // When
         val uiState = prayers.toUi(now + 6.hours)
 
-        // Then
         assertEquals(5, uiState.prayers.size)
         val expectedOrder = listOf(
             PrayerName.FAJR, PrayerName.DHUHR, PrayerName.ASR, PrayerName.MAGHRIB, PrayerName.ISHA
@@ -89,7 +79,6 @@ class MainMapperKtTest {
 
     @Test
     fun `getCurrentPrayer should return first prayer when now is before first OR after last prayer`() {
-        // Given
         val base = Instant.fromEpochSeconds(10_000)
         val prayers = listOf(
             PrayerTime(PrayerName.FAJR, base + 1.hours, DEFAULT_HIJRI_DATE),
@@ -99,11 +88,9 @@ class MainMapperKtTest {
             PrayerTime(PrayerName.ISHA, base + 13.hours, DEFAULT_HIJRI_DATE)
         )
 
-        // When
         val beforeUi = prayers.toUi(base - 30.minutes)
         val afterUi = prayers.toUi(base + 15.hours)
 
-        // Then
         assertEquals(0, beforeUi.nextPrayerIndex)
         assertEquals(PrayerName.FAJR, beforeUi.prayers[0].name)
         assertEquals(0, afterUi.nextPrayerIndex)
@@ -112,7 +99,6 @@ class MainMapperKtTest {
 
     @Test
     fun `getCurrentPrayer should move to next when now equals prayer time`() {
-        // Given
         val base = Instant.fromEpochSeconds(10_000)
         val prayers = listOf(
             PrayerTime(PrayerName.FAJR, base, DEFAULT_HIJRI_DATE),
@@ -120,17 +106,14 @@ class MainMapperKtTest {
             PrayerTime(PrayerName.ASR, base + 8.hours, DEFAULT_HIJRI_DATE)
         )
 
-        // When
         val uiState = prayers.toUi(base)
 
-        // Then
         assertEquals(1, uiState.nextPrayerIndex)
         assertEquals(PrayerName.DHUHR, uiState.prayers[uiState.nextPrayerIndex].name)
     }
 
     @Test
     fun `toUi should handle missing prayers gracefully`() {
-        // Given
         val now = Instant.fromEpochSeconds(10_000)
         val prayers = listOf(
             PrayerTime(PrayerName.FAJR, now, DEFAULT_HIJRI_DATE),
@@ -138,10 +121,8 @@ class MainMapperKtTest {
             PrayerTime(PrayerName.ISHA, now + 13.hours, DEFAULT_HIJRI_DATE)
         )
 
-        // When
         val uiState = prayers.toUi(now)
 
-        // Then
         assertEquals(3, uiState.prayers.size)
         assertNotNull(uiState.nextPrayerIndex)
     }

--- a/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/main/MainViewModelTest.kt
+++ b/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/main/MainViewModelTest.kt
@@ -7,10 +7,11 @@ import dev.mokkery.answering.throws
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import net.thechance.mena.faith.domain.entity.PrayerName
 import net.thechance.mena.faith.domain.entity.PrayerTime
@@ -37,27 +38,21 @@ class MainViewModelTest {
     @OptIn(ExperimentalTime::class)
     @BeforeTest
     fun setup() {
-        // Given
         quranRepository = mock(MockMode.autofill)
         prayerTimeRepository = mock(MockMode.autofill)
 
         everySuspend { quranRepository.getLastAyahForTilawah() } returns fakeAyah
         everySuspend { prayerTimeRepository.getPrayerTimes(any(), any()) } returns fakePrayerTimes
 
-        // When
         viewModel = MainViewModel(quranRepository, prayerTimeRepository, testDispatcher)
-
     }
 
     @OptIn(ExperimentalTime::class)
     @Test
     fun `viewModel should load prayer times`() = runTest(testDispatcher) {
-
-        // When
-        advanceUntilIdle()
+        testDispatcher.scheduler.advanceUntilIdle()
         val state = viewModel.uiState.value
 
-        // Then
         assertFalse(state.isLoading)
         assertEquals(fakePrayerTimes.size, state.prayerTimes.size)
         assertTrue(state.prayerTimes.isNotEmpty())
@@ -65,8 +60,7 @@ class MainViewModelTest {
 
     @OptIn(ExperimentalTime::class)
     @Test
-    fun `init should handle prayer times error `() = runTest {
-        // Given
+    fun `init should handle prayer times error`() = runTest {
         everySuspend {
             prayerTimeRepository.getPrayerTimes(
                 any(),
@@ -74,12 +68,10 @@ class MainViewModelTest {
             )
         } throws Exception("Network error")
 
-        // When
         val failingViewModel = MainViewModel(quranRepository, prayerTimeRepository, testDispatcher)
-        advanceUntilIdle()
+        testDispatcher.scheduler.advanceUntilIdle()
         val state = failingViewModel.uiState.value
 
-        // Then
         assertFalse(state.isLoading)
         assertTrue(state.prayerTimes.isEmpty())
     }
@@ -87,29 +79,38 @@ class MainViewModelTest {
     @OptIn(ExperimentalTime::class)
     @Test
     fun `onContinueTilawahClick should emit NavigateToSurah effect`() = runTest {
-        // Given
-        advanceUntilIdle()
+        testDispatcher.scheduler.advanceUntilIdle()
 
-        // When
         viewModel.uiEffect.test {
             viewModel.onContinueTilawahClick(SURAH_ID, SURAH_NAME, AYAH_NUMBER)
 
-            // Then
-            assertEquals(MainScreenEffect.NavigateToSurah(SURAH_ID, SURAH_NAME,AYAH_NUMBER), awaitItem())
+            assertEquals(
+                MainScreenEffect.NavigateToSurah(SURAH_ID, SURAH_NAME, AYAH_NUMBER),
+                awaitItem()
+            )
+        }
+    }
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun `onQuranClick should emit NavigateToQuran effect`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.uiEffect.test {
+            viewModel.onQuranClick()
+
+            assertEquals(MainScreenEffect.NavigateToQuran, awaitItem())
         }
     }
 
     @OptIn(ExperimentalTime::class)
     @Test
     fun `onQiblahClick should emit NavigateToQiblah effect`() = runTest {
-        // Given
-        advanceUntilIdle()
+        testDispatcher.scheduler.advanceUntilIdle()
 
-        // When
         viewModel.uiEffect.test {
             viewModel.onQiblahClick()
 
-            // Then
             assertEquals(MainScreenEffect.NavigateToQiblah, awaitItem())
         }
     }
@@ -117,46 +118,29 @@ class MainViewModelTest {
     @OptIn(ExperimentalTime::class)
     @Test
     fun `onMosquesClick should emit NavigateToMosques effect`() = runTest {
-        // Given
-        advanceUntilIdle()
+        testDispatcher.scheduler.advanceUntilIdle()
 
-        // When
         viewModel.uiEffect.test {
             viewModel.onMosquesClick()
-
-            // Then
             assertEquals(MainScreenEffect.NavigateToMosques, awaitItem())
         }
     }
 
-    @OptIn(ExperimentalTime::class)
     @Test
-    fun `multiple navigation clicks should emit multiple effects`() = runTest {
-        // Given
-        advanceUntilIdle()
+    fun `refreshTilawah should load last ayah for tilawah`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
 
-        // When
-        viewModel.uiEffect.test {
-            viewModel.onQuranClick()
-            // Then
-            assertEquals(MainScreenEffect.NavigateToQuran, awaitItem())
+        viewModel.refreshTilawah()
+        testDispatcher.scheduler.advanceUntilIdle()
 
-            // When
-            viewModel.onQiblahClick()
-            // Then
-            assertEquals(MainScreenEffect.NavigateToQiblah, awaitItem())
-
-            // When
-            viewModel.onMosquesClick()
-            // Then
-            assertEquals(MainScreenEffect.NavigateToMosques, awaitItem())
-        }
+        verifySuspend(mode = exactly(2)) { quranRepository.getLastAyahForTilawah() } // once in init, once in refresh
     }
 
     private companion object {
         const val SURAH_ID = 1
         const val SURAH_NAME = "Al-Fatihah"
         const val AYAH_NUMBER = 1
+
         @OptIn(ExperimentalTime::class)
         private val now = Instant.fromEpochSeconds(1_700_000_000)
 


### PR DESCRIPTION
- Extract `MainTopBar`, `FaithFeatureCard`, and `CardIcon` into their own composable files.
- Add `@Preview` annotations to components for easier UI development.
- Simplify ViewModel success callbacks and navigation logic.
- Clean up tests by removing unnecessary `Given/When/Then` comments.
- Introduce `FaithFeatureType` enum to manage feature card data and actions.
- Refactor `MainScreen.kt` to improve structure and readability.