### PR TITLE
Fix/cht 79 general bugs

### DIFF
--- a/core_chat_presentation/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core_chat_presentation/src/commonMain/composeResources/values-ar/strings.xml
@@ -46,4 +46,5 @@
     <string name="you">أنت</string>
     <string name="could_not_get_sync_contacts_status">لم نتمكن من الحصول على حالة مزامنة جهات الاتصال، يرجى المحاولة مرة أخرى.</string>
     <string name="could_not_load_chats">فشل تحميل المحادثات</string>
+    <string name="could_not_get_balance">فشل جلب الرصيد الحالي</string>
 </resources>

--- a/core_chat_presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core_chat_presentation/src/commonMain/composeResources/values/strings.xml
@@ -46,4 +46,5 @@
     <string name="you">You</string>
     <string name="could_not_get_sync_contacts_status">Could not get sync contacts status, please try again</string>
     <string name="could_not_load_chats">Could not get chats</string>
+    <string name="could_not_get_balance">Could not get current balance</string>
 </resources>

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/components/LoadingView.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/components/LoadingView.kt
@@ -1,0 +1,19 @@
+package net.thechance.mena.core_chat.presentation.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import net.thechance.mena.designsystem.presentation.component.indicator.DotsProgressIndicator
+
+
+@Composable
+fun LoadingView(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        DotsProgressIndicator()
+    }
+}

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/components/SkeletonShape.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/components/SkeletonShape.kt
@@ -1,0 +1,36 @@
+package net.thechance.mena.core_chat.presentation.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+
+@Composable
+fun SkeletonShape(
+    modifier: Modifier = Modifier,
+    durationMillis: Int = 2000,
+    background: Color = Theme.colorScheme.background.surfaceHigh
+) {
+    val transition = rememberInfiniteTransition(label = "skeletonAnimation")
+    val alphaAnim by transition.animateFloat(
+        initialValue = 0.5f, targetValue = 1f, animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = durationMillis, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        )
+    )
+    Box(
+        modifier = modifier
+            .background(color = background)
+            .alpha(alphaAnim)
+    )
+}

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModel.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.LocalDateTime
 import mena.core_chat_presentation.generated.resources.Res
 import mena.core_chat_presentation.generated.resources.error
 import mena.core_chat_presentation.generated.resources.error_cant_get_messages
@@ -44,6 +45,7 @@ import net.thechance.mena.core_chat.presentation.utils.Paginator
 import net.thechance.mena.core_chat.presentation.utils.UiText
 import net.thechance.mena.core_chat.presentation.utils.encodeToByteArrayWithCompressionToMaxSize
 import net.thechance.mena.core_chat.presentation.utils.getUuidOrNull
