### PR TITLE
fix: use remember instead of rememberSaveable

### DIFF
--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/createDukan/component/Map.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/createDukan/component/Map.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
@@ -55,7 +56,7 @@ fun Map(
 
     var locked by rememberSaveable { mutableStateOf(isLocked) }
     val camera = rememberCameraState(firstPosition = cameraPosition)
-    var screenSize by rememberSaveable { mutableStateOf(Pair(0.dp, 0.dp)) }
+    var screenSize by remember { mutableStateOf(Pair(0.dp, 0.dp)) }
     LaunchedEffect(Unit) {
         camera.animateTo(
             finalPosition = cameraPosition,
@@ -79,7 +80,6 @@ fun Map(
                 locked = false
             }
         }
-
         MaplibreMap(
             modifier = Modifier.fillMaxSize(),
             cameraState = camera,


### PR DESCRIPTION
fix when create dukan when navigate to map crash because rememberSaveable with pair cant serialize on old device

[screencast-Genymotion-2025-10-29_11.31.42.375.webm](https://github.com/user-attachments/assets/de64de49-c9aa-4c44-ae02-51090cfc3572)
