### PR TITLE
fix:UI in Dukan screens

### DIFF
--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/chip/SelectionRow.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/chip/SelectionRow.kt
@@ -22,12 +22,11 @@ fun SelectionRow(
     isItemSelected: (CreateDukanUiState.DukanCategoryUiState) -> Boolean,
     onItemClicked: (CreateDukanUiState.DukanCategoryUiState) -> Boolean,
     onItemEnabled: (CreateDukanUiState.DukanCategoryUiState) -> Boolean,
-    modifier: Modifier = Modifier
 ) {
     LazyRow(
         contentPadding = PaddingValues(horizontal = Theme.spacing._16),
         horizontalArrangement = Arrangement.spacedBy(Theme.spacing._8),
-        modifier = modifier.requiredWidth(getScreenWidth())
+        modifier = Modifier.requiredWidth(getScreenWidth())
     ) {
         items(availableItems) { item ->
             Chip(

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/chip/SelectionRow.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/chip/SelectionRow.kt
@@ -2,6 +2,7 @@ package net.thechance.mena.dukan.presentation.component.chip
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -12,6 +13,7 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.rememberAsyncImagePainter
 import net.thechance.mena.designsystem.presentation.component.chip.Chip
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.dukan.presentation.util.getScreenWidth
 import net.thechance.mena.dukan.presentation.viewModel.createDukan.CreateDukanUiState
 
 @Composable
@@ -20,10 +22,12 @@ fun SelectionRow(
     isItemSelected: (CreateDukanUiState.DukanCategoryUiState) -> Boolean,
     onItemClicked: (CreateDukanUiState.DukanCategoryUiState) -> Boolean,
     onItemEnabled: (CreateDukanUiState.DukanCategoryUiState) -> Boolean,
+    modifier: Modifier = Modifier
 ) {
     LazyRow(
         contentPadding = PaddingValues(horizontal = Theme.spacing._16),
-        horizontalArrangement = Arrangement.spacedBy(Theme.spacing._8)
+        horizontalArrangement = Arrangement.spacedBy(Theme.spacing._8),
+        modifier = modifier.requiredWidth(getScreenWidth())
     ) {
         items(availableItems) { item ->
             Chip(

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/product/EditProductIcon.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/product/EditProductIcon.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import mena.dukan_presentation.generated.resources.Res
 import mena.dukan_presentation.generated.resources.edit_product_pencil
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
@@ -24,11 +25,9 @@ fun EditProductIcon(
         painter = painterResource(Res.drawable.edit_product_pencil),
         contentDescription = stringResource(Res.string.edit_product_pencil),
         modifier = modifier
+            .clip(RoundedCornerShape(Theme.radius.full))
+            .background(Theme.colorScheme.primary.primary)
             .clickable(onClick = onClick)
-            .background(
-                color = Theme.colorScheme.primary.primary,
-                shape = RoundedCornerShape(size = Theme.radius.full)
-            )
             .padding(Theme.spacing._8)
     )
 }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/product/ProductInfo.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/product/ProductInfo.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextOverflow
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 
@@ -18,7 +17,8 @@ fun ProductInfo(
         Text(
             text = name,
             style = Theme.typography.label.medium,
-            color = Theme.colorScheme.shadePrimary
+            color = Theme.colorScheme.shadePrimary,
+            maxLines = 1,
         )
 
         description?.let {
@@ -29,7 +29,6 @@ fun ProductInfo(
                 color = Theme.colorScheme.shadeTertiary,
                 maxLines = 2,
                 minLines = 2,
-                overflow = TextOverflow.Ellipsis
             )
         }
     }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/createDukan/content/CreateDukanContentBasicInformation.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/createDukan/content/CreateDukanContentBasicInformation.kt
@@ -45,7 +45,11 @@ fun CreateDukanPagerContent(
         modifier = Modifier
             .fillMaxSize()
             .background(Theme.colorScheme.background.surface),
-        contentPadding = PaddingValues(bottom = Theme.spacing._16)
+        contentPadding = PaddingValues(
+            start = Theme.spacing._16,
+            end = Theme.spacing._16,
+            bottom = Theme.spacing._16
+        )
     ) {
         item {
             HeaderSection()
@@ -57,7 +61,6 @@ fun CreateDukanPagerContent(
                 onValueChanged = interactionListener::onNameChanged,
                 hint = stringResource(Res.string.enter_dukan_name),
                 modifier = Modifier
-                    .padding(horizontal = Theme.spacing._16)
                     .padding(bottom = Theme.spacing._12),
                 leadingIcon = painterResource(Res.drawable.ic_shop),
                 title = stringResource(Res.string.dukan_name),
@@ -83,7 +86,6 @@ private fun HeaderSection() {
         text = stringResource(Res.string.enter_your_dukan_information),
         style = Theme.typography.title.medium,
         color = Theme.colorScheme.shadePrimary,
-        modifier = Modifier.padding(horizontal = Theme.spacing._16),
         textAlign = TextAlign.Start
     )
 
@@ -92,7 +94,6 @@ private fun HeaderSection() {
         style = Theme.typography.body.small,
         color = Theme.colorScheme.shadeSecondary,
         modifier = Modifier
-            .padding(horizontal = Theme.spacing._16)
             .padding(bottom = Theme.spacing._16),
         textAlign = TextAlign.Start
     )
@@ -105,21 +106,19 @@ private fun CategoryHeaderSection() {
         style = Theme.typography.title.small,
         color = Theme.colorScheme.shadePrimary,
         modifier = Modifier
-            .padding(horizontal = Theme.spacing._16)
             .padding(bottom = Theme.spacing._4),
         textAlign = TextAlign.Start
     )
 
     Row(
         modifier = Modifier
-            .padding(horizontal = Theme.spacing._16)
             .padding(bottom = Theme.spacing._8),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
             modifier = Modifier
                 .padding(vertical = Theme.spacing._2)
-                .padding(bottom = Theme.spacing._2)
+                .padding(end = Theme.spacing._2)
                 .align(Alignment.CenterVertically)
                 .size(12.dp),
             painter = painterResource(Res.drawable.ic_alert_circle),

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/dukanDetails/components/noImageDukanDetails/NoImageDukanShelves.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/dukanDetails/components/noImageDukanDetails/NoImageDukanShelves.kt
@@ -57,8 +57,8 @@ fun NoImageDukanShelves(
     AnimatedContent(
         targetState = shelves.loadState.refresh,
         label = "ShelvesContentAnimation"
-    ) {
-        when (it) {
+    ) { loadingState ->
+        when (loadingState) {
             LoadState.Loading -> NoImageDukanShelvesSkeleton()
             is LoadState.NotLoading -> {
                 LazyColumn(

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/dukanDetails/components/wideImageDukanDetails/WideImageDukanProducts.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/dukanDetails/components/wideImageDukanDetails/WideImageDukanProducts.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import app.cash.paging.compose.LazyPagingItems
 import coil3.compose.AsyncImage
@@ -78,8 +77,7 @@ private fun ProductCard(
                 text = title,
                 style = Theme.typography.label.small,
                 color = Theme.colorScheme.shadePrimary,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
                 modifier = Modifier.padding(top = Theme.spacing._12)
             )
 


### PR DESCRIPTION
- handle max lines 
- remove horizontal padding in each item in create dukan screen, use content padding in lazy column 
- fix ripple on product edit icon 
- fix icon padding with category selection 