### PR TITLE
fix:downloading started toast only appears if there are transactions

### DIFF
--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsViewModel.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsViewModel.kt
@@ -162,6 +162,9 @@ class ExportTransactionsViewModel(
             showInvalidDatesSnackBar()
             return
         }
+        updateState { oldState ->
+            oldState.copy(isDownloadLoading = true, isViewAndShareButtonEnabled = false)
+        }
         tryToExecute(
             callee = {
                 val statement = getStatement()
@@ -296,9 +299,6 @@ class ExportTransactionsViewModel(
     }
 
     private suspend fun onDownloadStart() {
-        updateState { oldState ->
-            oldState.copy(isDownloadLoading = true, isViewAndShareButtonEnabled = false)
-        }
         showToast(messageRes = Res.string.downloading_started)
     }
 

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsViewModel.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsViewModel.kt
@@ -162,12 +162,14 @@ class ExportTransactionsViewModel(
             showInvalidDatesSnackBar()
             return
         }
+        updateState { oldState ->
+            oldState.copy(isDownloadLoading = true, isViewAndShareButtonEnabled = false)
+        }
         tryToExecute(
-            onStart = ::onDownloadStart,
             callee = ::getStatement,
-            onSuccess = { statement -> downloadStatement(statement) },
             onError = ::handleDownloadError,
-            dispatcher = dispatcher
+            onSuccess = { statement -> downloadStatement(statement) },
+            dispatcher = dispatcher,
         )
     }
 
@@ -289,26 +291,26 @@ class ExportTransactionsViewModel(
     }
 
     private suspend fun onDownloadStart() {
-        if (currentState.hasNoTransactionsError) {
-            showToast(messageRes = Res.string.error_no_transactions)
-            return
-        }
-
-        updateState { oldState ->
-            oldState.copy(isDownloadLoading = true, isViewAndShareButtonEnabled = false)
-        }
         showToast(messageRes = Res.string.downloading_started)
     }
 
     @OptIn(ExperimentalTime::class)
     private suspend fun getStatement(): StatementWithMetaData {
-        return if (currentState.isCustomFilterCardSelected) {
+        val statement = if (currentState.isCustomFilterCardSelected) {
             statementRepository.getStatementWithMetadata(
                 getTransactionFilterParams()
             )
         } else {
             statementRepository.getStatementWithMetadata()
         }
+        if (statement.byteArray.isEmpty()) {
+            currentState.copy(hasNoTransactionsError = true)
+            showToast(messageRes = Res.string.error_no_transactions)
+
+        } else {
+            onDownloadStart()
+        }
+        return statement
     }
 
     private fun getTransactionFilterParams(): TransactionFilterParams =

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsViewModel.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsViewModel.kt
@@ -162,16 +162,21 @@ class ExportTransactionsViewModel(
             showInvalidDatesSnackBar()
             return
         }
-        updateState { oldState ->
-            oldState.copy(isDownloadLoading = true, isViewAndShareButtonEnabled = false)
-        }
         tryToExecute(
-            callee = ::getStatement,
+            callee = {
+                val statement = getStatement()
+                if (statement.byteArray.isEmpty()) {
+                    showToast(messageRes = Res.string.error_no_transactions)
+                }
+                onDownloadStart()
+                statement
+            },
             onError = ::handleDownloadError,
             onSuccess = { statement -> downloadStatement(statement) },
             dispatcher = dispatcher,
         )
     }
+
 
     private fun areDatesValid(): Boolean {
         val startDate = currentState.filterState.startDate
@@ -291,6 +296,9 @@ class ExportTransactionsViewModel(
     }
 
     private suspend fun onDownloadStart() {
+        updateState { oldState ->
+            oldState.copy(isDownloadLoading = true, isViewAndShareButtonEnabled = false)
+        }
         showToast(messageRes = Res.string.downloading_started)
     }
 


### PR DESCRIPTION
make downloading started toast only appears if there are transactions
before:

https://github.com/user-attachments/assets/ca6240a3-1d3b-4f35-9405-a336dac41f9f

after:

https://github.com/user-attachments/assets/9d10c66a-8c6b-4192-9b46-2b29460bef9a

