### PR TITLE
Fix/TRN-78-update home screen state handling

### DIFF
--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
@@ -138,7 +138,7 @@ private fun HomeScreenContent(
 
             AnimatedVisibility(
                 modifier = Modifier.align(Alignment.BottomEnd),
-                visible = reels.loadState.refresh !is LoadState.Loading,
+                visible = shouldShowEmptyState && !hasNetworkError,
                 content = { AddTrendFAB(onClickFab = { listener.onClickAddReel() }) }
             )
         }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
@@ -107,7 +107,7 @@ private fun HomeScreenContent(
 
         val shouldShowEmptyState = reels.itemSnapshotList.isEmpty() &&
                 reels.loadState.refresh is LoadState.NotLoading &&
-                reels.loadState.refresh !is LoadState.Error
+                reels.loadState.refresh.toErrorState() == null
 
         Box(modifier = Modifier.fillMaxSize()) {
             AnimatedVisibility(
@@ -138,7 +138,7 @@ private fun HomeScreenContent(
 
             AnimatedVisibility(
                 modifier = Modifier.align(Alignment.BottomEnd),
-                visible = state.isLoading.not(),
+                visible = reels.itemSnapshotList.isNotEmpty() && reels.loadState.refresh !is LoadState.Loading,
                 content = { AddTrendFAB(onClickFab = { listener.onClickAddReel() }) }
             )
         }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
 import app.cash.paging.compose.LazyPagingItems
 import app.cash.paging.compose.collectAsLazyPagingItems
 import mena.trends_presentation.generated.resources.Res
@@ -100,18 +101,22 @@ private fun HomeScreenContent(
         }
     ) {
         val reels = state.reels.collectAsLazyPagingItems()
+
+        val hasNetworkError = reels.loadState.refresh.toErrorState() == ErrorState.NoInternet
+                && reels.itemSnapshotList.isEmpty()
+
         val shouldShowEmptyState = reels.itemSnapshotList.isEmpty() &&
-                !state.isLoading &&
-                reels.loadState.refresh.toErrorState() == null
+                reels.loadState.refresh is LoadState.NotLoading &&
+                reels.loadState.refresh !is LoadState.Error
 
         Box(modifier = Modifier.fillMaxSize()) {
             AnimatedVisibility(
-                visible = state.isLoading,
+                visible = reels.loadState.refresh is LoadState.Loading,
                 content = { LoadingProgressBar() }
             )
 
             AnimatedVisibility(
-                visible = reels.loadState.refresh.toErrorState() == ErrorState.NoInternet,
+                visible = hasNetworkError,
                 content = { NoConnection { listener.onClickRetry() } }
             )
 
@@ -121,7 +126,7 @@ private fun HomeScreenContent(
             )
 
             AnimatedVisibility(
-                visible = reels.itemSnapshotList.isNotEmpty() && state.isLoading.not(),
+                visible = reels.itemSnapshotList.isNotEmpty() && reels.loadState.refresh !is LoadState.Loading,
                 content = {
                     ReelsListSection(
                         reels = reels,

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
@@ -138,7 +138,7 @@ private fun HomeScreenContent(
 
             AnimatedVisibility(
                 modifier = Modifier.align(Alignment.BottomEnd),
-                visible = reels.itemSnapshotList.isNotEmpty() && reels.loadState.refresh !is LoadState.Loading,
+                visible = reels.loadState.refresh !is LoadState.Loading,
                 content = { AddTrendFAB(onClickFab = { listener.onClickAddReel() }) }
             )
         }


### PR DESCRIPTION
The home screen's state handling is updated to rely on the `PagingItems` load state instead of the ViewModel's `isLoading` state. This change improves the accuracy of loading, empty, and error state representations.