### PR TITLE
fix: delete trend failed with configuration changes 

### DIFF
--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelInteractionListener.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelInteractionListener.kt
@@ -2,6 +2,7 @@ package net.thechance.mena.trends.presentation.screen.user_reel
 
 internal interface UserReelInteractionListener {
     fun onClickBack()
+    fun onChangeCurrentReel(reelId: String)
     fun onClickDelete()
     fun onClickConfirmDelete()
     fun onDismissConfirmationDialog()

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
@@ -73,7 +73,6 @@ import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.trends.presentation.navigation.LocalNavController
 import net.thechance.mena.trends.presentation.navigation.Route
-import net.thechance.mena.trends.presentation.shared.component.TrendsAnimatedVisibility
 import net.thechance.mena.trends.presentation.shared.component.modifier.noRippleClickable
 import net.thechance.mena.trends.presentation.shared.util.ObserveAsEffect
 import net.thechance.mena.trends.presentation.shared.util.asString

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -72,6 +73,7 @@ import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.trends.presentation.navigation.LocalNavController
 import net.thechance.mena.trends.presentation.navigation.Route
+import net.thechance.mena.trends.presentation.shared.component.TrendsAnimatedVisibility
 import net.thechance.mena.trends.presentation.shared.component.modifier.noRippleClickable
 import net.thechance.mena.trends.presentation.shared.util.ObserveAsEffect
 import net.thechance.mena.trends.presentation.shared.util.asString
@@ -189,6 +191,14 @@ private fun UserReelScreenContent(
             initialPage = 0,
             pageCount = { reels.itemCount },
         )
+
+        LaunchedEffect(pagerState.currentPage) {
+            if(reels.itemCount > 0) {
+                reels[pagerState.currentPage]?.let { reel ->
+                    listener.onChangeCurrentReel(reel.id)
+                }
+            }
+        }
 
         TopAppBar(onBackClick = listener::onClickBack, modifier = Modifier.zIndex(5f))
 

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelState.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelState.kt
@@ -10,6 +10,7 @@ import net.thechance.mena.trends.presentation.shared.util.TimeAgoValue
 internal data class UserReelState(
     val reels: Flow<PagingData<UserReelUiState>> = flowOf(),
     val isLoading: Boolean = false,
+    val currentReelId: String = "",
     val error: ErrorState? = null,
     val isConfirmationDialogVisible: Boolean = false,
     val isReelDeleted: Boolean? = null,

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModel.kt
@@ -84,11 +84,12 @@ internal class UserReelViewModel(
     }
 
     override fun increaseReelView(reelId: String) {
-        tryToExecute(
-            block = { reelsRepository.addReelView(reelId) },
-            onError = { error -> updateState { copy(error = error) } },
-            dispatcher = defaultDispatcher
-        )
+        if(state.value.isReelDeleted == null) {
+            tryToExecute(
+                block = { reelsRepository.addReelView(reelId) },
+                dispatcher = defaultDispatcher
+            )
+        }
     }
 
     override fun onClickLike(reelId: String, isLiked: Boolean) {

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModel.kt
@@ -147,7 +147,7 @@ internal class UserReelViewModel(
 
     override fun onClickConfirmDelete() {
         tryToExecute(
-            block = { reelsRepository.deleteReelById(userReelArgs.realId) },
+            block = { reelsRepository.deleteReelById(state.value.currentReelId) },
             onSuccess = { onDeleteReelSuccess() },
             onError = { errorState -> updateState { copy(error = errorState) } },
             dispatcher = defaultDispatcher

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModel.kt
@@ -23,6 +23,7 @@ internal class UserReelViewModel(
 ) : BaseViewModel<UserReelState, UserReelEffect>(UserReelState()), UserReelInteractionListener {
 
     init {
+        updateState { copy(currentReelId = userReelArgs.realId) }
         getFeedReals()
     }
 
@@ -132,6 +133,10 @@ internal class UserReelViewModel(
 
     override fun onClickBack() {
         sendEffect(UserReelEffect.NavigateBack)
+    }
+
+    override fun onChangeCurrentReel(reelId: String) {
+        updateState { copy(currentReelId = reelId) }
     }
 
     override fun onClickDelete() {

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModelTest.kt
@@ -61,6 +61,7 @@ class UserReelViewModelTest {
             skipItems(1)
             val initialState = awaitItem()
 
+            assertThat(initialState.currentReelId).isEqualTo("2")
             assertFalse(initialState.isLoading)
             assertNull(initialState.error)
             assertFalse(initialState.isConfirmationDialogVisible)
@@ -132,6 +133,15 @@ class UserReelViewModelTest {
     }
 
     @Test
+    fun `onChangeCurrentReel should update state with new reel id`() = runTest {
+        viewModel.onChangeCurrentReel("newReelId")
+
+        viewModel.state.test {
+            assertThat(awaitItem().currentReelId).isEqualTo("newReelId")
+        }
+    }
+
+    @Test
     fun `onClickDelete should show confirmation dialog when called`() = runTest {
         viewModel.onClickDelete()
 
@@ -198,25 +208,16 @@ class UserReelViewModelTest {
     }
 
     @Test
-    fun `onClickConfirmDelete should update error state when repository throws exception`() =
-        runTest {
+    fun `onClickConfirmDelete should update error state when repository throws exception`() = runTest(testDispatcher) {
+        everySuspend { mockReelsRepository.deleteReelById(any()) } throws Exception("Failed")
 
-            val errorMockRepository: ReelsRepository = mock(MockMode.autofill) {
-                everySuspend { deleteReelById("1") } throws Exception()
-            }
+        viewModel.onClickConfirmDelete()
+        advanceUntilIdle()
 
-            val errorViewModel =
-                UserReelViewModel(userReelArgs, errorMockRepository, testDispatcher)
-
-            errorViewModel.onClickConfirmDelete()
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            errorViewModel.state.test {
-                val errorState = awaitItem()
-                assertNotNull(errorState.error is ErrorState)
-                cancelAndIgnoreRemainingEvents()
-            }
+        viewModel.state.test {
+            assertThat(awaitItem().error).isEqualTo(ErrorState.RequestFailed("Failed"))
         }
+    }
 
     @Test
     fun `onClickPublisherInfo should send NavigateToPublisherProfile effect when called`() =

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModelTest.kt
@@ -84,6 +84,18 @@ class UserReelViewModelTest {
         }
 
     @Test
+    fun `viewmodel init should update isLoading to false getFeedReels return data`() =
+        runTest(testDispatcher) {
+            everySuspend { mockReelsRepository.getFeedReels(any()) } returns feedReels
+
+            advanceUntilIdle()
+
+            viewModel.state.test {
+                assertThat(awaitItem().isLoading).isFalse()
+            }
+        }
+
+    @Test
     fun `onClickDescription should expand description when called with collapsed state`() =
         runTest {
             viewModel.onClickDescription(isCollapsed = false)
@@ -219,17 +231,11 @@ class UserReelViewModelTest {
         }
 
     @Test
-    fun `increaseReelView should update error state when repository throws exception`() = runTest {
-        everySuspend { mockReelsRepository.addReelView(any()) } throws Exception("View failed")
-
+    fun `increaseReelView should call addReelView if isReelDeleted is null`() = runTest {
         viewModel.increaseReelView("2")
         advanceUntilIdle()
 
-        viewModel.state.test {
-            val state = awaitItem()
-            assertNotNull(state.error)
-            cancelAndIgnoreRemainingEvents()
-        }
+        verifySuspend { mockReelsRepository.addReelView("2") }
     }
 
     @Test


### PR DESCRIPTION
## Description
- fix calling `increaseView` each time recomposition happens by adding condition if trend is deleted or not 