### PR TITLE
Fix: TRN-94 Update Categories

### DIFF
--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -75,13 +74,12 @@ internal fun UpdateCategoriesScreen(
                     )
                 )
 
-                navController.navigate(Route.Home)
+                navController.navigate(Route.Home) {
+                    popUpTo(Route.Home) { inclusive = true }
+                    launchSingleTop = true
+                }
             }
         }
-    }
-
-    LaunchedEffect(Unit) {
-        viewModel.getCategories()
     }
 
     UpdateCategoriesScreenContent(

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModel.kt
@@ -21,10 +21,10 @@ internal class UpdateCategoriesViewModel(
 ), UpdateCategoriesInteractionListener {
 
     init {
-        initializeCategories()
+        getCategories()
     }
 
-    private fun initializeCategories() {
+    private fun getCategories() {
         tryToExecute(
             block = { repository.getAllCategories() },
             onSuccess = ::handleLoadCategoriesSuccess,
@@ -76,6 +76,6 @@ internal class UpdateCategoriesViewModel(
 
     override fun onClickRetry() {
         updateState{ copy(errorState = null) }
-        initializeCategories()
+        getCategories()
     }
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModel.kt
@@ -24,7 +24,7 @@ internal class UpdateCategoriesViewModel(
         initializeCategories()
     }
 
-    fun initializeCategories() {
+    private fun initializeCategories() {
         tryToExecute(
             block = { repository.getAllCategories() },
             onSuccess = ::handleLoadCategoriesSuccess,

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModel.kt
@@ -21,10 +21,10 @@ internal class UpdateCategoriesViewModel(
 ), UpdateCategoriesInteractionListener {
 
     init {
-        getCategories()
+        initializeCategories()
     }
 
-    fun getCategories() {
+    fun initializeCategories() {
         tryToExecute(
             block = { repository.getAllCategories() },
             onSuccess = ::handleLoadCategoriesSuccess,
@@ -76,6 +76,6 @@ internal class UpdateCategoriesViewModel(
 
     override fun onClickRetry() {
         updateState{ copy(errorState = null) }
-        getCategories()
+        initializeCategories()
     }
 }

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModelTest.kt
@@ -3,6 +3,7 @@ package net.thechance.mena.trends.presentation.screen.update_categories
 import app.cash.turbine.test
 import assertk.assertThat
 import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.answering.throws
@@ -136,4 +137,18 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
                 cancelAndIgnoreRemainingEvents()
             }
         }
+
+    @Test
+    fun `onRetryClick should reset error and call getCategories`() =
+        runTest(testDispatcher) {
+            viewModel.onClickRetry()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            viewModel.state.test {
+                val state = awaitItem()
+                assertThat(state.errorState).isNull()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
 }

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModelTest.kt
@@ -35,7 +35,7 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
     }
 
     @Test
-    fun `initializeCategories should start loading when initially called`() =
+    fun `getCategories should start loading when initially called`() =
         runTest(testDispatcher) {
             viewModel.state.test {
                 val state = awaitItem()
@@ -44,7 +44,7 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
         }
 
     @Test
-    fun `initializeCategories should return categories with success when repository returns value`() =
+    fun `getCategories should return categories with success when repository returns value`() =
         runTest(testDispatcher) {
             viewModel.state.test {
                 skipItems(1)
@@ -55,7 +55,7 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
         }
 
     @Test
-    fun `initializeCategories should throw exception when initially called`() =
+    fun `getCategories should throw exception when initially called`() =
         runTest(testDispatcher) {
             everySuspend { repository.getAllCategories() } throws Exception()
 
@@ -68,7 +68,7 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
         }
 
     @Test
-    fun `initializeCategories should end loading when initially called`() =
+    fun `getCategories should end loading when initially called`() =
         runTest(testDispatcher) {
             viewModel.state.test {
                 skipItems(2)
@@ -139,7 +139,7 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
         }
 
     @Test
-    fun `onRetryClick should reset error and call getCategories`() =
+    fun `onRetryClick should reset error`() =
         runTest(testDispatcher) {
             viewModel.onClickRetry()
             testDispatcher.scheduler.advanceUntilIdle()
@@ -150,5 +150,4 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
                 cancelAndIgnoreRemainingEvents()
             }
         }
-
 }

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModelTest.kt
@@ -3,14 +3,12 @@ package net.thechance.mena.trends.presentation.screen.update_categories
 import app.cash.turbine.test
 import assertk.assertThat
 import assertk.assertions.isNotNull
-import assertk.assertions.isNull
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.answering.throws
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
-import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
 import net.thechance.mena.trends.domain.repository.CategoryRepository
 import net.thechance.mena.trends.presentation.utils.TestExtensions
@@ -138,17 +136,4 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
                 cancelAndIgnoreRemainingEvents()
             }
         }
-
-    @Test
-    fun `onRetryClick should reset error and call initializeCategories`() = runTest {
-        viewModel.onClickRetry()
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        viewModel.state.test {
-            val state = awaitItem()
-            assertThat(state.errorState).isNull()
-            verifySuspend { viewModel.initializeCategories() }
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
 }

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModelTest.kt
@@ -36,7 +36,7 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
     }
 
     @Test
-    fun `getCategories should start loading when initially called`() =
+    fun `initializeCategories should start loading when initially called`() =
         runTest(testDispatcher) {
             viewModel.state.test {
                 val state = awaitItem()
@@ -45,7 +45,7 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
         }
 
     @Test
-    fun `getCategories should return categories with success when repository returns value`() =
+    fun `initializeCategories should return categories with success when repository returns value`() =
         runTest(testDispatcher) {
             viewModel.state.test {
                 skipItems(1)
@@ -56,7 +56,7 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
         }
 
     @Test
-    fun `getCategories should throw exception when initially called`() =
+    fun `initializeCategories should throw exception when initially called`() =
         runTest(testDispatcher) {
             everySuspend { repository.getAllCategories() } throws Exception()
 
@@ -69,7 +69,7 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
         }
 
     @Test
-    fun `getCategories should end loading when initially called`() =
+    fun `initializeCategories should end loading when initially called`() =
         runTest(testDispatcher) {
             viewModel.state.test {
                 skipItems(2)
@@ -140,14 +140,14 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
         }
 
     @Test
-    fun `onRetryClick should reset error and call getCategories`() = runTest {
+    fun `onRetryClick should reset error and call initializeCategories`() = runTest {
         viewModel.onClickRetry()
         testDispatcher.scheduler.advanceUntilIdle()
 
         viewModel.state.test {
             val state = awaitItem()
             assertThat(state.errorState).isNull()
-            verifySuspend { viewModel.getCategories() }
+            verifySuspend { viewModel.initializeCategories() }
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesViewModelTest.kt
@@ -35,7 +35,7 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
     }
 
     @Test
-    fun `initializeCategories should start loading when initially called`() =
+    fun `getCategories should start loading when initially called`() =
         runTest(testDispatcher) {
             viewModel.state.test {
                 val state = awaitItem()
@@ -44,7 +44,7 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
         }
 
     @Test
-    fun `initializeCategories should return categories with success when repository returns value`() =
+    fun `getCategories should return categories with success when repository returns value`() =
         runTest(testDispatcher) {
             viewModel.state.test {
                 skipItems(1)
@@ -55,7 +55,7 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
         }
 
     @Test
-    fun `initializeCategories should throw exception when initially called`() =
+    fun `getCategories should throw exception when initially called`() =
         runTest(testDispatcher) {
             everySuspend { repository.getAllCategories() } throws Exception()
 
@@ -68,7 +68,7 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
         }
 
     @Test
-    fun `initializeCategories should end loading when initially called`() =
+    fun `getCategories should end loading when initially called`() =
         runTest(testDispatcher) {
             viewModel.state.test {
                 skipItems(2)
@@ -139,7 +139,7 @@ class UpdateCategoriesViewModelTest : TestExtensions() {
         }
 
     @Test
-    fun `onRetryClick should reset error and call getCategories`() =
+    fun `onRetryClick should reset error`() =
         runTest(testDispatcher) {
             viewModel.onClickRetry()
             testDispatcher.scheduler.advanceUntilIdle()


### PR DESCRIPTION
## Changes Made

### Navigation Enhancement
- Updated navigation behavior in `UpdateCategoriesScreen` to clear back stack when navigating to Home
- Added `popUpTo` with inclusive flag and `launchSingleTop` for proper navigation flow
- Removed `LaunchedEffect` for category loading

### ViewModel Refactoring
- Renamed `getCategories()` to `initializeCategories()` for better semantics
