### PR TITLE
Feature/FTH-131 implement add mosque validation  

### DIFF
--- a/faith_presentation/src/commonMain/composeResources/values/strings.xml
+++ b/faith_presentation/src/commonMain/composeResources/values/strings.xml
@@ -164,6 +164,7 @@
     <string name="mosque_address">Address</string>
     <string name="upload_image">Upload Image</string>
     <string name="add_new_mosque">Add New Mosque</string>
+    <string name="add">Add</string>
     <string name="image_size_required">Image (9:16)</string>
     <string name="view_on_map">View on map</string>
     <string name="icon_location">location icon</string>

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueInteractionListener.kt
@@ -9,7 +9,7 @@ internal interface CreateMosqueInteractionListener {
     fun onClickUploadImage(image: ImageSrc)
     fun onAddClick()
     fun onNameChange(name: String)
-    fun onAddressChanged(address: String)
-    fun mapPositionChanged(coordinate: Coordinate)
+    fun onAddressChange(address: String)
+    fun mapPositionChange(coordinate: Coordinate)
 
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueInteractionListener.kt
@@ -7,6 +7,7 @@ internal interface CreateMosqueInteractionListener {
     fun onBackClicked()
     fun onEditImageMosqueClicked()
     fun onClickUploadImage(image: ImageSrc)
+    fun onAddClicked()
     fun onNameChange(name: String)
     fun onAddressChanged(address: String)
     fun mapPositionChanged(coordinate: Coordinate)

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueInteractionListener.kt
@@ -4,10 +4,10 @@ import com.attafitamim.krop.core.images.ImageSrc
 import net.thechance.mena.faith.presentation.feature.mosque.Coordinate
 
 internal interface CreateMosqueInteractionListener {
-    fun onBackClicked()
-    fun onEditImageMosqueClicked()
+    fun onBackClick()
+    fun onEditImageMosqueClick()
     fun onClickUploadImage(image: ImageSrc)
-    fun onAddClicked()
+    fun onAddClick()
     fun onNameChange(name: String)
     fun onAddressChanged(address: String)
     fun mapPositionChanged(coordinate: Coordinate)

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueScreen.kt
@@ -124,7 +124,7 @@ private fun MosqueLocationMapSection(
     LaunchedEffect(cameraState) {
         snapshotFlow { cameraState.position }
             .collect {
-                listener.mapPositionChanged(
+                listener.mapPositionChange(
                     coordinate = Coordinate(
                         latitude = cameraState.position.target.latitude,
                         longitude = cameraState.position.target.longitude
@@ -159,7 +159,7 @@ private fun MosqueAddressSection(
     )
     TextField(
         value = state.address,
-        onValueChanged = listener::onAddressChanged,
+        onValueChanged = listener::onAddressChange,
         hint = "",
         leadingIcon = painterResource(Res.drawable.ic_location),
     )
@@ -220,8 +220,8 @@ private fun MosqueCreateScreenPreview() {
                 override fun onClickUploadImage(image: ImageSrc) {}
                 override fun onAddClick() {}
                 override fun onNameChange(name: String) {}
-                override fun onAddressChanged(address: String) {}
-                override fun mapPositionChanged(coordinate: Coordinate) {}
+                override fun onAddressChange(address: String) {}
+                override fun mapPositionChange(coordinate: Coordinate) {}
             }
         )
     }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueScreen.kt
@@ -59,7 +59,7 @@ internal fun CreateMosqueScreen(viewModel: CreateMosqueViewModel = koinViewModel
                     .fillMaxWidth()
                     .padding(Theme.spacing._16),
                 text = stringResource(Res.string.add),
-                onClick = viewModel::onAddClicked,
+                onClick = viewModel::onAddClick,
                 isEnabled = uiState.isButtonEnabled,
                 contentPadding = PaddingValues(vertical = Theme.spacing._12)
             )
@@ -171,7 +171,7 @@ private fun CreateMosqueAppBar(
 ) {
     AppBar(
         title = stringResource(Res.string.add_new_mosque),
-        onLeadingClick = listener::onBackClicked,
+        onLeadingClick = listener::onBackClick,
         contentPadding = PaddingValues(
             horizontal = Theme.spacing._12,
             vertical = Theme.spacing._8
@@ -215,10 +215,10 @@ private fun MosqueCreateScreenPreview() {
         Content(
             uiState = CreateMosqueUiState(),
             listener = object : CreateMosqueInteractionListener {
-                override fun onBackClicked() {}
-                override fun onEditImageMosqueClicked() {}
+                override fun onBackClick() {}
+                override fun onEditImageMosqueClick() {}
                 override fun onClickUploadImage(image: ImageSrc) {}
-                override fun onAddClicked() {}
+                override fun onAddClick() {}
                 override fun onNameChange(name: String) {}
                 override fun onAddressChanged(address: String) {}
                 override fun mapPositionChanged(coordinate: Coordinate) {}

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueScreen.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.attafitamim.krop.core.images.ImageSrc
 import io.github.dellisd.spatialk.geojson.Position
 import mena.faith_presentation.generated.resources.Res
+import mena.faith_presentation.generated.resources.add
 import mena.faith_presentation.generated.resources.add_new_mosque
 import mena.faith_presentation.generated.resources.back
 import mena.faith_presentation.generated.resources.ic_arrow_left
@@ -26,6 +27,7 @@ import mena.faith_presentation.generated.resources.location
 import mena.faith_presentation.generated.resources.mosque_address
 import mena.faith_presentation.generated.resources.mosque_name
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
+import net.thechance.mena.designsystem.presentation.component.button.PrimaryButton
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.component.text.Text
@@ -50,7 +52,18 @@ internal fun CreateMosqueScreen(viewModel: CreateMosqueViewModel = koinViewModel
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Scaffold(
-        topBar = { CreateMosqueAppBar(viewModel) }
+        topBar = { CreateMosqueAppBar(viewModel) },
+        bottomBar = {
+            PrimaryButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(Theme.spacing._16),
+                text = stringResource(Res.string.add),
+                onClick = viewModel::onAddClicked,
+                isEnabled = uiState.isButtonEnabled,
+                contentPadding = PaddingValues(vertical = Theme.spacing._12)
+            )
+        }
     ) {
         Content(uiState, viewModel)
     }
@@ -70,7 +83,7 @@ private fun Content(
         item { MosqueLocationHeader(uiState, listener) }
         item { MosqueLocationMapSection(uiState, listener) }
         item { MosqueAddressSection(uiState, listener) }
-        item { AddImage(uiState, listener) }
+        item { UploadMosqueImage(uiState, listener) }
     }
 }
 
@@ -173,7 +186,7 @@ private fun CreateMosqueAppBar(
 }
 
 @Composable
-private fun AddImage(
+private fun UploadMosqueImage(
     uiState: CreateMosqueUiState,
     listener: CreateMosqueInteractionListener
 ) {
@@ -205,6 +218,7 @@ private fun MosqueCreateScreenPreview() {
                 override fun onBackClicked() {}
                 override fun onEditImageMosqueClicked() {}
                 override fun onClickUploadImage(image: ImageSrc) {}
+                override fun onAddClicked() {}
                 override fun onNameChange(name: String) {}
                 override fun onAddressChanged(address: String) {}
                 override fun mapPositionChanged(coordinate: Coordinate) {}

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueUiState.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueUiState.kt
@@ -1,22 +1,15 @@
 package net.thechance.mena.faith.presentation.feature.mosque.create
 
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.ImageBitmapConfig
 import com.attafitamim.krop.core.images.ImageSrc
 import net.thechance.mena.faith.presentation.feature.mosque.Coordinate
 
 internal data class CreateMosqueUiState(
     val selectedImage: ImageSrc? = null,
-    val croppedImage: ImageBitmap? = ImageBitmap(
-        width = 100,
-        height = 100,
-        config = ImageBitmapConfig.Argb8888,
-        hasAlpha = true
-    ),
+    val croppedImage: ImageBitmap? = null,
     val address: String = "",
     val name: String = "",
-    val location: Coordinate? = Coordinate(26.820553, 30.802498),
+    val location: Coordinate? = null,
     val isImageBeingCropped: Boolean = false,
     val isButtonEnabled: Boolean = false
 )
-

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueUiState.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueUiState.kt
@@ -1,12 +1,22 @@
 package net.thechance.mena.faith.presentation.feature.mosque.create
 
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.ImageBitmapConfig
+import com.attafitamim.krop.core.images.ImageSrc
 import net.thechance.mena.faith.presentation.feature.mosque.Coordinate
 
 internal data class CreateMosqueUiState(
-    val croppedImage: ImageBitmap? = null,
-    val isImageBeingCropped: Boolean = false,
+    val selectedImage: ImageSrc? = null,
+    val croppedImage: ImageBitmap? = ImageBitmap(
+        width = 100,
+        height = 100,
+        config = ImageBitmapConfig.Argb8888,
+        hasAlpha = true
+    ),
     val address: String = "",
     val name: String = "",
-    val location: Coordinate? = null,
+    val location: Coordinate? = Coordinate(26.820553, 30.802498),
+    val isImageBeingCropped: Boolean = false,
+    val isButtonEnabled: Boolean = false
 )
+

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueViewModel.kt
@@ -8,6 +8,7 @@ internal class CreateMosqueViewModel() :
     BaseViewModel<CreateMosqueUiState, CreateMosqueEffect>(
         CreateMosqueUiState()
     ), CreateMosqueInteractionListener {
+
     override fun onBackClicked() {
         //TODO("Not yet implemented")
     }
@@ -17,20 +18,42 @@ internal class CreateMosqueViewModel() :
     }
 
     override fun onClickUploadImage(image: ImageSrc) {
+        updateState {
+            it.copy(
+                selectedImage = image,
+                isImageBeingCropped = true
+            )
+        }
+        checkIfFormIsComplete()
+    }
+
+    override fun onAddClicked() {
         //TODO("Not yet implemented")
     }
 
     override fun onNameChange(name: String) {
-        //TODO("Not yet implemented")
+        updateState { it.copy(name = name) }
+        checkIfFormIsComplete()
     }
 
     override fun onAddressChanged(address: String) {
-        //TODO("Not yet implemented")
+        updateState { it.copy(address = address) }
+        checkIfFormIsComplete()
     }
 
     override fun mapPositionChanged(coordinate: Coordinate) {
-        //TODO("Not yet implemented")
+        updateState { it.copy(location = coordinate) }
+        checkIfFormIsComplete()
     }
 
-
+    private fun checkIfFormIsComplete() {
+        updateState { currentState ->
+            currentState.copy(
+                isButtonEnabled = currentState.name.isNotBlank() &&
+                        currentState.address.isNotBlank() &&
+                        currentState.location != null &&
+                        currentState.croppedImage != null
+            )
+        }
+    }
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueViewModel.kt
@@ -21,7 +21,7 @@ internal class CreateMosqueViewModel() :
         updateState {
             it.copy(
                 selectedImage = image,
-                isImageBeingCropped = true
+                isImageBeingCropped = false
             )
         }
         checkIfFormIsComplete()

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueViewModel.kt
@@ -9,11 +9,11 @@ internal class CreateMosqueViewModel() :
         CreateMosqueUiState()
     ), CreateMosqueInteractionListener {
 
-    override fun onBackClicked() {
+    override fun onBackClick() {
         //TODO("Not yet implemented")
     }
 
-    override fun onEditImageMosqueClicked() {
+    override fun onEditImageMosqueClick() {
         //TODO("Not yet implemented")
     }
 
@@ -27,7 +27,7 @@ internal class CreateMosqueViewModel() :
         checkIfFormIsComplete()
     }
 
-    override fun onAddClicked() {
+    override fun onAddClick() {
         //TODO("Not yet implemented")
     }
 

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/create/CreateMosqueViewModel.kt
@@ -36,12 +36,12 @@ internal class CreateMosqueViewModel() :
         checkIfFormIsComplete()
     }
 
-    override fun onAddressChanged(address: String) {
+    override fun onAddressChange(address: String) {
         updateState { it.copy(address = address) }
         checkIfFormIsComplete()
     }
 
-    override fun mapPositionChanged(coordinate: Coordinate) {
+    override fun mapPositionChange(coordinate: Coordinate) {
         updateState { it.copy(location = coordinate) }
         checkIfFormIsComplete()
     }


### PR DESCRIPTION
This PR introduces the business logic for the "Add New Mosque" screen.

- Implemented the `CreateMosqueViewModel` to handle user interactions like changing the mosque name, address, location, and uploading an image.
- Added an "Add" button to the screen, which is enabled only when all required fields (name, address, location, and image) are filled.
- Renamed the image upload composable to `UploadMosqueImage` for clarity.

