### PR TITLE
fix: hide hijri date and sunrise time if blank

### DIFF
--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/MainScreen.kt
@@ -132,17 +132,23 @@ private fun PrayerSection(
         verticalArrangement = Arrangement.spacedBy(Theme.spacing._8)
     ) {
         PrayerTimesCard(prayerTimesUiState = uiState.prayerTimesUiState)
-        Text(
-            text = uiState.hijriDate,
-            color = Theme.colorScheme.shadeSecondary,
-            style = Theme.typography.label.extraSmall
-        )
-        SunriseTimeRow(
-            icon = painterResource(Res.drawable.ic_sunrise),
-            title = stringResource(Res.string.sunrise_time_label),
-            time = uiState.sunriseTime,
-            modifier = Modifier.padding(vertical = Theme.spacing._12)
-        )
+        if (uiState.hijriDate.isNotBlank()) {
+            Text(
+                text = uiState.hijriDate,
+                color = Theme.colorScheme.shadeSecondary,
+                style = Theme.typography.label.extraSmall
+            )
+        }
+
+        if (uiState.sunriseTime.isNotBlank()) {
+            SunriseTimeRow(
+                icon = painterResource(Res.drawable.ic_sunrise),
+                title = stringResource(Res.string.sunrise_time_label),
+                time = uiState.sunriseTime,
+                modifier = Modifier.padding(vertical = Theme.spacing._12)
+            )
+        }
+
         TilawahSection(
             tilawahUiState = uiState.tilawahUiState,
             onContinueTilawahClick = onContinueTilawahClick(uiState, listener),

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/search/component/SearchEmptyState.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/search/component/SearchEmptyState.kt
@@ -6,12 +6,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import mena.faith_presentation.generated.resources.Res
 import mena.faith_presentation.generated.resources.ic_empty_search
 import mena.faith_presentation.generated.resources.ic_search_warning
@@ -45,7 +43,6 @@ internal fun SearchEmptyState(
     ) {
         EmptyStateIcon(
             isStartState = isStartState,
-            modifier = modifier
         )
 
         Text(
@@ -67,10 +64,9 @@ internal fun SearchEmptyState(
 @Composable
 private fun EmptyStateIcon(
     isStartState: Boolean,
-    modifier: Modifier
+    modifier: Modifier = Modifier
 ) {
     Box(
-        modifier = modifier.size(128.dp),
         contentAlignment = Alignment.Center
     ) {
         Image(


### PR DESCRIPTION
### Fixed show empty prayer time data, when there’s no prayer time data from the backend, the related section should be hidden.

<img width="322" height="701" alt="image" src="https://github.com/user-attachments/assets/96254387-ea16-4f42-82f2-e24ead525b98" />

### Fixed the empty search state text alignment to be centered instead of aligned to the bottom.

<img width="327" height="701" alt="image" src="https://github.com/user-attachments/assets/f3ef5111-53c6-4482-bb24-085541ac723c" />
