### PR TITLE
fix:fix downloaded statements wrong dates at ios

### DIFF
--- a/wallet_presentation/src/iosMain/kotlin/net/thechance/mena/wallet/presentation/utils/dateFormatter.ios.kt
+++ b/wallet_presentation/src/iosMain/kotlin/net/thechance/mena/wallet/presentation/utils/dateFormatter.ios.kt
@@ -8,6 +8,7 @@ import kotlinx.datetime.toInstant
 import platform.Foundation.NSDate
 import platform.Foundation.NSDateFormatter
 import platform.Foundation.NSTimeZone
+import platform.Foundation.dateWithTimeIntervalSince1970
 import platform.Foundation.localTimeZone
 import kotlin.time.ExperimentalTime
 
@@ -17,7 +18,8 @@ actual fun formatLocalDateTime(date: LocalDateTime, outputFormat: String): Strin
         dateFormat = outputFormat
         timeZone = NSTimeZone.localTimeZone
     }
-    val nsDate = NSDate(date.toEpochSeconds())
+    val epochSeconds = date.toEpochSeconds()
+    val nsDate = NSDate.dateWithTimeIntervalSince1970(epochSeconds)
     return formatter.stringFromDate(nsDate)
 }
 


### PR DESCRIPTION
issue:
NSDate (Apple's date system) counts time starting from January 1, 2001.
But my code converts dates to seconds counted from January 1, 1970 (Unix time).
so my dates were ~31 years off (the gap between 1970 and 2001)

solution :
val nsDate = NSDate.dateWithTimeIntervalSince1970(epochSeconds)
This tells NSDate: "i'm giving you seconds counted from 1970, not 2001" - so it interprets the time correctly.

before:
<img width="300" height="350" alt="Screenshot 2025-10-30 at 3 42 50 AM" src="https://github.com/user-attachments/assets/8d60335d-cddc-40b4-83ac-219310b35c62" />

after:
<img width="360" height="380" alt="Screenshot 2025-10-30 at 3 28 27 PM" src="https://github.com/user-attachments/assets/b15e9431-aaa9-489e-a8f9-8ac3ca60fad2" />
