### PR TITLE
Fix/IDN-117 fix buttons height, shape and ripple

### DIFF
--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/appBar/AppBarOptionContainer.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/appBar/AppBarOptionContainer.kt
@@ -3,6 +3,7 @@ package net.thechance.mena.designsystem.presentation.component.appBar
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,7 +12,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -38,7 +41,11 @@ fun AppBarOptionContainer(
     content: @Composable () -> Unit,
 ) {
     val clickableModifier = onClick?.let {
-        Modifier.clickable(onClick = it)
+        Modifier.clickable(
+            onClick = it,
+            interactionSource = remember { MutableInteractionSource() },
+            indication = ripple(),
+        )
     } ?: Modifier
 
     Box(

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/button/Button.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/button/Button.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -15,8 +16,10 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -60,7 +63,11 @@ fun Button(
             )
             .clip(shape)
             .then(
-                if (isEnabled && !isLoading) Modifier.clickable(onClick = onClick)
+                if (isEnabled && !isLoading) Modifier.clickable(
+                    onClick = onClick,
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = ripple(),
+                )
                 else Modifier
             )
             .background(color = buttonBackgroundColor)

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/button/FabButton.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/button/FabButton.kt
@@ -2,7 +2,6 @@ package net.thechance.mena.designsystem.presentation.component.button
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -12,6 +11,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import sv.lib.squircleshape.SquircleShape
 
 @Composable
 fun FabButton(
@@ -23,7 +23,7 @@ fun FabButton(
     containerColor: Color = Theme.colorScheme.primary.primary,
     contentColor: Color = Theme.colorScheme.primary.onPrimary,
     contentPadding: PaddingValues = PaddingValues(16.dp),
-    shape: Shape = RoundedCornerShape(Theme.radius.md)
+    shape: Shape = SquircleShape(Theme.radius.md)
 ) {
     Button(
         onClick = onClick,

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/button/NegativeButton.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/button/NegativeButton.kt
@@ -1,7 +1,7 @@
 package net.thechance.mena.designsystem.presentation.component.button
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import net.thechance.mena.designsystem.presentation.component.button.content.BaseButtonContent
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import sv.lib.squircleshape.SquircleShape
 
 @Composable
 fun NegativeButton(
@@ -31,7 +32,7 @@ fun NegativeButton(
         horizontal = Theme.spacing._16,
         vertical = Theme.spacing._8
     ),
-    shape: Shape = RoundedCornerShape(Theme.radius.md)
+    shape: Shape = SquircleShape(Theme.radius.md)
 ) {
     Button(
         isEnabled = isEnabled,
@@ -48,7 +49,7 @@ fun NegativeButton(
             Theme.colorScheme.primary.onPrimaryBody,
             Theme.colorScheme.primary.onPrimary
         ),
-        modifier = modifier
+        modifier = modifier.height(48.dp)
     ) {
         BaseButtonContent(
             text = text,

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/button/OutlinedButton.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/button/OutlinedButton.kt
@@ -2,7 +2,7 @@ package net.thechance.mena.designsystem.presentation.component.button
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import net.thechance.mena.designsystem.presentation.component.button.content.BaseButtonContent
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import sv.lib.squircleshape.SquircleShape
 
 @Composable
 fun OutlinedButton(
@@ -30,7 +31,7 @@ fun OutlinedButton(
         horizontal = Theme.spacing._16,
         vertical = Theme.spacing._8
     ),
-    shape: Shape = RoundedCornerShape(Theme.radius.md)
+    shape: Shape = SquircleShape(Theme.radius.md)
 ) {
     Button(
         isEnabled = isEnabled,
@@ -48,7 +49,7 @@ fun OutlinedButton(
             Theme.colorScheme.shadeTertiary,
             Theme.colorScheme.primary.primary
         ),
-        modifier = modifier
+        modifier = modifier.height(48.dp)
     ) {
         BaseButtonContent(
             text = text,

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/button/PrimaryButton.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/button/PrimaryButton.kt
@@ -1,7 +1,7 @@
 package net.thechance.mena.designsystem.presentation.component.button
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import net.thechance.mena.designsystem.presentation.component.button.content.BaseButtonContent
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import sv.lib.squircleshape.SquircleShape
 
 @Composable
 fun PrimaryButton(
@@ -30,7 +31,7 @@ fun PrimaryButton(
         horizontal = Theme.spacing._16,
         vertical = Theme.spacing._8
     ),
-    shape: Shape = RoundedCornerShape(Theme.radius.md)
+    shape: Shape = SquircleShape(Theme.radius.md)
 ) {
     Button(
         isEnabled = isEnabled,
@@ -47,7 +48,7 @@ fun PrimaryButton(
             Theme.colorScheme.primary.onPrimary
         ),
         onClick = onClick,
-        modifier = modifier
+        modifier = modifier.height(48.dp)
     ) {
         BaseButtonContent(
             text = text,


### PR DESCRIPTION
- Fixed some buttons height to be 48.dp to match design
- Added ripple to buttons
- Cahnged some buttons shapes to squircle

Affected buttons + back button of the app bar:

<img width="875" height="295" alt="Screenshot 2025-11-06 at 00 13 38" src="https://github.com/user-attachments/assets/ba29b42e-ed18-4601-8a21-ee0f3b7223a8" />
