### PR TITLE
Refactor/IDN-110 Move Date Picker to Design System and Make It Reusable

### DIFF
--- a/design_system/build.gradle.kts
+++ b/design_system/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
                 implementation(compose.ui)
                 implementation(compose.components.resources)
                 implementation(compose.components.uiToolingPreview)
+                implementation(libs.squircle.shape)
             }
         }
 

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/datePicker/WheelDatePicker.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/datePicker/WheelDatePicker.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import net.thechance.mena.designsystem.presentation.component.text.Text
+import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import sv.lib.squircleshape.SquircleShape
@@ -225,7 +226,7 @@ private fun VerticalPicker(
 @Preview
 @Composable
 private fun WheelDatePickerPreview() {
-    net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme {
+    MenaTheme {
         WheelDatePicker(
             selectedDayIndex = 14,
             selectedMonthIndex = 5,

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/datePicker/WheelDatePicker.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/datePicker/WheelDatePicker.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.components
+package net.thechance.mena.designsystem.presentation.component.datePicker
 
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.tween
@@ -24,7 +24,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.flow.distinctUntilChanged
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -36,64 +38,44 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.number
-import kotlinx.datetime.toLocalDateTime
 import net.thechance.mena.designsystem.presentation.component.text.Text
-import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
-import net.thechance.mena.identity.presentation.util.AppMonth
-import net.thechance.mena.identity.presentation.util.getNumberOfDaysInMonth
-import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import sv.lib.squircleshape.SquircleShape
 import kotlin.math.absoluteValue
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
 
-@OptIn(ExperimentalTime::class)
 @Composable
 fun WheelDatePicker(
-    selectedDate: LocalDate?,
+    selectedDayIndex: Int,
+    selectedMonthIndex: Int,
+    selectedYearIndex: Int,
+    days: List<String>,
+    months: List<String>,
+    years: List<String>,
     modifier: Modifier = Modifier,
-    minYear: Int = 1920,
-    maxYear: Int = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).year,
-    onDateChange: (day: Int, month: Int, year: Int) -> Unit,
+    onDateChange: (dayIndex: Int, monthIndex: Int, yearIndex: Int) -> Unit,
 ) {
-    if (selectedDate == null)
-        return
+    val dayPagerState = rememberPagerState(
+        initialPage = selectedDayIndex.coerceIn(0, days.size - 1),
+        pageCount = { days.size }
+    )
 
     val monthPagerState = rememberPagerState(
-        initialPage = (selectedDate.month.number) - 1, pageCount = { 12 }
+        initialPage = selectedMonthIndex.coerceIn(0, months.size - 1),
+        pageCount = { months.size }
     )
 
     val yearPagerState = rememberPagerState(
-        initialPage = (selectedDate.year) - minYear,
-        pageCount = { maxYear - minYear + 1 }
+        initialPage = selectedYearIndex.coerceIn(0, years.size - 1),
+        pageCount = { years.size }
     )
-
-    val currentMonth = monthPagerState.currentPage + 1
-    val currentYear = minYear + yearPagerState.currentPage
-    val daysInMonth = remember(currentMonth, currentYear) {
-        getNumberOfDaysInMonth(currentYear, currentMonth)
-    }
-
-    val dayPagerState = rememberPagerState(
-        initialPage = (selectedDate.day) - 1,
-        pageCount = { daysInMonth }
-    )
-
-    val days = remember(daysInMonth) {
-        (1..daysInMonth).map { it.toString().padStart(2, '0') }
-    }
 
     var rowWidth by remember { mutableStateOf(0) }
 
-    LaunchedEffect(selectedDate) {
-        val targetYearPage = selectedDate.year - minYear
-        val targetMonthPage = selectedDate.month.number - 1
-        val targetDayPage = selectedDate.day - 1
+    LaunchedEffect(selectedDayIndex, selectedMonthIndex, selectedYearIndex) {
+        val targetDayPage = selectedDayIndex.coerceIn(0, days.size - 1)
+        val targetMonthPage = selectedMonthIndex.coerceIn(0, months.size - 1)
+        val targetYearPage = selectedYearIndex.coerceIn(0, years.size - 1)
 
         coroutineScope {
             if (yearPagerState.currentPage != targetYearPage) {
@@ -129,40 +111,38 @@ fun WheelDatePicker(
         ) {
             VerticalPicker(
                 state = monthPagerState,
-                options = AppMonth.entries.map { stringResource(it.res) },
+                options = months,
                 modifier = Modifier.padding(end = Theme.spacing._32),
-            ) {
-                val day = dayPagerState.currentPage + 1
-                val month = monthPagerState.currentPage + 1
-                val year = minYear + yearPagerState.currentPage
-                onDateChange(day, month, year)
-            }
+            )
 
             VerticalPicker(
                 state = dayPagerState,
                 options = days,
                 modifier = Modifier.padding(end = 52.dp)
-            ) {
-                val day = dayPagerState.currentPage + 1
-                val month = monthPagerState.currentPage + 1
-                val year = minYear + yearPagerState.currentPage
-                onDateChange(day, month, year)
-            }
+            )
 
             VerticalPicker(
                 state = yearPagerState,
-                options = (minYear..maxYear).map { it.toString() },
+                options = years,
                 isYearPicker = true
-            ) {
-                val day = dayPagerState.currentPage + 1
-                val month = monthPagerState.currentPage + 1
-                val year = minYear + yearPagerState.currentPage
-                onDateChange(day, month, year)
-            }
+            )
         }
     }
-}
 
+    LaunchedEffect(dayPagerState, monthPagerState, yearPagerState) {
+        snapshotFlow {
+            Triple(
+                dayPagerState.currentPage,
+                monthPagerState.currentPage,
+                yearPagerState.currentPage
+            )
+        }
+            .distinctUntilChanged()
+            .collect { (dayIndex, monthIndex, yearIndex) ->
+                onDateChange(dayIndex, monthIndex, yearIndex)
+            }
+    }
+}
 
 @Composable
 private fun ChoiceIndicator(modifier: Modifier = Modifier) {
@@ -179,8 +159,7 @@ private fun VerticalPicker(
     state: PagerState,
     options: List<String>,
     isYearPicker: Boolean = false,
-    modifier: Modifier = Modifier,
-    onDateChange: () -> Unit
+    modifier: Modifier = Modifier
 ) {
     val textMeasurer = rememberTextMeasurer()
     val baseStyle = Theme.typography.body.large
@@ -222,8 +201,6 @@ private fun VerticalPicker(
                 else -> 0.2f
             }
 
-            onDateChange()
-
             Box(
                 modifier = Modifier
                     .fillMaxHeight()
@@ -247,11 +224,17 @@ private fun VerticalPicker(
 
 @Preview
 @Composable
-private fun DatePickerBottomSheetContentPreview() {
-    MenaTheme {
+private fun WheelDatePickerPreview() {
+    net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme {
         WheelDatePicker(
-            selectedDate = LocalDate(2023, 1, 1),
-            onDateChange = { day, month, year -> },
+            selectedDayIndex = 14,
+            selectedMonthIndex = 5,
+            selectedYearIndex = 104,
+            days = (1..31).map { it.toString().padStart(2, '0') },
+            months = listOf("January", "February", "March", "April", "May", "June",
+                "July", "August", "September", "October", "November", "December"),
+            years = (1920..2024).map { it.toString() },
+            onDateChange = { _, _, _ -> },
         )
     }
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/GregorianDatePicker.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/GregorianDatePicker.kt
@@ -2,6 +2,7 @@ package net.thechance.mena.identity.presentation.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -84,7 +85,7 @@ private fun createYearList(minYear: Int, maxYear: Int): List<String> {
 @Composable
 private fun rememberMonthYearState(
     initialDate: LocalDate
-): Pair<androidx.compose.runtime.MutableState<Int>, androidx.compose.runtime.MutableState<Int>> {
+): Pair<MutableState<Int>, MutableState<Int>> {
     val currentMonthState = remember { mutableStateOf(initialDate.month.number) }
     val currentYearState = remember { mutableStateOf(initialDate.year) }
 

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/GregorianDatePicker.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/GregorianDatePicker.kt
@@ -1,0 +1,163 @@
+package net.thechance.mena.identity.presentation.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.YearMonth
+import kotlinx.datetime.number
+import kotlinx.datetime.toLocalDateTime
+import net.thechance.mena.designsystem.presentation.component.datePicker.WheelDatePicker
+import net.thechance.mena.identity.presentation.util.getDefaultMonthNames
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+@Composable
+fun GregorianDatePicker(
+    selectedDate: LocalDate?,
+    modifier: Modifier = Modifier,
+    minYear: Int = 1920,
+    maxYear: Int = 2024,
+    onDateChange: (day: Int, month: Int, year: Int) -> Unit,
+) {
+    val dateToUse = getEffectiveDate(selectedDate)
+    val monthNames = getDefaultMonthNames()
+    val yearList = createYearList(minYear, maxYear)
+
+    val (currentMonthState, currentYearState) = rememberMonthYearState(dateToUse)
+    val currentMonth = currentMonthState.value
+    val currentYear = currentYearState.value
+
+    val daysList = createDaysList(currentMonth, currentYear)
+    val selectedIndices = calculateSelectionIndices(
+        date = dateToUse,
+        month = currentMonth,
+        year = currentYear,
+        daysCount = daysList.size,
+        minYear = minYear
+    )
+
+    WheelDatePicker(
+        selectedDayIndex = selectedIndices.dayIndex,
+        selectedMonthIndex = selectedIndices.monthIndex,
+        selectedYearIndex = selectedIndices.yearIndex,
+        days = daysList,
+        months = monthNames,
+        years = yearList,
+        modifier = modifier,
+        onDateChange = { dayIndex, monthIndex, yearIndex ->
+            handleWheelDateChange(
+                dayIndex = dayIndex,
+                monthIndex = monthIndex,
+                yearIndex = yearIndex,
+                minYear = minYear,
+                onMonthYearUpdate = { month, year ->
+                    currentMonthState.value = month
+                    currentYearState.value = year
+                },
+                onDateChange = onDateChange
+            )
+        }
+    )
+}
+
+@OptIn(ExperimentalTime::class)
+@Composable
+private fun getEffectiveDate(selectedDate: LocalDate?): LocalDate {
+    val today = remember {
+        Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+    }
+    return selectedDate ?: today
+}
+
+@Composable
+private fun createYearList(minYear: Int, maxYear: Int): List<String> {
+    return remember(minYear, maxYear) {
+        (minYear..maxYear).map { it.toString() }
+    }
+}
+
+@Composable
+private fun rememberMonthYearState(
+    initialDate: LocalDate
+): Pair<androidx.compose.runtime.MutableState<Int>, androidx.compose.runtime.MutableState<Int>> {
+    val currentMonthState = remember { mutableStateOf(initialDate.month.number) }
+    val currentYearState = remember { mutableStateOf(initialDate.year) }
+
+    LaunchedEffect(initialDate.month.number, initialDate.year) {
+        currentMonthState.value = initialDate.month.number
+        currentYearState.value = initialDate.year
+    }
+
+    return currentMonthState to currentYearState
+}
+
+@Composable
+private fun createDaysList(month: Int, year: Int): List<String> {
+    val daysCount = remember(month, year) {
+        YearMonth(year, month).numberOfDays
+    }
+
+    return remember(daysCount) {
+        (1..daysCount).map { day ->
+            day.toString().padStart(2, '0')
+        }
+    }
+}
+
+private data class SelectionIndices(
+    val dayIndex: Int,
+    val monthIndex: Int,
+    val yearIndex: Int
+)
+
+private fun calculateSelectionIndices(
+    date: LocalDate,
+    month: Int,
+    year: Int,
+    daysCount: Int,
+    minYear: Int
+): SelectionIndices {
+    val dayIndex = (date.day.coerceIn(1, daysCount) - 1)
+    val monthIndex = month - 1
+    val yearIndex = year - minYear
+
+    return SelectionIndices(
+        dayIndex = dayIndex,
+        monthIndex = monthIndex,
+        yearIndex = yearIndex
+    )
+}
+
+private fun convertMonthIndexToValue(monthIndex: Int): Int = monthIndex + 1
+
+private fun convertYearIndexToValue(yearIndex: Int, minYear: Int): Int = minYear + yearIndex
+
+private fun convertDayIndexToValue(dayIndex: Int): Int = dayIndex + 1
+
+private fun getDaysInMonth(month: Int, year: Int): Int {
+    return YearMonth(year, month).numberOfDays
+}
+
+private fun handleWheelDateChange(
+    dayIndex: Int,
+    monthIndex: Int,
+    yearIndex: Int,
+    minYear: Int,
+    onMonthYearUpdate: (month: Int, year: Int) -> Unit,
+    onDateChange: (day: Int, month: Int, year: Int) -> Unit
+) {
+    val month = convertMonthIndexToValue(monthIndex)
+    val year = convertYearIndexToValue(yearIndex, minYear)
+
+    onMonthYearUpdate(month, year)
+
+    val daysInMonth = getDaysInMonth(month, year)
+    val day = convertDayIndexToValue(dayIndex).coerceIn(1, daysInMonth)
+
+    onDateChange(day, month, year)
+}

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileScreen.kt
@@ -54,11 +54,11 @@ import net.thechance.mena.designsystem.presentation.component.snackbar.SnackBar
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.identity.presentation.base.BaseScreen
-import net.thechance.mena.identity.presentation.components.WheelDatePicker
+import net.thechance.mena.identity.presentation.components.GregorianDatePicker
 import net.thechance.mena.identity.presentation.screen.editProfile.component.AtPrefixTransformation
+import net.thechance.mena.identity.presentation.screen.editProfile.component.EditProfileImage
 import net.thechance.mena.identity.presentation.screen.editProfile.component.GenderToggle
 import net.thechance.mena.identity.presentation.screen.editProfile.component.ProfileEditText
-import net.thechance.mena.identity.presentation.screen.editProfile.component.EditProfileImage
 import net.thechance.mena.identity.presentation.screen.editProfile.dialog.GetImageDialog
 import net.thechance.mena.identity.presentation.screen.imageCropper.ImageCropperScreen
 import net.thechance.mena.identity.presentation.util.rememberCameraPicker
@@ -97,7 +97,7 @@ class EditUserProfileScreen : BaseScreen<
         }
 
         val cameraImagePicker = rememberCameraPicker { imageBitmap ->
-                listener.onRequireCropImage(imageBitmap)
+            listener.onRequireCropImage(imageBitmap)
         }
 
         LaunchedEffect(state.showCamera) {
@@ -133,10 +133,10 @@ class EditUserProfileScreen : BaseScreen<
                 dialog(state.showEditImageDialog) {
                     GetImageDialog(
                         isVisible = it,
-                        onDismiss =  listener::onDismissEditImageDialog,
+                        onDismiss = listener::onDismissEditImageDialog,
                         onUploadImage = galleryPicker::launch,
                         onTakeImageFromCamera = listener::onTakeImageFromCamera,
-                        onRemoveImage =  listener::onRemoveProfileImage,
+                        onRemoveImage = listener::onRemoveProfileImage,
                     )
                 }
 
@@ -220,7 +220,7 @@ class EditUserProfileScreen : BaseScreen<
                     style = Theme.typography.title.small
                 )
 
-                WheelDatePicker(
+                GregorianDatePicker(
                     modifier = Modifier.padding(top = Theme.spacing._16),
                     selectedDate = state.birthDate,
                     onDateChange = listener::onChangeDate,

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreen.kt
@@ -17,11 +17,10 @@ import mena.identity_presentation.generated.resources.date_picker_screen_prompt_
 import mena.identity_presentation.generated.resources.next
 import net.thechance.mena.designsystem.presentation.component.button.PrimaryButton
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
-import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.identity.presentation.base.BaseScreen
 import net.thechance.mena.identity.presentation.components.AuthScreenContainer
+import net.thechance.mena.identity.presentation.components.GregorianDatePicker
 import net.thechance.mena.identity.presentation.components.PageDescription
-import net.thechance.mena.identity.presentation.components.WheelDatePicker
 import net.thechance.mena.identity.presentation.screen.register.selectGender.SelectGenderScreen
 import org.jetbrains.compose.resources.stringResource
 
@@ -54,7 +53,7 @@ class DatePickerScreen :
                         modifier = Modifier.weight(1f),
                         contentAlignment = Alignment.Center
                     ) {
-                        WheelDatePicker(
+                        GregorianDatePicker(
                             selectedDate = state.selectedDate,
                             onDateChange = listener::onChangeDate
                         )

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/util/DateUtils.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/util/DateUtils.kt
@@ -1,7 +1,6 @@
 package net.thechance.mena.identity.presentation.util
 
 import androidx.compose.runtime.Composable
-import kotlinx.datetime.YearMonth
 import mena.identity_presentation.generated.resources.Res
 import mena.identity_presentation.generated.resources.month_april
 import mena.identity_presentation.generated.resources.month_august
@@ -16,11 +15,6 @@ import mena.identity_presentation.generated.resources.month_november
 import mena.identity_presentation.generated.resources.month_october
 import mena.identity_presentation.generated.resources.month_september
 import org.jetbrains.compose.resources.stringResource
-
-
-fun getNumberOfDaysInMonth(year: Int, month: Int): Int {
-    return YearMonth(year, month).numberOfDays
-}
 
 @Composable
 fun getDefaultMonthNames(): List<String> {

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/util/DateUtils.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/util/DateUtils.kt
@@ -1,5 +1,6 @@
 package net.thechance.mena.identity.presentation.util
 
+import androidx.compose.runtime.Composable
 import kotlinx.datetime.YearMonth
 import mena.identity_presentation.generated.resources.Res
 import mena.identity_presentation.generated.resources.month_april
@@ -14,23 +15,27 @@ import mena.identity_presentation.generated.resources.month_may
 import mena.identity_presentation.generated.resources.month_november
 import mena.identity_presentation.generated.resources.month_october
 import mena.identity_presentation.generated.resources.month_september
-import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+
 
 fun getNumberOfDaysInMonth(year: Int, month: Int): Int {
     return YearMonth(year, month).numberOfDays
 }
 
-enum class AppMonth(val number: Int, val res: StringResource) {
-    January(1, Res.string.month_january),
-    February(2, Res.string.month_february),
-    March(3, Res.string.month_march),
-    April(4, Res.string.month_april),
-    May(5, Res.string.month_may),
-    June(6, Res.string.month_june),
-    July(7, Res.string.month_july),
-    August(8, Res.string.month_august),
-    September(9, Res.string.month_september),
-    October(10, Res.string.month_october),
-    November(11, Res.string.month_november),
-    December(12, Res.string.month_december)
+@Composable
+fun getDefaultMonthNames(): List<String> {
+    return listOf(
+        stringResource(Res.string.month_january),
+        stringResource(Res.string.month_february),
+        stringResource(Res.string.month_march),
+        stringResource(Res.string.month_april),
+        stringResource(Res.string.month_may),
+        stringResource(Res.string.month_june),
+        stringResource(Res.string.month_july),
+        stringResource(Res.string.month_august),
+        stringResource(Res.string.month_september),
+        stringResource(Res.string.month_october),
+        stringResource(Res.string.month_november),
+        stringResource(Res.string.month_december)
+    )
 }


### PR DESCRIPTION
## Changes
- **Moved `WheelDatePicker` to Design System**: Core wheel picker component is now in `design_system` module as a pure presentational component
- **Created `GregorianDatePicker` wrapper**: Calendar-specific logic moved to `identity_presentation` module
- **Made component "dumb"**: `WheelDatePicker` now accepts lists of strings and indices, making it calendar-agnostic
- **Fixed scrolling vibration**: Improved scroll performance by using `snapshotFlow` and `distinctUntilChanged` to debounce date changes
- Make it more reusable across different calendar systems (Gregorian, Hijri, etc.)

[Screen_recording_20251105_101554.webm](https://github.com/user-attachments/assets/26d8852a-081b-4b1b-8a72-42e2dc7f357b)
