### PR TITLE
FTH-125 Handle Search Result Selection and Map Centering

### DIFF
--- a/faith_presentation/src/commonMain/composeResources/drawable/ic_add.xml
+++ b/faith_presentation/src/commonMain/composeResources/drawable/ic_add.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M11.042,3.333C11.042,2.758 10.575,2.292 10,2.292C9.425,2.292 8.958,2.758 8.958,3.333V8.958H3.333C2.758,8.958 2.292,9.425 2.292,10C2.292,10.575 2.758,11.042 3.333,11.042H8.958V16.667C8.958,17.242 9.425,17.708 10,17.708C10.575,17.708 11.042,17.242 11.042,16.667V11.042H16.667C17.242,11.042 17.708,10.575 17.708,10C17.708,9.425 17.242,8.958 16.667,8.958H11.042V3.333Z"
+      android:fillColor="#000000"/>
+</vector>

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/NearbyMosquesInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/NearbyMosquesInteractionListener.kt
@@ -7,6 +7,9 @@ internal interface NearbyMosquesInteractionListener {
     fun onViewMosqueDetailsClick(mosque: MosqueUiState)
     fun onViewMosqueOnMapClick(coordinate: Coordinate)
     fun onSearchByCoordinatesClick(coordinate: Coordinate)
+    fun onSearchResultClick(mosque: MosqueUiState)
     fun mapPositionChanged(coordinate: Coordinate)
     fun onQueryChange(query: String)
+    fun changeSearchButtonVisibility(isVisible: Boolean)
+    fun onDismissSearchBottomSheet()
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/NearbyMosquesScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/NearbyMosquesScreen.kt
@@ -157,12 +157,10 @@ private fun Content(
                 )
                 if (uiState.isSearchButtonVisible) {
                     SearchMosquesButton(onClick = {
-                        listener.onBackClick()
-                        val target = cameraState.position.target
                         listener.onSearchByCoordinatesClick(
                             coordinate = Coordinate(
-                                latitude = target.latitude,
-                                longitude = target.longitude
+                                latitude = cameraState.position.target.latitude,
+                                longitude = cameraState.position.target.longitude
                             )
                         )
                     })

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/NearbyMosquesScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/NearbyMosquesScreen.kt
@@ -4,11 +4,15 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -20,16 +24,25 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.dellisd.spatialk.geojson.Position
+import kotlinx.coroutines.delay
 import mena.faith_presentation.generated.resources.Res
+import mena.faith_presentation.generated.resources.add
+import mena.faith_presentation.generated.resources.arrow_left
+import mena.faith_presentation.generated.resources.ic_add
 import mena.faith_presentation.generated.resources.ic_outline_search
+import mena.faith_presentation.generated.resources.nearby_mosques
 import mena.faith_presentation.generated.resources.no_nearby_mosques_found
 import mena.faith_presentation.generated.resources.search_area
 import mena.faith_presentation.generated.resources.search_hint
+import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
 import net.thechance.mena.designsystem.presentation.component.button.Button
+import net.thechance.mena.designsystem.presentation.component.icon.Icon
+import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.component.textField.TextField
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.faith.presentation.feature.mosque.component.NoMosquesFoundCard
+import net.thechance.mena.faith.presentation.feature.mosque.component.SearchResultsBottomSheet
 import net.thechance.mena.faith.presentation.utils.MapStyle
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -66,68 +79,108 @@ private fun Content(
         zoom = 14.0
     )
     val cameraState = rememberCameraState(firstPosition = initialCameraPosition)
-
     LaunchedEffect(cameraState) {
         snapshotFlow { cameraState.position }
             .collect {
-                listener.mapPositionChanged(
-                    coordinate = Coordinate(
-                        latitude = cameraState.position.target.latitude,
-                        longitude = cameraState.position.target.longitude
-                    )
-                )
-            }
-    }
-
-    Box(
-        modifier = Modifier.fillMaxSize()
-    ) {
-        MaplibreMap(
-            modifier = Modifier.fillMaxSize(),
-            cameraState = cameraState,
-            baseStyle = BaseStyle.Uri(MapStyle.BRIGHT),
-        )
-
-        if (uiState.isSearchButtonVisible) {
-            SearchMosquesButton(
-                onClick = {
-                    val target = cameraState.position.target
-                    listener.onSearchByCoordinatesClick(
+                if (!cameraState.isCameraMoving) {
+                    listener.mapPositionChanged(
                         coordinate = Coordinate(
-                            latitude = target.latitude,
-                            longitude = target.longitude
+                            latitude = cameraState.position.target.latitude,
+                            longitude = cameraState.position.target.longitude
                         )
                     )
+                }
+            }
+    }
+    LaunchedEffect(cameraState.isCameraMoving) {
+        listener.changeSearchButtonVisibility(!cameraState.isCameraMoving)
+        delay(500)
+        listener.changeSearchButtonVisibility(true)
+    }
+    LaunchedEffect(uiState.centerOfMap) {
+        cameraState.animateTo(initialCameraPosition)
+    }
+    Scaffold(
+        topBar = {
+            AppBar(
+                modifier = Modifier.background(Theme.colorScheme.background.surfaceLow),
+                title = stringResource(Res.string.nearby_mosques),
+                leadingContent = {
+                    Icon(
+                        painter = painterResource(Res.drawable.arrow_left),
+                        contentDescription = stringResource(Res.string.arrow_left)
+                    )
                 },
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .padding(top = Theme.spacing._32)
+                trailingContent = {
+                    Icon(
+                        modifier = Modifier.size(20.dp),
+                        painter = painterResource(Res.drawable.ic_add),
+                        contentDescription = stringResource(Res.string.add)
+                    )
+                },
+                onLeadingClick = listener::onBackClick
             )
+        },
+        overlays = {
+            bottomSheet(isVisible = uiState.isSearchResultsBottomSheetVisible) { isVisible ->
+                SearchResultsBottomSheet(
+                    isVisible = isVisible,
+                    mosques = uiState.mosquesSearchResults,
+                    onMosqueClick = listener::onSearchResultClick,
+                    onDismiss = listener::onDismissSearchBottomSheet
+                )
+            }
         }
-        TextField(
-            value = uiState.query,
-            hint = stringResource(Res.string.search_hint),
-            leadingIcon = painterResource(Res.drawable.ic_outline_search),
-            leadingIconTint = Theme.colorScheme.shadeSecondary,
-            onValueChanged = listener::onQueryChange,
-            modifier = Modifier
-                .align(Alignment.TopCenter)
-                .padding(horizontal = Theme.spacing._16)
-                .fillMaxWidth()
-        )
-
-        AnimatedVisibility(
-            visible = uiState.isNoMosquesCardVisible,
-            enter = fadeIn(tween()),
-            exit = fadeOut(tween()),
-            modifier = Modifier.align(Alignment.BottomCenter)
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize()
         ) {
-            NoMosquesFoundCard(
-                message = stringResource(Res.string.no_nearby_mosques_found),
-                modifier = Modifier
-                    .padding(horizontal = Theme.spacing._12)
-                    .padding(bottom = Theme.spacing._24)
+            MaplibreMap(
+                modifier = Modifier.fillMaxSize(),
+                cameraState = cameraState,
+                baseStyle = BaseStyle.Uri(MapStyle.BRIGHT),
             )
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = Theme.spacing._12, vertical = 10.dp)
+                    .align(Alignment.TopCenter),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                TextField(
+                    value = uiState.query,
+                    hint = stringResource(Res.string.search_hint),
+                    leadingIcon = painterResource(Res.drawable.ic_outline_search),
+                    leadingIconTint = Theme.colorScheme.shadeSecondary,
+                    onValueChanged = listener::onQueryChange,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                if (uiState.isSearchButtonVisible) {
+                    SearchMosquesButton(onClick = {
+                        listener.onBackClick()
+                        val target = cameraState.position.target
+                        listener.onSearchByCoordinatesClick(
+                            coordinate = Coordinate(
+                                latitude = target.latitude,
+                                longitude = target.longitude
+                            )
+                        )
+                    })
+                }
+            }
+            AnimatedVisibility(
+                visible = uiState.isNoMosquesCardVisible,
+                enter = fadeIn(tween()),
+                exit = fadeOut(tween()),
+                modifier = Modifier.align(Alignment.BottomCenter)
+            ) {
+                NoMosquesFoundCard(
+                    message = stringResource(Res.string.no_nearby_mosques_found),
+                    modifier = Modifier
+                        .padding(horizontal = Theme.spacing._12)
+                        .padding(bottom = Theme.spacing._24)
+                )
+            }
         }
     }
 }
@@ -164,8 +217,11 @@ private fun NearbyMosquesScreenPreview() {
             override fun onViewMosqueDetailsClick(mosque: MosqueUiState) {}
             override fun onViewMosqueOnMapClick(coordinate: Coordinate) {}
             override fun onSearchByCoordinatesClick(coordinate: Coordinate) {}
+            override fun onSearchResultClick(mosque: MosqueUiState) {}
             override fun mapPositionChanged(coordinate: Coordinate) {}
             override fun onQueryChange(query: String) {}
+            override fun changeSearchButtonVisibility(isVisible: Boolean) {}
+            override fun onDismissSearchBottomSheet() {}
         }
     )
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/NearbyMosquesViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/NearbyMosquesViewModel.kt
@@ -19,7 +19,6 @@ internal class NearbyMosquesViewModel(
         initialState = NearbyMosquesMapUiState(),
     ), NearbyMosquesInteractionListener {
 
-    private var searchButtonInactivityJob: Job? = null
     private var searchJob: Job? = null
 
     override fun onBackClick() {
@@ -46,9 +45,17 @@ internal class NearbyMosquesViewModel(
 //        TODO("Not yet implemented")
     }
 
+    override fun onSearchResultClick(mosque: MosqueUiState) {
+        updateState {
+            it.copy(
+                isSearchResultsBottomSheetVisible = false,
+                centerOfMap = mosque.coordinate
+            )
+        }
+    }
+
     override fun mapPositionChanged(coordinate: Coordinate) {
-        updateCenterOfMap(coordinate = coordinate)
-        handleSearchButtonVisibilityOnInteraction()
+        updateState { it.copy(centerOfMap = coordinate) }
     }
 
     override fun onQueryChange(query: String) {
@@ -64,6 +71,14 @@ internal class NearbyMosquesViewModel(
         } else {
             performSearch(query)
         }
+    }
+
+    override fun changeSearchButtonVisibility(isVisible: Boolean) {
+        updateState { it.copy(isSearchButtonVisible = isVisible) }
+    }
+
+    override fun onDismissSearchBottomSheet() {
+        updateState { it.copy(isSearchResultsBottomSheetVisible = false) }
     }
 
     private fun performSearch(query: String) {
@@ -104,21 +119,6 @@ internal class NearbyMosquesViewModel(
 
     private fun handleSearchError() {
         // TODO: show snack bar with error message (Res.string.no_mosques_found) to the user
-    }
-
-    private fun handleSearchButtonVisibilityOnInteraction() {
-        updateState { it.copy(isSearchButtonVisible = false) }
-        searchButtonInactivityJob?.cancel()
-        searchButtonInactivityJob = viewModelScope.launch {
-            delay(500)
-            updateState { it.copy(isSearchButtonVisible = true) }
-        }
-    }
-
-    private fun updateCenterOfMap(coordinate: Coordinate) {
-        updateState {
-            it.copy(centerOfMap = coordinate)
-        }
     }
 
     private companion object {


### PR DESCRIPTION
- Implement a bottom sheet to display search results.
- Add `onSearchResultClick` to center the map on the selected mosque.
- Introduce `AppBar` with back and add-new-mosque icons.
- Refactor search button visibility logic to be controlled by camera movement state.
- Add `onDismissSearchBottomSheet` to handle closing the results sheet.

![Adobe Express - Recording 2025-11-05 144859](https://github.com/user-attachments/assets/3185b850-2fa2-449a-9fca-d052ccc794ff)
