### PR TITLE
Feature/IDN-140 Add addresses screen to identity feature API

### DIFF
--- a/identity_api/src/commonMain/kotlin/net/thechance/mena/identity/api/IdentityFeatureApi.kt
+++ b/identity_api/src/commonMain/kotlin/net/thechance/mena/identity/api/IdentityFeatureApi.kt
@@ -8,4 +8,7 @@ interface IdentityFeatureApi {
 
     @Composable
     fun LoginFlow()
+
+    @Composable
+    fun NavigateToAddressesScreen()
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/api/IdentityFeatureApiImpl.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/api/IdentityFeatureApiImpl.kt
@@ -3,6 +3,7 @@ package net.thechance.mena.identity.presentation.api
 import androidx.compose.runtime.Composable
 import cafe.adriel.voyager.navigator.Navigator
 import net.thechance.mena.identity.api.IdentityFeatureApi
+import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.AddressesScreen
 import net.thechance.mena.identity.presentation.screen.login.LoginScreen
 import net.thechance.mena.identity.presentation.screen.profile.ProfileScreen
 
@@ -15,5 +16,10 @@ class IdentityFeatureApiImpl : IdentityFeatureApi {
     @Composable
     override fun LoginFlow() {
         Navigator(LoginScreen())
+    }
+
+    @Composable
+    override fun NavigateToAddressesScreen() {
+        Navigator(AddressesScreen())
     }
 }


### PR DESCRIPTION
## Add NavigateToAddressesScreen to Identity API

Exposes address navigation for inter-module access.

**Changes:**
- Added `NavigateToAddressesScreen()` to `IdentityFeatureApi`
- Implemented in `IdentityFeatureApiImpl` using `Navigator(AddressesScreen())`

**Usage:** Call `identityApi.NavigateToAddressesScreen()` from any module