### PR TITLE
Fix: TRN-99 Home Screen Scroll State

### DIFF
--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
@@ -1,6 +1,5 @@
 package net.thechance.mena.trends.presentation.screen.home
 
-import app.cash.paging.compose.itemKey
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -9,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -21,7 +22,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
 import app.cash.paging.compose.LazyPagingItems
 import app.cash.paging.compose.collectAsLazyPagingItems
-import kotlinx.serialization.json.JsonNull.content
+import app.cash.paging.compose.itemKey
 import mena.trends_presentation.generated.resources.Res
 import mena.trends_presentation.generated.resources.add_reel
 import mena.trends_presentation.generated.resources.edit_tags
@@ -100,6 +101,7 @@ private fun HomeScreenContent(
         }
     ) {
         val reels = state.reels.collectAsLazyPagingItems()
+        val listState = rememberLazyListState()
 
         val hasNetworkError = reels.loadState.refresh.toErrorState() == ErrorState.NoInternet
                 && reels.itemSnapshotList.isEmpty()
@@ -131,7 +133,8 @@ private fun HomeScreenContent(
                         reels = reels,
                         onClickLike = listener::onClickLike,
                         onClickReel = listener::onClickReel,
-                        onExpandDescription = listener::onClickExpandDescription
+                        onExpandDescription = listener::onClickExpandDescription,
+                        listState = listState,
                     )
                 }
             )
@@ -166,6 +169,7 @@ private fun AddTrendFAB(
 @Composable
 private fun ReelsListSection(
     reels: LazyPagingItems<ReelUiState>,
+    listState: LazyListState,
     onClickLike: (reelId: String, isLiked: Boolean) -> Unit,
     onClickReel: (reelId: String) -> Unit,
     onExpandDescription: (reelId: String) -> Unit
@@ -174,6 +178,7 @@ private fun ReelsListSection(
         modifier = Modifier
             .fillMaxSize()
             .padding(horizontal = Theme.spacing._16),
+        state = listState,
         contentPadding = PaddingValues(vertical = Theme.spacing._8),
         verticalArrangement = Arrangement.spacedBy(Theme.spacing._16)
     ) {


### PR DESCRIPTION
## Summary
Preserve scroll position in the Home screen's Reels list by hoisting `LazyListState` to survive composition changes.

## Solution
Hoist LazyListState to HomeScreenContent scope, above the TrendsAnimatedVisibility wrapper. This ensures the state survives visibility changes and data refreshes, maintaining scroll position across:

- Data re-fetches via LaunchedEffect
- Loading state transitions
- Navigation back to the Home screen

## Changes
- Added rememberLazyListState() in HomeScreenContent
- Passed LazyListState to ReelsListSection and LazyColumn

## Impact
Improves user experience by maintaining scroll position during data updates, and enables future scroll-dependent features (e.g., scroll-to-top, scroll-based animations).