### PR TITLE
Refactor: Add profile image placeholder

### DIFF
--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/ProfileImage.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/ProfileImage.kt
@@ -1,0 +1,67 @@
+package net.thechance.mena.identity.presentation.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.shadow.Shadow
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import mena.identity_presentation.generated.resources.Res
+import mena.identity_presentation.generated.resources.profile_profile_picture_content_description
+import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.identity.presentation.screen.editProfile.component.AsyncProfileImage
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun ProfileImage(
+    profileImageUrl: String,
+    profileImageBitmap: ImageBitmap?,
+    modifier: Modifier = Modifier,
+    shadowColor: Color = Color(0x0F111D2E)
+) {
+    Box(
+        modifier = modifier
+            .border(1.dp, Theme.colorScheme.stroke, CircleShape)
+            .dropShadow(
+                shape = CircleShape,
+                shadow = Shadow(
+                    radius = 8.dp,
+                    spread = 0.dp,
+                    color = shadowColor,
+                    offset = DpOffset(x = 0.dp, 4.dp)
+                )
+            )
+            .dropShadow(
+                shape = CircleShape,
+                shadow = Shadow(
+                    radius = 8.dp,
+                    spread = 0.dp,
+                    color = shadowColor,
+                    offset = DpOffset(x = 4.dp, 0.dp)
+                )
+            )
+    ) {
+        if (profileImageBitmap == null) {
+            AsyncProfileImage(profileImageUrl)
+        } else {
+            Image(
+                bitmap = profileImageBitmap,
+                contentScale = ContentScale.Crop,
+                contentDescription = stringResource(Res.string.profile_profile_picture_content_description),
+                modifier = Modifier
+                    .size(88.dp)
+                    .clip(CircleShape),
+            )
+        }
+    }
+
+}

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileScreen.kt
@@ -58,7 +58,7 @@ import net.thechance.mena.identity.presentation.components.WheelDatePicker
 import net.thechance.mena.identity.presentation.screen.editProfile.component.AtPrefixTransformation
 import net.thechance.mena.identity.presentation.screen.editProfile.component.GenderToggle
 import net.thechance.mena.identity.presentation.screen.editProfile.component.ProfileEditText
-import net.thechance.mena.identity.presentation.screen.editProfile.component.ProfileImage
+import net.thechance.mena.identity.presentation.screen.editProfile.component.EditProfileImage
 import net.thechance.mena.identity.presentation.screen.editProfile.dialog.GetImageDialog
 import net.thechance.mena.identity.presentation.screen.imageCropper.ImageCropperScreen
 import net.thechance.mena.identity.presentation.util.rememberCameraPicker
@@ -184,7 +184,7 @@ class EditUserProfileScreen : BaseScreen<
                     }
                 )
 
