### PR TITLE
fix:no transaction found toast appear even there are transactions

### DIFF
--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsViewModel.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsViewModel.kt
@@ -479,7 +479,8 @@ class ExportTransactionsViewModel(
             oldState.copy(
                 toast = oldState.toast.copy(
                     isVisible = false
-                )
+                ),
+                hasNoTransactionsError = false
             )
         }
     }


### PR DESCRIPTION
Issue: 
hasNoTransactionsError state nod updater after hiding it's toast , so if i select date that has no transactions 
then click view or download "No Transaction Found" toast appear then if i select any date that has transaction the toast still appearing cuz we don't update it's state 

Solution:
update hasNoTransactionsError state  to false at hideToast function

Before:

https://github.com/user-attachments/assets/6251f7b2-45fe-4397-b171-9d05d02e1589

After:

https://github.com/user-attachments/assets/76f763a1-92a1-4f53-b1be-341a1cf9aff1










