### PR TITLE
Refactor/WLT-82 Improve Viewmodel Error Handling

### DIFF
--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/base/BaseViewModel.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/base/BaseViewModel.kt
@@ -3,6 +3,8 @@ package net.thechance.mena.wallet.presentation.base
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
@@ -14,7 +16,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import net.thechance.mena.wallet.domain.exceptions.NoDataFoundException
 import net.thechance.mena.wallet.domain.exceptions.NoInternetException
-import kotlin.coroutines.cancellation.CancellationException
 
 abstract class BaseViewModel<STATE, EFFECT>(initialState: STATE) : ViewModel() {
     private val _state = MutableStateFlow(initialState)
@@ -43,17 +44,17 @@ abstract class BaseViewModel<STATE, EFFECT>(initialState: STATE) : ViewModel() {
         onStart: (suspend () -> Unit)? = null,
         onFinish: (suspend () -> Unit)? = null,
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        inScope: CoroutineScope = viewModelScope
     ): Job {
-        return viewModelScope.launch(dispatcher) {
+        val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+            inScope.launch {
+                onError(mapError(throwable))
+            }
+        }
+        return inScope.launch(dispatcher + exceptionHandler) {
             try {
                 onStart?.invoke()
-                callee().let { result ->
-                    onSuccess(result)
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (t: Throwable) {
-                onError(mapError(t))
+                onSuccess(callee())
             } finally {
                 onFinish?.invoke()
             }

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/base/BaseViewModel.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/base/BaseViewModel.kt
@@ -47,16 +47,16 @@ abstract class BaseViewModel<STATE, EFFECT>(initialState: STATE) : ViewModel() {
         inScope: CoroutineScope = viewModelScope
     ): Job {
         val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
-            inScope.launch { onError(mapError(throwable)) }
+            inScope.launch {
+                onError(mapError(throwable))
+                onFinish?.invoke()
+            }
         }
 
         return inScope.launch(dispatcher + exceptionHandler) {
-            try {
-                onStart?.invoke()
-                onSuccess(callee())
-            } finally {
-                onFinish?.invoke()
-            }
+            onStart?.invoke()
+            onSuccess(callee())
+            onFinish?.invoke()
         }
     }
 

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/base/BaseViewModel.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/base/BaseViewModel.kt
@@ -47,10 +47,9 @@ abstract class BaseViewModel<STATE, EFFECT>(initialState: STATE) : ViewModel() {
         inScope: CoroutineScope = viewModelScope
     ): Job {
         val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
-            inScope.launch {
-                onError(mapError(throwable))
-            }
+            inScope.launch { onError(mapError(throwable)) }
         }
+
         return inScope.launch(dispatcher + exceptionHandler) {
             try {
                 onStart?.invoke()

--- a/wallet_presentation/src/commonTest/kotlin/net/thechance/mena/wallet/presentation/screen/wallet/WalletViewModelTest.kt
+++ b/wallet_presentation/src/commonTest/kotlin/net/thechance/mena/wallet/presentation/screen/wallet/WalletViewModelTest.kt
@@ -80,9 +80,9 @@ class WalletViewModelTest {
         everySuspend { balanceRepository.getBalance() } throws expectedException
 
         val viewModel = WalletViewModel( stringProvider,balanceRepository, transactionRepository, testDispatcher)
+        advanceUntilIdle()
 
         viewModel.state.test {
-            skipItems(2)
 
             val errorState = awaitItem().balanceState.errorState
             assertEquals(ErrorState.UnknownError, errorState)
@@ -99,7 +99,7 @@ class WalletViewModelTest {
         val viewModel = WalletViewModel( stringProvider,balanceRepository, transactionRepository, testDispatcher)
 
         viewModel.state.test {
-            skipItems(3)
+            skipItems(4)
 
             val snackBarState = awaitItem()
             assertSnackBarState(isVisible = true, isSuccess = false, snackBarState = snackBarState.snackBar)


### PR DESCRIPTION
### PR Content:
- Utilize `CoroutineExceptionHandler` in `tryToExecute` to handle uncaught exceptions caused by child coroutines.