-                ProfileImage(
+                EditProfileImage(
                     profileImageUrl = state.profileImageUrl,
                     profileImageBitmap = state.profileImageBitmap,
                     modifier = Modifier.fillMaxWidth().align(Alignment.CenterHorizontally),

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/component/EditProfileImage.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/component/EditProfileImage.kt
@@ -1,6 +1,5 @@
 package net.thechance.mena.identity.presentation.screen.editProfile.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -35,6 +34,7 @@ import mena.identity_presentation.generated.resources.pencil_edit
 import mena.identity_presentation.generated.resources.profile_profile_picture_content_description
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.identity.presentation.components.ProfileImage
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
@@ -42,7 +42,7 @@ import org.koin.core.qualifier.named
 
 
 @Composable
-fun ProfileImage(
+fun EditProfileImage(
     profileImageUrl: String,
     profileImageBitmap: ImageBitmap?,
     modifier: Modifier = Modifier,
@@ -54,43 +54,12 @@ fun ProfileImage(
         modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Box(modifier = Modifier) {
-            Box(
+            ProfileImage(
+                profileImageUrl = profileImageUrl,
+                profileImageBitmap = profileImageBitmap,
                 modifier = Modifier
                     .padding(bottom = Theme.spacing._16)
-                    .border(1.dp, Theme.colorScheme.stroke, CircleShape)
-                    .dropShadow(
-                        shape = CircleShape,
-                        shadow = Shadow(
-                            radius = 8.dp,
-                            spread = 0.dp,
-                            color = shadowColor,
-                            offset = DpOffset(x = 0.dp, 4.dp)
-                        )
-                    )
-                    .dropShadow(
-                        shape = CircleShape,
-                        shadow = Shadow(
-                            radius = 8.dp,
-                            spread = 0.dp,
-                            color = shadowColor,
-                            offset = DpOffset(x = 4.dp, 0.dp)
-                        )
-                    )
-            ) {
-                if (profileImageBitmap == null) {
-                    AsyncProfileImage(profileImageUrl)
-                } else {
-                    Image(
-                        bitmap = profileImageBitmap,
-                        contentScale = ContentScale.Crop,
-                        contentDescription = stringResource(Res.string.profile_profile_picture_content_description),
-                        modifier = Modifier
-                            .size(88.dp)
-                            .clip(CircleShape),
-                    )
-                }
-            }
-
+            )
             Box(
                 modifier = Modifier
                     .size(32.dp)

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/profile/ProfileScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/profile/ProfileScreen.kt
@@ -6,13 +6,16 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
@@ -33,6 +36,7 @@ import net.thechance.mena.designsystem.presentation.component.snackbar.SnackBar
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.identity.presentation.base.BaseScreen
+import net.thechance.mena.identity.presentation.components.ProfileImage
 import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.AddressesScreen
 import net.thechance.mena.identity.presentation.screen.editProfile.EditUserProfileScreen
 import net.thechance.mena.identity.presentation.screen.profile.components.AccountSettingsSection
@@ -123,6 +127,20 @@ class ProfileScreen : BaseScreen<
                         )
                     }
                     item {
+                        Box {
+                            ProfileImage(
+                                profileImageUrl = state.profileImageUrl,
+                                profileImageBitmap = null
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .padding(end = 15.dp, bottom = 3.dp)
+                                    .align(Alignment.BottomEnd)
+                                    .size(10.dp)
+                                    .border(1.dp, Theme.colorScheme.stroke, CircleShape)
+                                    .background(Theme.colorScheme.success, CircleShape)
+                            )
+                        }
                         AnimatedVisibility(
                             visible = state.isSuccess,
                             enter = expandVertically(),
@@ -130,11 +148,10 @@ class ProfileScreen : BaseScreen<
                             modifier = Modifier.fillMaxWidth()
                         ) {
                             ProfileInfoContainer(
-                                modifier = Modifier
-                                    .fillMaxWidth(),
-                                profilePicture = state.profileImageUrl,
                                 fullName = state.fullName,
                                 userName = state.userName,
+                                modifier = Modifier
+                                    .fillMaxWidth(),
                             )
                         }
                     }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/profile/components/ProfileInfoContainer.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/profile/components/ProfileInfoContainer.kt
@@ -1,32 +1,21 @@
 package net.thechance.mena.identity.presentation.screen.profile.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.dp
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
-import net.thechance.mena.identity.presentation.screen.editProfile.component.AsyncProfileImage
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 
 @Composable
 fun ProfileInfoContainer(
-    profilePicture: String,
     fullName: String,
     userName: String,
     modifier: Modifier = Modifier,
@@ -36,41 +25,6 @@ fun ProfileInfoContainer(
     Column(
         modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Box(modifier = Modifier) {
-            Box(
-                modifier = Modifier
-                    .border(1.dp, Theme.colorScheme.stroke, CircleShape)
-                    .dropShadow(
-                        shape = CircleShape,
-                        shadow = Shadow(
-                            radius = 8.dp,
-                            spread = 0.dp,
-                            color = shadowColor,
-                            offset = DpOffset(x = 0.dp, 4.dp)
-                        )
-                    )
-                    .dropShadow(
-                        shape = CircleShape,
-                        shadow = Shadow(
-                            radius = 8.dp,
-                            spread = 0.dp,
-                            color = shadowColor,
-                            offset = DpOffset(x = 4.dp, 0.dp)
-                        )
-                    )
-            ) {
-                AsyncProfileImage(profilePicture)
-            }
-
-            Box(
-                modifier = Modifier
-                    .padding(end = 15.dp, bottom = 3.dp)
-                    .align(Alignment.BottomEnd)
-                    .size(10.dp)
-                    .border(1.dp, Theme.colorScheme.stroke, CircleShape)
-                    .background(Theme.colorScheme.success, CircleShape)
-            )
-        }
         Text(
             text = fullName,
             style = Theme.typography.label.medium.copy(
@@ -100,7 +54,6 @@ fun ProfileInfoContainer(
 fun PreviewProfileInfoContainer() {
     MenaTheme {
         ProfileInfoContainer(
-            profilePicture = "https://i.pinimg.com/736x/b4/d6/e5/b4d6e50449fff312606a05bce43cc4c3.jpg",
             fullName = "Mohammed Ahmed Mansour",
             userName = "@Mohammed_2025",
         )


### PR DESCRIPTION
This PR refactor profile image component to be reusable and used in both screens (Edit Profile And Profile Screen). Additionally, it makes the profile image appears and fallback to a placeholder if it doesn't exist.

<img width="1022" height="846" alt="Screenshot 2025-11-03 at 11 19 09" src="https://github.com/user-attachments/assets/fd48250a-173d-4723-b0e9-e646b2e24a22" />
