### PR TITLE
remove key from lazy row to prevent app crash

### DIFF
--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/AddToCartSection.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/AddToCartSection.kt
@@ -58,7 +58,7 @@ fun AddToCartSection(
             iconPadding = PaddingValues(Theme.spacing._8 + Theme.spacing._2)
         )
         Button(
-            modifier = Modifier
+            modifier = Modifier.height(48.dp)
                 .fillMaxWidth(),
             onClick = onAddToCartClick,
             isEnabled = true,

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/ProductDetailsImagesSection.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/ProductDetailsImagesSection.kt
@@ -161,7 +161,7 @@ fun ProductDetailsSecondaryImages(
         verticalAlignment = Alignment.CenterVertically,
         contentPadding = PaddingValues(horizontal = Theme.spacing._4)
     ) {
-        items(items = images, key = { it }) { imageUrl ->
+        items(items = images) { imageUrl ->
             ProductDetailsSecondaryImageItem(
                 imageUrl = imageUrl,
                 isSelected = (imageUrl == selectedImageUrl),


### PR DESCRIPTION
# What have been done 
- Fix app crash on entering product details because of duplicated image urls 