### PR TITLE
Fix/IDN-117 fix dialog shape to be squircle

### DIFF
--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/dialog/BasicDialog.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/dialog/BasicDialog.kt
@@ -39,6 +39,7 @@ import net.thechance.mena.designsystem.presentation.component.scaffold.ScaffoldS
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import sv.lib.squircleshape.SquircleShape
 
 @Composable
 fun ScaffoldScope.BasicDialog(
@@ -50,7 +51,7 @@ fun ScaffoldScope.BasicDialog(
     dismissOnClickOutside: Boolean = true,
     contentColor: Color = Theme.colorScheme.background.surfaceLow,
     scrimColor: Color = Theme.colorScheme.primary.primary.copy(0.55f),
-    dialogCornerShape: Shape = RoundedCornerShape(Theme.radius.xl),
+    dialogCornerShape: Shape = SquircleShape(Theme.radius.xl),
     cancelBackgroundShape: Shape = RoundedCornerShape(Theme.radius.full),
     contentPadding: PaddingValues = PaddingValues(12.dp),
     onCancelClick: () -> Unit = {},

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/dialog/Dialog.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/dialog/Dialog.kt
@@ -27,6 +27,7 @@ import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import sv.lib.squircleshape.SquircleShape
 
 @Deprecated("Use new Dialog instead")
 @Composable
@@ -114,7 +115,7 @@ fun ScaffoldScope.Dialog(
     onCancelClick: () -> Unit = {},
     contentColor: Color = Theme.colorScheme.background.surfaceLow,
     scrimColor: Color = Theme.colorScheme.primary.primary.copy(0.55f),
-    dialogCornerShape: Shape = RoundedCornerShape(Theme.radius.xl),
+    dialogCornerShape: Shape = SquircleShape(Theme.radius.xl),
     cancelBackgroundShape: Shape = RoundedCornerShape(Theme.radius.full),
     contentPadding: PaddingValues = PaddingValues(12.dp),
 ) {


### PR DESCRIPTION
Changed dialog default shape to be squircle same as design


<table>
  <tr>
    <th>
Before
    </th>
    <th>
After
    </th>
    </tr>
  <tr>
    <td>
<img width="1080" height="2280" alt="Screenshot_20251105_233837" src="https://github.com/user-attachments/assets/e9e16171-4dfb-4c80-8391-23389d2bb31e" />
    </td>
    <td>
<img width="1080" height="2280" alt="Screenshot_20251105_233900" src="https://github.com/user-attachments/assets/fd6af78e-2aaa-49a8-bfda-f80c6a2ddac9" />
    </td>
  </tr>
  <tr>
</table>
