### PR TITLE
Fix status bar color across the app

### DIFF
--- a/composeApp/src/commonMain/kotlin/net/thechance/mena/appEntryPoint/EntryPoint.kt
+++ b/composeApp/src/commonMain/kotlin/net/thechance/mena/appEntryPoint/EntryPoint.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -67,8 +66,6 @@ private fun LoggedInContainer(
             .fillMaxSize()
             .background(Theme.colorScheme.background.surfaceLow)
             .navigationBarsPadding()
-            .systemBarsPadding()
-            .background(Theme.colorScheme.background.surfaceHigh)
     ) {
         FeatureContent(activeFeature)
 

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/scaffold/Scaffold.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/scaffold/Scaffold.kt
@@ -42,7 +42,6 @@ fun Scaffold(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(backgroundColor)
             .then(
                 if (hasBlur) Modifier.blur(4.dp) else Modifier
             )

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/scaffold/Scaffold.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/scaffold/Scaffold.kt
@@ -3,22 +3,29 @@ package net.thechance.mena.designsystem.presentation.component.scaffold
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 
 @Composable
 fun Scaffold(
     modifier: Modifier = Modifier,
+    backgroundColor: Color = Theme.colorScheme.background.surface,
+    statusBarColor: Color = backgroundColor,
     topBar: @Composable () -> Unit = {},
     bottomBar: @Composable () -> Unit = {},
     snakeBar: @Composable () -> Unit = {},
@@ -35,10 +42,12 @@ fun Scaffold(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(Theme.colorScheme.background.surface)
+            .background(backgroundColor)
             .then(
                 if (hasBlur) Modifier.blur(4.dp) else Modifier
             )
+            .background(statusBarColor)
+            .windowInsetsPadding(WindowInsets.statusBars)
             .navigationBarsPadding()
             .systemBarsPadding(),
         contentAlignment = Alignment.Center
@@ -47,6 +56,8 @@ fun Scaffold(
             topBar()
             Box(
                 modifier = Modifier
+                    .background(backgroundColor)
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
                     .fillMaxWidth()
                     .weight(1f)
             ) {
@@ -65,6 +76,6 @@ fun Scaffold(
     }
 
     scope.items.forEach {
-            it.content(scope, it.isVisible)
+        it.content(scope, it.isVisible)
     }
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/pickLocation/PickLocationScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/pickLocation/PickLocationScreen.kt
@@ -48,6 +48,7 @@ data class PickLocationScreen(
         listener: PickLocationScreenInteractionListener
     ) {
         Scaffold(
+            statusBarColor = Theme.colorScheme.background.surfaceLow,
             topBar = {
                 AuthAppBar(
                     title = stringResource(Res.string.pick_location_title),


### PR DESCRIPTION
The `systemBarsPadding` modifier and a redundant `background` modifier have been removed from the `EntryPoint` composable.
 
Also, a `statusBarColor` parameter added to the `Scaffold` composable to match the new design where some screens may contains different color than others across the app.


https://github.com/user-attachments/assets/19285d20-1bde-4140-8d9e-4ee2977f9f16