+import net.thechance.mena.core_chat.presentation.utils.now
 import org.jetbrains.compose.resources.StringResource
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -102,14 +104,22 @@ class ChatViewModel(
 
     private fun startUiDerivation() {
         viewModelScope.launch(dispatcher) {
+            var earliestUnReadMessageTime: LocalDateTime = LocalDateTime.now()
             messages
-                .map { list -> list.map { it.toUi() } }
+                .map { list ->
+                    list.map {
+                        if (it.status == MessageStatus.SENT && it.sendAt < earliestUnReadMessageTime) {
+                            earliestUnReadMessageTime = it.sendAt
+                            println(earliestUnReadMessageTime)
+                        }
+                        it.toUi()
+                    }
+                }
                 .collectLatest { uiList ->
                     updateState { state ->
                         state.copy(
                             chatListItems = uiList
-                                .sortedByDescending { it.sendTime }
-                                .buildListItems()
+                                .buildListItems { msg -> msg.status != MessageStatus.FAILED && msg.status != MessageStatus.LOADING && msg.sendTime < earliestUnReadMessageTime }
                         )
                     }
                 }
@@ -229,7 +239,7 @@ class ChatViewModel(
     }
 
     private suspend fun onSendMessageSuccess(message: MessageUiState) {
-        safeUpdateMessages { messages -> messages.filter{ it.id != message.id && it.sendAt != message.sendTime } }
+        safeUpdateMessages { messages -> messages.filter { it.id != message.id && it.sendAt != message.sendTime } }
     }
 
     override fun onMessageClicked(messageId: Uuid) {
@@ -257,7 +267,7 @@ class ChatViewModel(
     }
 
     private suspend fun onDeleteFailedMessageSuccess(failedMessage: MessageUiState) {
-        safeUpdateMessages { messages -> messages.filter{ it.id != failedMessage.id } }
+        safeUpdateMessages { messages -> messages.filter { it.id != failedMessage.id } }
         updateState { state ->
             state.copy(
                 failedMessageToReSend = null,
@@ -288,13 +298,7 @@ class ChatViewModel(
         tryToCollect(
             collect = { messageRepository.observeMessagesForChatOrAll(chatId) },
             onCollect = ::onCollectNewMessage,
-            onError = {
-                showSnackBar(
-                    Res.string.error,
-                    Res.string.error_cant_subscribe_to_new_messages,
-                    true
-                )
-            },
+            onError = { onCollectNewMessageFailed() },
         )
     }
 
@@ -303,10 +307,17 @@ class ChatViewModel(
         safeUpdateMessages { current ->
             current.toMutableList().apply { add(0, message) }
                 .distinctBy { it.id }
-                .sortedByDescending { it.sendAt }
         }
 
         messageRepository.markMessagesOfChatAsRead(message.chatId)
+    }
+
+    private fun onCollectNewMessageFailed() {
+        showSnackBar(
+            Res.string.error,
+            Res.string.error_cant_subscribe_to_new_messages,
+            true
+        )
     }
 
     private fun subscribeToPendingMessages(chatId: Uuid) {
@@ -324,7 +335,6 @@ class ChatViewModel(
                 .toMutableList()
                 .apply { addAll(pendingMessages) }
                 .distinctBy { it.id }
-                .sortedByDescending { it.sendAt }
         }
 
         if (!hasResentPendingMessages) {
@@ -348,7 +358,6 @@ class ChatViewModel(
         safeUpdateMessages { current ->
             current.toMutableList().apply { addAll(messages.data) }
                 .distinctBy { it.id }
-                .sortedByDescending { it.sendAt }
         }
         messageRepository.markMessagesOfChatAsRead(state.value.chatId ?: return)
 
@@ -371,10 +380,7 @@ class ChatViewModel(
 
             }
         }
-
     }
-
-
 
     override fun onMessageImageClicked(messages: List<MessageUiState>, initialImageIndex: Int) {
         updateState {
@@ -478,6 +484,7 @@ class ChatViewModel(
             _messages.update(block)
         }
     }
+
     companion object {
         const val PAGE_SIZE = 40
         const val INITIAL_PAGE = 0

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatListItem.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatListItem.kt
@@ -2,8 +2,6 @@
 
 package net.thechance.mena.core_chat.presentation.screen.chat.components
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -42,36 +40,28 @@ fun ChatListItem(
 
         is ChatListItem.TextMessage -> {
             val markedMessage = item.data
-            Row(
-                modifier = modifier.fillMaxWidth(),
-                horizontalArrangement = if (markedMessage.isMine) Arrangement.End else Arrangement.Start
-            ) {
-                TextMessageLayout(
-                    message = markedMessage,
-                    chatAvatarUrl = chatAvatarUrl,
-                    showMessageInfo = (markedMessage.isVisibleMessageInfo || markedMessage.isLastInSeries || markedMessage.status == MessageStatus.FAILED),
-                    isMarkedLastInSeries = markedMessage.isLastInSeries,
-                    onMessageClick = { onMessageClick(markedMessage.id) },
-                    onFailClick = { onFailedMessageClick(markedMessage) },
-                )
-            }
+            TextMessageLayout(
+                modifier = modifier,
+                message = markedMessage,
+                chatAvatarUrl = chatAvatarUrl,
+                showMessageInfo = (markedMessage.isVisibleMessageInfo || markedMessage.isLastInSeries || markedMessage.status == MessageStatus.FAILED),
+                isMarkedLastInSeries = markedMessage.isLastInSeries,
+                onMessageClick = { onMessageClick(markedMessage.id) },
+                onFailClick = { onFailedMessageClick(markedMessage) },
+            )
         }
 
         is ChatListItem.ImageMessages -> {
             val markedMessage = item.data
-            Row(
-                modifier = modifier.fillMaxWidth(),
-                horizontalArrangement = if (markedMessage.last().isMine) Arrangement.End else Arrangement.Start
-            ) {
-                ImageMessagesLayout(
-                    messages = markedMessage,
-                    chatAvatarUrl = chatAvatarUrl,
-                    showMessageInfo = (markedMessage.last().isVisibleMessageInfo || markedMessage.last().isLastInSeries || markedMessage.last().status == MessageStatus.FAILED),
-                    isMarkedLastInSeries = markedMessage.last().isLastInSeries,
-                    onMessageImageClick = onMessageImageClick,
-                    onFailClick = onFailedMessageClick,
-                )
-            }
+            ImageMessagesLayout(
+                modifier = modifier,
+                messages = markedMessage,
+                chatAvatarUrl = chatAvatarUrl,
+                showMessageInfo = (markedMessage.last().isVisibleMessageInfo || markedMessage.last().isLastInSeries || markedMessage.last().status == MessageStatus.FAILED),
+                isMarkedLastInSeries = markedMessage.last().isLastInSeries,
+                onMessageImageClick = onMessageImageClick,
+                onFailClick = onFailedMessageClick,
+            )
         }
     }
 }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatScreenOverlays.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatScreenOverlays.kt
@@ -2,7 +2,6 @@ package net.thechance.mena.core_chat.presentation.screen.chat.components
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import mena.core_chat_presentation.generated.resources.Res
@@ -18,7 +17,6 @@ import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
-@Composable
 fun ScaffoldScope.ChatScreenOverlays(
     showResendMessageDialog: Boolean,
     onDeleteFailedMessageClick: () -> Unit = { },

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatScreenOverlays.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatScreenOverlays.kt
@@ -2,6 +2,7 @@ package net.thechance.mena.core_chat.presentation.screen.chat.components
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import mena.core_chat_presentation.generated.resources.Res
@@ -17,6 +18,7 @@ import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
+@Composable
 fun ScaffoldScope.ChatScreenOverlays(
     showResendMessageDialog: Boolean,
     onDeleteFailedMessageClick: () -> Unit = { },

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/CloseIcon.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/CloseIcon.kt
@@ -17,7 +17,7 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-fun CancelDialogIcon(
+fun CloseIcon(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -36,10 +36,10 @@ fun CancelDialogIcon(
 
 @Composable
 @Preview()
-private fun PreviewCancelIcon() {
+private fun Preview() {
 
     MenaTheme {
-        CancelDialogIcon(
+        CloseIcon(
             onClick = {},
             modifier = Modifier
         )

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ImageMessagesLayout.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ImageMessagesLayout.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -129,12 +128,13 @@ fun ImageMessagesLayout(
                     when (imageData.content) {
                         is MessageContent.Image -> {
                             val images = imageData.content.data
-                                when (images) {
-                                    is ImageData.ImageUrl -> images.url
-                                    is ImageData.ImageByteArray -> images.byteArray
-                                }
+                            when (images) {
+                                is ImageData.ImageUrl -> images.url
+                                is ImageData.ImageByteArray -> images.byteArray
+                            }
 
                         }
+
                         is MessageContent.Text -> return@Column
                     }
                 }
@@ -149,16 +149,16 @@ fun ImageMessagesLayout(
         }
         AnimatedVisibility(
             visible = showMessageInfo,
-            modifier = Modifier.align(messageInfoAlignment)
+            modifier = Modifier
+                .align(messageInfoAlignment)
+                .padding(start = messagePaddingStart, end = messagePaddingEnd)
+
         ) {
             MessageInfo(
                 messageTime = messages.last().sendTime,
                 messageStatus = messages.last().status,
                 messageIsMine = messages.last().isMine,
                 onFailClick = { onFailClick(messages.last()) },
-                modifier = Modifier
-                    .align(messageInfoAlignment)
-                    .padding(start = messagePaddingStart, end = messagePaddingEnd)
             )
         }
     }
@@ -168,21 +168,36 @@ fun ImageMessagesLayout(
 @Preview()
 private fun PreviewBaseMessageLayout() {
     MenaTheme {
-        Box(
-            modifier = Modifier.fillMaxWidth()
-        ) {
+        Column {
             ImageMessagesLayout(
-                messages = listOf(MessageUiState(
-                    Uuid.random(),
-                    Uuid.random(),
-                    sendTime = LocalDateTime.now(),
-                    status = MessageStatus.READ,
-                    isMine = false,
-                    content = MessageContent.Text("Good Morning!")
-                )),
+                messages = listOf(
+                    MessageUiState(
+                        Uuid.random(),
+                        Uuid.random(),
+                        sendTime = LocalDateTime.now(),
+                        status = MessageStatus.READ,
+                        isMine = false,
+                        content = MessageContent.Image(ImageData.ImageUrl("https://images"))
+                    )
+                ),
                 showMessageInfo = true,
                 isMarkedLastInSeries = true,
-                onMessageImageClick = { message,index -> }
+                onMessageImageClick = { message, index -> }
+            )
+            ImageMessagesLayout(
+                messages = listOf(
+                    MessageUiState(
+                        Uuid.random(),
+                        Uuid.random(),
+                        sendTime = LocalDateTime.now(),
+                        status = MessageStatus.FAILED,
+                        isMine = true,
+                        content = MessageContent.Image(ImageData.ImageUrl("https://images"))
+                    )
+                ),
+                showMessageInfo = true,
+                isMarkedLastInSeries = true,
+                onMessageImageClick = { message, index -> }
             )
         }
     }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ImageMessagesLayout.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ImageMessagesLayout.kt
@@ -152,7 +152,6 @@ fun ImageMessagesLayout(
             modifier = Modifier
                 .align(messageInfoAlignment)
                 .padding(start = messagePaddingStart, end = messagePaddingEnd)
-
         ) {
             MessageInfo(
                 messageTime = messages.last().sendTime,

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ImageMessagesLayout.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ImageMessagesLayout.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -46,16 +47,11 @@ fun ImageMessagesLayout(
     onFailClick: (MessageUiState) -> Unit = {},
     onMessageImageClick: (List<MessageUiState>, Int) -> Unit,
 ) {
+
     val messageBackground =
         if (messages.last().isMine) Theme.colorScheme.background.surfaceLow
         else Theme.colorScheme.brand.brandVariant
 
-    val messagePaddingStart = if (messages.last().isMine)
-        Theme.spacing._24
-    else
-        Theme.spacing._8
-
-    val messagePaddingEnd = if (messages.last().isMine) 0.dp else Theme.spacing._8
     val maxRadius = Theme.radius.lg
 
     val messageShape = if (messages.last().isMine && isMarkedLastInSeries)
@@ -75,99 +71,93 @@ fun ImageMessagesLayout(
     else
         RoundedCornerShape(size = maxRadius)
 
-    val messageInfoAlignment = if (messages.last().isMine)
-        Alignment.Start
-    else
-        Alignment.End
+    val messageInfoAlignment = if (messages.last().isMine) Alignment.Start else Alignment.End
     val messageAlignment = if (messages.last().isMine) Alignment.End else Alignment.Start
 
-    val verticalPadding = Theme.spacing._4
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(Theme.spacing._2),
-        horizontalAlignment = messageAlignment
+    Box(
+        modifier = modifier.fillMaxWidth(),
+        contentAlignment = if (messages.last().isMine) Alignment.CenterEnd else Alignment.CenterStart
     ) {
-        Row(
-            verticalAlignment = Alignment.Bottom,
-            horizontalArrangement = Arrangement.spacedBy(Theme.spacing._8)
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(Theme.spacing._2),
+            horizontalAlignment = messageAlignment
         ) {
-            if (!messages.last().isMine) {
+            Row(
+                verticalAlignment = Alignment.Bottom,
+                horizontalArrangement = Arrangement.spacedBy(Theme.spacing._8)
+            ) {
+                if (!messages.last().isMine) {
+                    Box(
+                        modifier = Modifier
+                            .clip(CircleShape)
+                            .size(24.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        if (isMarkedLastInSeries) {
+                            AsyncImage(
+                                modifier = Modifier.fillMaxSize(),
+                                model = chatAvatarUrl,
+                                placeholder = painterResource(Res.drawable.ic_profile_placeholder),
+                                error = painterResource(Res.drawable.ic_profile_placeholder),
+                                contentScale = ContentScale.Crop,
+                                contentDescription = "Contact photo",
+                            )
+                        }
+                    }
+                }
+
                 Box(
                     modifier = Modifier
-                        .clip(CircleShape)
-                        .size(24.dp),
-                    contentAlignment = Alignment.Center
+                        .clip(messageShape)
+                        .background(color = messageBackground, shape = messageShape)
+                        .padding(Theme.spacing._4)
                 ) {
-                    if (isMarkedLastInSeries) {
-                        AsyncImage(
-                            modifier = Modifier.fillMaxSize(),
-                            model = chatAvatarUrl,
-                            placeholder = painterResource(Res.drawable.ic_profile_placeholder),
-                            error = painterResource(Res.drawable.ic_profile_placeholder),
-                            contentScale = ContentScale.Crop,
-                            contentDescription = "Contact photo",
-                        )
-                    }
-                }
-            }
-            Box(
-                modifier = Modifier
-                    .padding(start = messagePaddingStart, end = messagePaddingEnd)
-                    .clip(messageShape)
-                    .background(
-                        color = messageBackground,
-                        shape = messageShape
-                    )
-                    .padding(
-                        horizontal = verticalPadding,
-                        vertical = Theme.spacing._4
-                    )
-            ) {
+                    val imageDataList = messages.map { imageData ->
+                        when (imageData.content) {
+                            is MessageContent.Image -> {
+                                val images = imageData.content.data
+                                when (images) {
+                                    is ImageData.ImageUrl -> images.url
+                                    is ImageData.ImageByteArray -> images.byteArray
+                                }
 
-                val imageDataList = messages.map { imageData ->
-                    when (imageData.content) {
-                        is MessageContent.Image -> {
-                            val images = imageData.content.data
-                            when (images) {
-                                is ImageData.ImageUrl -> images.url
-                                is ImageData.ImageByteArray -> images.byteArray
                             }
 
+                            is MessageContent.Text -> return@Column
                         }
-
-                        is MessageContent.Text -> return@Column
                     }
-                }
 
-                ImageMessageContent(
-                    images = imageDataList,
-                    modifier = Modifier.size(156.dp, 162.dp).clip(messageShape),
-                    onImageClick = { index -> onMessageImageClick(messages, index) }
-                )
+                    ImageMessageContent(
+                        images = imageDataList,
+                        modifier = Modifier.size(156.dp, 162.dp).clip(messageShape),
+                        onImageClick = { index -> onMessageImageClick(messages, index) }
+                    )
+                }
             }
 
-        }
-        AnimatedVisibility(
-            visible = showMessageInfo,
-            modifier = Modifier
-                .align(messageInfoAlignment)
-                .padding(start = messagePaddingStart, end = messagePaddingEnd)
-        ) {
-            MessageInfo(
-                messageTime = messages.last().sendTime,
-                messageStatus = messages.last().status,
-                messageIsMine = messages.last().isMine,
-                onFailClick = { onFailClick(messages.last()) },
-            )
+            AnimatedVisibility(
+                visible = showMessageInfo,
+                modifier = Modifier.align(messageInfoAlignment)
+            ) {
+                MessageInfo(
+                    messageTime = messages.last().sendTime,
+                    messageStatus = messages.last().status,
+                    messageIsMine = messages.last().isMine,
+                    onFailClick = { onFailClick(messages.last()) },
+                )
+            }
         }
     }
 }
 
+@Preview
 @Composable
-@Preview()
-private fun PreviewBaseMessageLayout() {
+private fun Preview() {
     MenaTheme {
-        Column {
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
             ImageMessagesLayout(
                 messages = listOf(
                     MessageUiState(

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/TextMessageLayout.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/TextMessageLayout.kt
@@ -144,9 +144,6 @@ fun TextMessageLayout(
                 messageStatus = message.status,
                 messageIsMine = message.isMine,
                 onFailClick = onFailClick,
-                modifier = Modifier
-                    .align(messageInfoAlignment)
-
             )
         }
     }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/TextMessageLayout.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/TextMessageLayout.kt
@@ -54,12 +54,6 @@ fun TextMessageLayout(
         if (message.isMine) Theme.colorScheme.background.surfaceLow
         else Theme.colorScheme.brand.brandVariant
 
-    val messagePaddingStart = if (message.isMine)
-        Theme.spacing._24
-    else
-        Theme.spacing._8
-
-    val messagePaddingEnd = if (message.isMine) 0.dp else Theme.spacing._8
     val maxRadius = Theme.radius.md
 
     val messageShape = if (message.isMine && isMarkedLastInSeries)
@@ -79,81 +73,80 @@ fun TextMessageLayout(
     else
         RoundedCornerShape(size = maxRadius)
 
-    val messageInfoAlignment = if (message.isMine)
-        Alignment.Start
-    else
-        Alignment.End
+    val messageInfoAlignment = if (message.isMine) Alignment.Start else Alignment.End
     val messageAlignment = if (message.isMine) Alignment.End else Alignment.Start
 
-    val verticalPadding = Theme.spacing._8
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(Theme.spacing._2),
-        horizontalAlignment = messageAlignment
+    Box(
+        modifier = modifier.fillMaxWidth(),
+        contentAlignment = if (message.isMine) Alignment.CenterEnd else Alignment.CenterStart
     ) {
-        Row(
-            verticalAlignment = Alignment.Bottom,
-            horizontalArrangement = Arrangement.spacedBy(Theme.spacing._8)
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(Theme.spacing._2),
+            horizontalAlignment = messageAlignment
         ) {
-            if (!message.isMine) {
-                Box(
-                    modifier = Modifier
-                        .clip(CircleShape)
-                        .size(24.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    if (isMarkedLastInSeries) {
-                        AsyncImage(
-                            modifier = Modifier.fillMaxSize(),
-                            model = chatAvatarUrl,
-                            placeholder = painterResource(Res.drawable.ic_profile_placeholder),
-                            error = painterResource(Res.drawable.ic_profile_placeholder),
-                            contentScale = ContentScale.Crop,
-                            contentDescription = "Contact photo",
-                        )
+            Row(
+                verticalAlignment = Alignment.Bottom,
+                horizontalArrangement = Arrangement.spacedBy(Theme.spacing._8)
+            ) {
+                if (!message.isMine) {
+                    Box(
+                        modifier = Modifier
+                            .clip(CircleShape)
+                            .size(24.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        if (isMarkedLastInSeries) {
+                            AsyncImage(
+                                modifier = Modifier.fillMaxSize(),
+                                model = chatAvatarUrl,
+                                placeholder = painterResource(Res.drawable.ic_profile_placeholder),
+                                error = painterResource(Res.drawable.ic_profile_placeholder),
+                                contentScale = ContentScale.Crop,
+                                contentDescription = "Contact photo",
+                            )
+                        }
                     }
                 }
-            }
-            Box(
-                modifier = Modifier
-                    .padding(start = messagePaddingStart, end = messagePaddingEnd)
-                    .clip(messageShape)
-                    .noHoverClickable(onClick = onMessageClick)
-                    .background(color = messageBackground, shape = messageShape)
-                    .padding(
-                        horizontal = verticalPadding,
-                        vertical = Theme.spacing._4
+
+                Box(
+                    modifier = Modifier
+                        .clip(messageShape)
+                        .noHoverClickable(onClick = onMessageClick)
+                        .background(color = messageBackground, shape = messageShape)
+                        .padding(
+                            horizontal = Theme.spacing._8,
+                            vertical = Theme.spacing._4
+                        )
+                ) {
+                    Text(
+                        text = message.content.text,
+                        style = Theme.typography.body.small,
+                        color = Theme.colorScheme.shadeSecondary
                     )
-            ) {
-                Text(
-                    text = message.content.text,
-                    style = Theme.typography.body.small,
-                    color = Theme.colorScheme.shadeSecondary
-                )
+                }
             }
 
-        }
-        AnimatedVisibility(
-            visible = showMessageInfo,
-            modifier = Modifier
-                .align(messageInfoAlignment)
-                .padding(start = messagePaddingStart, end = messagePaddingEnd)
-        ) {
-            MessageInfo(
-                messageTime = message.sendTime,
-                messageStatus = message.status,
-                messageIsMine = message.isMine,
-                onFailClick = onFailClick,
-            )
+            AnimatedVisibility(
+                visible = showMessageInfo,
+                modifier = Modifier.align(messageInfoAlignment)
+            ) {
+                MessageInfo(
+                    messageTime = message.sendTime,
+                    messageStatus = message.status,
+                    messageIsMine = message.isMine,
+                    onFailClick = onFailClick,
+                )
+            }
         }
     }
 }
 
+@Preview
 @Composable
-@Preview()
-private fun PreviewBaseMessageLayout() {
+private fun Preview() {
     MenaTheme {
-        Box(
+        Column(
             modifier = Modifier.fillMaxWidth()
         ) {
             TextMessageLayout(
@@ -163,6 +156,19 @@ private fun PreviewBaseMessageLayout() {
                     sendTime = LocalDateTime.now(),
                     status = MessageStatus.READ,
                     isMine = false,
+                    content = MessageContent.Text("Good Morning!")
+                ),
+                showMessageInfo = true,
+                isMarkedLastInSeries = true,
+            )
+
+            TextMessageLayout(
+                message = MessageUiState(
+                    Uuid.random(),
+                    Uuid.random(),
+                    sendTime = LocalDateTime.now(),
+                    status = MessageStatus.READ,
+                    isMine = true,
                     content = MessageContent.Text("Good Morning!")
                 ),
                 showMessageInfo = true,

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/TextMessageLayout.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/TextMessageLayout.kt
@@ -135,7 +135,9 @@ fun TextMessageLayout(
         }
         AnimatedVisibility(
             visible = showMessageInfo,
-            modifier = Modifier.align(messageInfoAlignment)
+            modifier = Modifier
+                .align(messageInfoAlignment)
+                .padding(start = messagePaddingStart, end = messagePaddingEnd)
         ) {
             MessageInfo(
                 messageTime = message.sendTime,
@@ -144,7 +146,7 @@ fun TextMessageLayout(
                 onFailClick = onFailClick,
                 modifier = Modifier
                     .align(messageInfoAlignment)
-                    .padding(start = messagePaddingStart, end = messagePaddingEnd)
+
             )
         }
     }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/mappers.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/mappers.kt
@@ -9,7 +9,6 @@ import mena.core_chat_presentation.generated.resources.today
 import mena.core_chat_presentation.generated.resources.yesterday
 import net.thechance.mena.core_chat.domain.entity.Message
 import net.thechance.mena.core_chat.domain.entity.MessageContent
-import net.thechance.mena.core_chat.domain.entity.MessageStatus
 import net.thechance.mena.core_chat.presentation.utils.UiText
 import net.thechance.mena.core_chat.presentation.utils.format
 import net.thechance.mena.core_chat.presentation.utils.minusDays
@@ -51,7 +50,7 @@ fun List<MessageUiState>.markLastInSeries(): List<MessageUiState> {
     }
 }
 
-fun List<MessageUiState>.toChatList(): List<ChatListItem> {
+fun List<MessageUiState>.toChatList(shouldGroupMessages: (MessageUiState) -> Boolean): List<ChatListItem> {
     if (isEmpty()) return emptyList()
 
     val today = LocalDateTime.now().date
@@ -61,7 +60,7 @@ fun List<MessageUiState>.toChatList(): List<ChatListItem> {
         .groupBy { it.sendTime.date }
         .flatMap { (date, messages) ->
             val markedMessages = messages.markLastInGroup()
-            val groupedMessages = markedMessages.toGroupedMessagesChatList()
+            val groupedMessages = markedMessages.toGroupedMessagesChatList(shouldGroupMessages)
 
             buildList {
                 add(ChatListItem.DateSeparator(date.toLabel(today, yesterday)))
@@ -72,8 +71,7 @@ fun List<MessageUiState>.toChatList(): List<ChatListItem> {
 }
 
 
-
-fun List<MessageUiState>.toGroupedMessagesChatList(): List<ChatListItem> {
+fun List<MessageUiState>.toGroupedMessagesChatList(shouldGroupMessages: (MessageUiState) -> Boolean): List<ChatListItem> {
     val grouped = mutableListOf<ChatListItem>()
     var tempImages = mutableListOf<MessageUiState>()
 
@@ -87,7 +85,10 @@ fun List<MessageUiState>.toGroupedMessagesChatList(): List<ChatListItem> {
     for (msg in this) {
         if (msg.content is MessageContent.Image) {
             val last = tempImages.lastOrNull()
-            if (last != null && last.isMine == msg.isMine && last.status == msg.status && msg.status != MessageStatus.FAILED && msg.status != MessageStatus.LOADING) {
+            if (last != null && last.isMine == msg.isMine && last.status == msg.status && shouldGroupMessages(
+                    msg
+                )
+            ) {
                 tempImages.add(msg)
             } else {
                 groupAndClear()
@@ -131,6 +132,7 @@ fun List<ChatListItem>.toggleMessageInfo(messageId: Uuid): List<ChatListItem> = 
 }
 
 
-fun List<MessageUiState>.buildListItems(): List<ChatListItem> {
-    return sortedByDescending { it.sendTime }.markLastInSeries().toChatList()
+fun List<MessageUiState>.buildListItems(shouldGroupImageMessages: (MessageUiState) -> Boolean): List<ChatListItem> {
+    return sortedByDescending { it.sendTime }.markLastInSeries()
+        .toChatList(shouldGroupImageMessages)
 }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/contacts/ContactsScreen.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/contacts/ContactsScreen.kt
@@ -2,7 +2,6 @@ package net.thechance.mena.core_chat.presentation.screen.contacts
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,9 +23,9 @@ import mena.core_chat_presentation.generated.resources.contacts_title
 import mena.core_chat_presentation.generated.resources.could_not_load_contacts
 import mena.core_chat_presentation.generated.resources.ic_arrow_left
 import mena.core_chat_presentation.generated.resources.ic_resync
-import mena.core_chat_presentation.generated.resources.loading
 import mena.core_chat_presentation.generated.resources.something_went_wrong
 import net.thechance.mena.core_chat.presentation.components.ErrorView
+import net.thechance.mena.core_chat.presentation.components.LoadingView
 import net.thechance.mena.core_chat.presentation.components.snackBarHost.LocalSnackBarHostController
 import net.thechance.mena.core_chat.presentation.navigation.ChatDetailsRoute
 import net.thechance.mena.core_chat.presentation.navigation.LocalNavController
@@ -37,7 +36,6 @@ import net.thechance.mena.core_chat.presentation.utils.EffectHandler
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBarOptionContainer
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
-import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -111,15 +109,7 @@ private fun ContactsContent(
         ) { loadState ->
             when (loadState) {
                 is LoadState.Loading -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            text = stringResource(Res.string.loading),
-                            style = Theme.typography.title.small
-                        )
-                    }
+                    LoadingView()
                 }
 
                 is LoadState.Error -> {

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeScreen.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeScreen.kt
@@ -1,7 +1,6 @@
 package net.thechance.mena.core_chat.presentation.screen.home
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -27,17 +26,18 @@ import mena.core_chat_presentation.generated.resources.chats
 import mena.core_chat_presentation.generated.resources.ic_coin
 import mena.core_chat_presentation.generated.resources.ic_plus
 import mena.core_chat_presentation.generated.resources.mena
+import net.thechance.mena.core_chat.presentation.components.snackBarHost.LocalSnackBarHostController
 import net.thechance.mena.core_chat.presentation.navigation.ChatDetailsRoute
 import net.thechance.mena.core_chat.presentation.navigation.ContactsRoute
-import net.thechance.mena.core_chat.presentation.utils.EffectHandler
 import net.thechance.mena.core_chat.presentation.navigation.LocalNavController
-import net.thechance.mena.core_chat.presentation.components.snackBarHost.LocalSnackBarHostController
 import net.thechance.mena.core_chat.presentation.navigation.SyncContactsRoute
 import net.thechance.mena.core_chat.presentation.navigation.WalletRoute
 import net.thechance.mena.core_chat.presentation.screen.home.HomeScreenState.ChatUiState
 import net.thechance.mena.core_chat.presentation.screen.home.components.ChatItem
 import net.thechance.mena.core_chat.presentation.screen.home.components.NoChatsHistoryView
+import net.thechance.mena.core_chat.presentation.utils.EffectHandler
 import net.thechance.mena.core_chat.presentation.utils.PaginationTrigger
+import net.thechance.mena.core_chat.presentation.utils.noHoverClickable
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
 import net.thechance.mena.designsystem.presentation.component.button.FabButton
 import net.thechance.mena.designsystem.presentation.component.indicator.DotsProgressIndicator
@@ -78,7 +78,7 @@ private fun HomeContent(
         topBar = {
             HomeScreenAppBar(
                 balanceAmount = state.balanceAmount.toString(),
-                interactionListener::onWalletClicked
+                onWalletClicked = interactionListener::onWalletClicked
             )
         }
     ) {
@@ -128,7 +128,8 @@ private fun HomeScreenAppBar(
         trailingContent = {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(Theme.spacing._4),
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.noHoverClickable { onWalletClicked() }
             ) {
                 Text(
                     text = balanceAmount,
@@ -139,7 +140,6 @@ private fun HomeScreenAppBar(
                     painter = painterResource(Res.drawable.ic_coin),
                     contentDescription = null,
                     modifier = Modifier.size(24.dp)
-                        .clickable { onWalletClicked() }
                 )
             }
         }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeScreen.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeScreen.kt
@@ -26,7 +26,6 @@ import mena.core_chat_presentation.generated.resources.chats
 import mena.core_chat_presentation.generated.resources.ic_coin
 import mena.core_chat_presentation.generated.resources.ic_plus
 import mena.core_chat_presentation.generated.resources.mena
-import net.thechance.mena.core_chat.presentation.components.LoadingView
 import net.thechance.mena.core_chat.presentation.components.snackBarHost.LocalSnackBarHostController
 import net.thechance.mena.core_chat.presentation.navigation.ChatDetailsRoute
 import net.thechance.mena.core_chat.presentation.navigation.ContactsRoute
@@ -34,7 +33,9 @@ import net.thechance.mena.core_chat.presentation.navigation.LocalNavController
 import net.thechance.mena.core_chat.presentation.navigation.SyncContactsRoute
 import net.thechance.mena.core_chat.presentation.navigation.WalletRoute
 import net.thechance.mena.core_chat.presentation.screen.home.HomeScreenState.ChatUiState
+import net.thechance.mena.core_chat.presentation.screen.home.components.BalanceSkeleton
 import net.thechance.mena.core_chat.presentation.screen.home.components.ChatItem
+import net.thechance.mena.core_chat.presentation.screen.home.components.ChatSummaryListSkeleton
 import net.thechance.mena.core_chat.presentation.screen.home.components.NoChatsHistoryView
 import net.thechance.mena.core_chat.presentation.utils.EffectHandler
 import net.thechance.mena.core_chat.presentation.utils.PaginationTrigger
@@ -78,27 +79,27 @@ private fun HomeContent(
         topBar = {
             HomeScreenAppBar(
                 balanceAmount = state.balanceAmount.toString(),
+                isLoading = state.isBalanceLoading,
                 onWalletClicked = interactionListener::onWalletClicked
             )
         }
     ) {
         Box(modifier = modifier.fillMaxSize()) {
-            Column(modifier = Modifier.fillMaxSize()) {
 
-                when {
-                    state.chats.isEmpty() && state.isLoading -> {
-                        LoadingView()
-                    }
+            when {
+                state.chats.isEmpty() && state.isLoading -> {
+                    ChatSummaryListSkeleton()
+                }
 
-                    state.chats.isEmpty() && !state.isLoading -> {
-                        EmptyView()
-                    }
+                state.chats.isEmpty() && !state.isLoading -> {
+                    EmptyView()
+                }
 
-                    else -> {
-                        ChatsSummaryList(listState, state, interactionListener::onChatClicked)
-                    }
+                else -> {
+                    ChatSummaryList(listState, state.chats, interactionListener::onChatClicked)
                 }
             }
+
             FabButton(
                 painter = painterResource(Res.drawable.ic_plus),
                 onClick = interactionListener::onNewChatClicked,
@@ -121,26 +122,32 @@ private fun HomeContent(
 @Composable
 private fun HomeScreenAppBar(
     balanceAmount: String,
+    isLoading: Boolean = false,
     onWalletClicked: () -> Unit
 ) {
     AppBar(
         title = stringResource(Res.string.mena),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 18.dp),
         trailingContent = {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(Theme.spacing._4),
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.noHoverClickable { onWalletClicked() }
-            ) {
-                Text(
-                    text = balanceAmount,
-                    color = Theme.colorScheme.shadeSecondary,
-                    style = Theme.typography.label.small,
-                )
-                Image(
-                    painter = painterResource(Res.drawable.ic_coin),
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp)
-                )
+            if (isLoading) {
+                BalanceSkeleton()
+            } else {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(Theme.spacing._4),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.noHoverClickable { onWalletClicked() }
+                ) {
+                    Text(
+                        text = balanceAmount,
+                        color = Theme.colorScheme.shadeSecondary,
+                        style = Theme.typography.label.small,
+                    )
+                    Image(
+                        painter = painterResource(Res.drawable.ic_coin),
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
             }
         }
     )
@@ -158,40 +165,36 @@ private fun EmptyView() {
 
 @Composable
 @OptIn(ExperimentalUuidApi::class)
-private fun ChatsSummaryList(
+private fun ChatSummaryList(
     listState: LazyListState,
-    state: HomeScreenState,
+    chats: List<ChatUiState>,
     onChatClicked: (ChatUiState) -> Unit
 ) {
-    Text(
-        text = stringResource(Res.string.chats),
-        color = Theme.colorScheme.shadePrimary,
-        style = Theme.typography.title.small,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = Theme.spacing._16)
-    )
-    LazyColumn(
-        state = listState,
-        modifier = Modifier
-            .padding(horizontal = Theme.spacing._16)
-            .fillMaxWidth(),
-        contentPadding = PaddingValues(vertical = Theme.spacing._12),
-        verticalArrangement = Arrangement.spacedBy(Theme.spacing._16)
-    ) {
-        items(
-            items = state.chats,
-            key = { it.id }
-        ) { chat ->
-            ChatItem(
-                chat = chat,
-                onChatClicked = onChatClicked
-            )
-        }
-
-        if (state.isLoading) {
-            item {
-                LoadingView(Modifier.padding(vertical = Theme.spacing._16))
+    Column {
+        Text(
+            text = stringResource(Res.string.chats),
+            color = Theme.colorScheme.shadePrimary,
+            style = Theme.typography.title.small,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Theme.spacing._16)
+        )
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .padding(horizontal = Theme.spacing._16)
+                .fillMaxWidth(),
+            contentPadding = PaddingValues(vertical = Theme.spacing._12),
+            verticalArrangement = Arrangement.spacedBy(Theme.spacing._16)
+        ) {
+            items(
+                items = chats,
+                key = { it.id }
+            ) { chat ->
+                ChatItem(
+                    chat = chat,
+                    onChatClicked = onChatClicked
+                )
             }
         }
     }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeScreen.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeScreen.kt
@@ -26,6 +26,7 @@ import mena.core_chat_presentation.generated.resources.chats
 import mena.core_chat_presentation.generated.resources.ic_coin
 import mena.core_chat_presentation.generated.resources.ic_plus
 import mena.core_chat_presentation.generated.resources.mena
+import net.thechance.mena.core_chat.presentation.components.LoadingView
 import net.thechance.mena.core_chat.presentation.components.snackBarHost.LocalSnackBarHostController
 import net.thechance.mena.core_chat.presentation.navigation.ChatDetailsRoute
 import net.thechance.mena.core_chat.presentation.navigation.ContactsRoute
@@ -40,7 +41,6 @@ import net.thechance.mena.core_chat.presentation.utils.PaginationTrigger
 import net.thechance.mena.core_chat.presentation.utils.noHoverClickable
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
 import net.thechance.mena.designsystem.presentation.component.button.FabButton
-import net.thechance.mena.designsystem.presentation.component.indicator.DotsProgressIndicator
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
@@ -144,16 +144,6 @@ private fun HomeScreenAppBar(
             }
         }
     )
-}
-
-@Composable
-private fun LoadingView(modifier: Modifier = Modifier) {
-    Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        DotsProgressIndicator()
-    }
 }
 
 @Composable

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeScreenState.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeScreenState.kt
@@ -6,9 +6,10 @@ import kotlin.uuid.Uuid
 
 data class HomeScreenState(
     val isLoading: Boolean = false,
+    val isBalanceLoading: Boolean = false,
     val isSynced: Boolean = false,
     val isError: Boolean = false,
-    val balanceAmount: Double = 0.0,
+    val balanceAmount: Int = 0,
     val chats: List<ChatUiState> = emptyList()
 ) {
     data class ChatUiState @OptIn(ExperimentalUuidApi::class) constructor(

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeViewModel.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeViewModel.kt
@@ -7,8 +7,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
 import mena.core_chat_presentation.generated.resources.Res
+import mena.core_chat_presentation.generated.resources.could_not_get_balance
 import mena.core_chat_presentation.generated.resources.could_not_load_chats
 import mena.core_chat_presentation.generated.resources.could_not_sync_contacts_message
+import mena.core_chat_presentation.generated.resources.error
 import mena.core_chat_presentation.generated.resources.something_went_wrong
 import net.thechance.mena.core_chat.domain.entity.ChatSummary
 import net.thechance.mena.core_chat.domain.entity.Message
@@ -126,14 +128,25 @@ class HomeViewModel(
 
     private fun getBalanceAmount() {
         tryToExecute(
+            onStart = { updateState { it.copy(isBalanceLoading = true) }},
             execute = { balanceRepository.getBalance() },
-            onSuccess = ::onGetBalanceAmountSuccess
+            onSuccess = ::onGetBalanceAmountSuccess,
+            onError = { onGetBalanceAmountError() }
         )
     }
 
     private fun onGetBalanceAmountSuccess(balanceAmount: Double) {
-        val balance = (balanceAmount * 100).toInt() / 100.0
-        updateState { it.copy(balanceAmount = balance) }
+        val balance = balanceAmount.toInt()
+        updateState { it.copy(balanceAmount = balance, isBalanceLoading = false) }
+    }
+
+    private fun onGetBalanceAmountError() {
+        updateState { it.copy(isBalanceLoading = false) }
+        showSnackBar(
+            titleStringResource = Res.string.error,
+            messageStringResource = Res.string.could_not_get_balance,
+            isError = true
+        )
     }
 
     override fun onChatsListScrolled() {

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/components/HomeScreenSkeletonShapes.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/components/HomeScreenSkeletonShapes.kt
@@ -1,0 +1,92 @@
+package net.thechance.mena.core_chat.presentation.screen.home.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import net.thechance.mena.core_chat.presentation.components.SkeletonShape
+import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Preview(showBackground = true)
+@Composable
+fun BalanceSkeleton(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Theme.spacing._4)
+    ) {
+        SkeletonShape(
+            modifier = Modifier
+                .size(height = Theme.spacing._16, width = 52.dp)
+        )
+        SkeletonShape(
+            modifier = Modifier
+                .size(Theme.spacing._24)
+                .clip(CircleShape)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ChatSummaryListSkeleton() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = Theme.spacing._16),
+        verticalArrangement = Arrangement.spacedBy(Theme.spacing._12),
+    ) {
+        SkeletonShape(
+            modifier = Modifier
+                .size(height = 24.dp, width = 167.dp)
+        )
+        repeat(10) {
+            ChatSummaryItemSkeleton(modifier = Modifier.padding(bottom = Theme.spacing._4))
+        }
+    }
+}
+
+@Composable
+private fun ChatSummaryItemSkeleton(modifier: Modifier = Modifier) {
+    Row(modifier = modifier) {
+        SkeletonShape(
+            modifier = Modifier
+                .padding(end = Theme.spacing._8)
+                .size(48.dp)
+                .clip(CircleShape)
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(end = 39.dp)
+                .weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            SkeletonShape(
+                modifier = Modifier
+                    .height(22.dp)
+                    .fillMaxWidth()
+            )
+            SkeletonShape(
+                modifier = Modifier
+                    .height(22.dp)
+                    .fillMaxWidth()
+            )
+        }
+        SkeletonShape(
+            modifier = Modifier
+                .size(height = Theme.spacing._16, width = 46.dp)
+        )
+    }
+}

--- a/core_chat_presentation/src/commonTest/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeViewModelTest.kt
+++ b/core_chat_presentation/src/commonTest/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeViewModelTest.kt
@@ -67,7 +67,7 @@ class HomeViewModelTest {
 
         viewModel.state.test {
             val state = awaitItem()
-            assertThat(state.balanceAmount).isEqualTo(expectedBalance)
+            assertThat(state.balanceAmount).isEqualTo(expectedBalance.toInt())
         }
     }
 
@@ -117,7 +117,7 @@ class HomeViewModelTest {
 
         viewModel.state.test {
             val state = awaitItem()
-            assertThat(state.balanceAmount).isEqualTo(0.0)
+            assertThat(state.balanceAmount).isEqualTo(0)
         }
     }
 


### PR DESCRIPTION
# What have been done:
- fix message layout and message info position
- refactor image message grouping to only group old read messages
- add loading skeleton to home screen

<img width="359" height="767" alt="image" src="https://github.com/user-attachments/assets/9c0369b5-e638-4fbf-9d8d-480272762516" />
<img width="354" height="780" alt="image" src="https://github.com/user-attachments/assets/9ba61000-45e3-4654-b3c4-ff4979d7458c" />

<img width="351" height="768" alt="image" src="https://github.com/user-attachments/assets/209b28e0-9d31-4a75-8dc7-8680aeb5f513" />

