### PR TITLE
fix single image display in Chat

### DIFF
--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ImageMessageContent.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ImageMessageContent.kt
@@ -31,6 +31,16 @@ fun ImageMessageContent(
         val gridWith = maxWidth
         val gridHeight = maxHeight
 
+        if (displayImages.size == 1) {
+            ImageGridItem(
+                imageUrl = displayImages[0],
+                index = 0,
+                onClick = onImageClick,
+                modifier = Modifier.fillMaxSize()
+            )
+            return@BoxWithConstraints
+        }
+
         LazyHorizontalGrid(
             rows = GridCells.Fixed(gridCells),
             modifier = Modifier
@@ -41,17 +51,6 @@ fun ImageMessageContent(
             userScrollEnabled = false
         ) {
             when (displayImages.size) {
-                1 -> {
-                    item {
-                        ImageGridItem(
-                            imageUrl = displayImages[0],
-                            index = 0,
-                            onClick = onImageClick,
-                            modifier = Modifier.fillMaxSize()
-                        )
-                    }
-                }
-
                 2 -> {
                     items(2) { index ->
                         ImageGridItem(


### PR DESCRIPTION
| Before | After |
|--------|-------|
| ![Before Image](https://github.com/user-attachments/assets/47fdfa68-0276-4bc5-ab3e-e0abc2b02d6e) | ![After Image](https://github.com/user-attachments/assets/d00774fa-bcee-4789-97bd-c26980df5df9) |