### PR TITLE
feat: implement Quran audio player for Android and iOS

### DIFF
--- a/faith_data/build.gradle.kts
+++ b/faith_data/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.androidx.room.sqlite.wrapper)
             implementation(libs.ktor.client.cio)
+            implementation(libs.androidx.media3.exoplayer.v180)
         }
         commonMain.dependencies {
             implementation(compose.runtime)

--- a/faith_data/src/androidMain/kotlin/net/thechance/mena/faith/data/audio/QuranPlayer.android.kt
+++ b/faith_data/src/androidMain/kotlin/net/thechance/mena/faith/data/audio/QuranPlayer.android.kt
@@ -1,0 +1,36 @@
+package net.thechance.mena.faith.data.audio
+
+import android.content.Context
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.ExoPlayer
+import net.thechance.mena.faith.domain.mediaPlayer.QuranPlayer
+import org.koin.mp.KoinPlatform.getKoin
+
+actual class QuranPlayerImpl() : QuranPlayer {
+    private val context = getKoin().get<Context>()
+    private val quranPlayer: ExoPlayer = ExoPlayer.Builder(context).build()
+
+    actual override fun playAyah(ayahUrl: String) {
+        if (ayahUrl.isEmpty()) return
+
+        quranPlayer.stop()
+        quranPlayer.clearMediaItems()
+        val mediaItem = MediaItem.fromUri(ayahUrl)
+
+        quranPlayer.setMediaItem(mediaItem)
+        quranPlayer.prepare()
+
+        quranPlayer.play()
+    }
+
+    actual override fun pauseAyah() {
+        quranPlayer.pause()
+    }
+
+
+    actual override fun repeatCurrentAyah() {
+        val currentAyah = quranPlayer.currentMediaItemIndex
+        quranPlayer.seekTo(currentAyah, 0L)
+        quranPlayer.play()
+    }
+}

--- a/faith_data/src/androidMain/kotlin/net/thechance/mena/faith/data/di/platformModule.android.kt
+++ b/faith_data/src/androidMain/kotlin/net/thechance/mena/faith/data/di/platformModule.android.kt
@@ -2,9 +2,13 @@ package net.thechance.mena.faith.data.di
 
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
+import net.thechance.mena.faith.data.audio.QuranPlayerImpl
 import net.thechance.mena.faith.data.database.QuranDatabase
 import net.thechance.mena.faith.data.database.QuranDatabaseBuilder
 import net.thechance.mena.faith.data.database.getQuranDatabase
+import net.thechance.mena.faith.domain.mediaPlayer.QuranPlayer
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 internal actual fun platformModule() = module {
@@ -13,4 +17,7 @@ internal actual fun platformModule() = module {
     }.also {
         Napier.base(DebugAntilog())
     }
+
+    singleOf(::QuranPlayerImpl) bind QuranPlayer::class
+
 }

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/audio/QuranPlayerImpl.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/audio/QuranPlayerImpl.kt
@@ -1,0 +1,9 @@
+package net.thechance.mena.faith.data.audio
+
+import net.thechance.mena.faith.domain.mediaPlayer.QuranPlayer
+
+expect class QuranPlayerImpl : QuranPlayer {
+    override fun playAyah(ayahUrl: String)
+    override fun pauseAyah()
+    override fun repeatCurrentAyah()
+}

--- a/faith_data/src/iosMain/kotlin/net/thechance/mena/faith/data/audio/QuranPlayer.ios.kt
+++ b/faith_data/src/iosMain/kotlin/net/thechance/mena/faith/data/audio/QuranPlayer.ios.kt
@@ -1,0 +1,39 @@
+package net.thechance.mena.faith.data.audio
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import net.thechance.mena.faith.domain.mediaPlayer.QuranPlayer
+import platform.AVFoundation.AVPlayer
+import platform.AVFoundation.AVPlayerItem
+import platform.AVFoundation.pause
+import platform.AVFoundation.play
+import platform.AVFoundation.seekToTime
+import platform.CoreMedia.CMTimeMake
+import platform.Foundation.NSURL
+
+actual class QuranPlayerImpl : QuranPlayer {
+    private var player: AVPlayer? = null
+
+    actual override fun playAyah(ayahUrl: String) {
+        if (ayahUrl.isEmpty()) return
+
+        player?.pause()
+        player = null
+
+        val ayahURL = NSURL.URLWithString(ayahUrl)
+        if (ayahURL != null) {
+            val item = AVPlayerItem.playerItemWithURL(ayahURL)
+            player = AVPlayer(item)
+            player?.play()
+        }
+    }
+
+    actual override fun pauseAyah() {
+        player?.pause()
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    actual override fun repeatCurrentAyah() {
+        player?.seekToTime(CMTimeMake(0, 1))
+        player?.play()
+    }
+}

--- a/faith_data/src/iosMain/kotlin/net/thechance/mena/faith/data/di/platformModule.ios.kt
+++ b/faith_data/src/iosMain/kotlin/net/thechance/mena/faith/data/di/platformModule.ios.kt
@@ -1,12 +1,18 @@
 package net.thechance.mena.faith.data.di
 
+import net.thechance.mena.faith.data.audio.QuranPlayerImpl
 import net.thechance.mena.faith.data.database.QuranDatabase
 import net.thechance.mena.faith.data.database.QuranDatabaseBuilder
 import net.thechance.mena.faith.data.database.getQuranDatabase
+import net.thechance.mena.faith.domain.mediaPlayer.QuranPlayer
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 internal actual fun platformModule() = module {
     single<QuranDatabase> {
         getQuranDatabase(QuranDatabaseBuilder().getBuilder())
     }
+
+    singleOf(::QuranPlayerImpl) bind QuranPlayer::class
 }

--- a/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/mediaPlayer/QuranPlayer.kt
+++ b/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/mediaPlayer/QuranPlayer.kt
@@ -1,0 +1,7 @@
+package net.thechance.mena.faith.domain.mediaPlayer
+
+interface QuranPlayer {
+    fun playAyah(ayahUrl: String)
+    fun pauseAyah()
+    fun repeatCurrentAyah()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ kotlin = "2.2.10"
 koverVersion = "0.9.1"
 kotlinxDatetime = "0.7.1"
 media3Exoplayer = "1.5.1"
+media3ExoplayerVersion = "1.8.0"
 napier = "2.7.1"
 navigationCompose = "2.9.0-rc02"
 ksp = "2.2.10-2.0.2"
@@ -59,8 +60,8 @@ peekaboo = "0.5.2"
 [libraries]
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3Exoplayer" }
 androidx-media3-exoplayer-dash = { module = "androidx.media3:media3-exoplayer-dash", version.ref = "media3Exoplayer" }
+androidx-media3-exoplayer-v180 = { module = "androidx.media3:media3-exoplayer", version.ref = "media3ExoplayerVersion" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3Exoplayer" }
-androidx-datastore-preferences-core = { module = "androidx.datastore:datastore-preferences-core", version.ref = "androidx-datastore" }
 androidx-paging-compose = { module = "app.cash.paging:paging-compose-common", version.ref = "paging-compose-version" }
 androidx-paging-runtime = { module = "app.cash.paging:paging-common", version.ref = "paging-compose-version" }
 androidx-paging-testing = { module = "androidx.paging:paging-testing", version.ref = "pagingTesting" }


### PR DESCRIPTION
implement Quran audio player for Android and iOS
------------------------------------------------------------------------------
-   **Android:** An `ExoPlayer`-based implementation (`QuranPlayerImpl`) for playing, pausing, and repeating Ayahs.
-   **iOS:** An `AVPlayer`-based implementation (`QuranPlayerImpl`) with the same playback functionalities.
-   **Koin DI:** The respective platform-specific `QuranPlayerImpl` is provided via Koin dependency injection.
-   **Dependencies:** Updated `media3-exoplayer` version and added it to the `faith_data` module.