### PR TITLE
Fix/WLT-121 general ui issues

### DIFF
--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/component/ErrorView.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/component/ErrorView.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.dp
 import mena.wallet_presentation.generated.resources.Res
 import mena.wallet_presentation.generated.resources.img_no_internet
+import mena.wallet_presentation.generated.resources.no_internet_content
+import mena.wallet_presentation.generated.resources.no_internet_title
 import mena.wallet_presentation.generated.resources.retry
 import mena.wallet_presentation.generated.resources.unknown_error_description
 import mena.wallet_presentation.generated.resources.unknown_error_title
@@ -25,9 +27,9 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 internal fun ErrorView(
-    image: Painter = painterResource(Res.drawable.img_no_internet),
-    title: String = stringResource(Res.string.unknown_error_title),
-    description: String = stringResource(Res.string.unknown_error_description),
+    image: Painter,
+    title: String,
+    description: String,
     onRetry: () -> Unit,
 ) {
     Column(
@@ -61,6 +63,11 @@ internal fun ErrorView(
 @Composable
 private fun NoInternetScreenPreview() {
     MenaTheme {
-        ErrorView(onRetry = {})
+        ErrorView(
+            image = painterResource(Res.drawable.img_no_internet),
+            title = stringResource(Res.string.no_internet_title),
+            description = stringResource(Res.string.no_internet_content),
+            onRetry = {}
+        )
     }
 }

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/confirm_payment/ConfirmPaymentScreen.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/confirm_payment/ConfirmPaymentScreen.kt
@@ -21,7 +21,6 @@ import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
-import net.thechance.mena.wallet.presentation.component.ErrorView
 import net.thechance.mena.wallet.presentation.component.WalletScaffold
 import net.thechance.mena.wallet.presentation.navigation.LocalNavController
 import net.thechance.mena.wallet.presentation.navigation.PaymentResultScreenRoute
@@ -81,34 +80,28 @@ private fun ConfirmPaymentScreenContent(
         errorState = state.errorState,
         onRetry = { interactionListener.onRefresh() }
     ) {
-        when {
-            state.errorState != null -> ErrorView(onRetry = { interactionListener.onRefresh() })
 
-            else -> {
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = 16.dp)
-                        .padding(bottom = 24.dp)
-                ) {
-                    PaymentDetailsSection(
-                        modifier = Modifier.fillMaxWidth().weight(1f),
-                        userMessage = state.userMessage,
-                        payment = state.paymentUiState,
-                        receiver = state.receiverUiState
-                    )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 24.dp)
+        ) {
+            PaymentDetailsSection(
+                modifier = Modifier.fillMaxWidth().weight(1f),
+                userMessage = state.userMessage,
+                payment = state.paymentUiState,
+                receiver = state.receiverUiState
+            )
 
-                    PayButton(
-                        isLoading = state.isPayButtonLoading,
-                        isEnabled = state.paymentUiState.status,
-                        onClick = interactionListener::onPayButtonClicked,
-                        payAmount = state.paymentUiState.amount
-                    )
-                }
-            }
+            PayButton(
+                isLoading = state.isPayButtonLoading,
+                isEnabled = state.paymentUiState.status,
+                onClick = interactionListener::onPayButtonClicked,
+                payAmount = state.paymentUiState.amount
+            )
         }
     }
-
 }
 
 private fun onConfirmPaymentEffect(
@@ -117,7 +110,9 @@ private fun onConfirmPaymentEffect(
     navigateBack: () -> Unit,
 ) {
     when (effect) {
-        ConfirmPaymentEffect.NavigateBack -> { navigateBack() }
+        ConfirmPaymentEffect.NavigateBack -> {
+            navigateBack()
+        }
 
         is ConfirmPaymentEffect.NavigateToPaymentResultScreen -> {
             navController.navigate(

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsViewModel.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsViewModel.kt
@@ -13,11 +13,11 @@ import mena.wallet_presentation.generated.resources.Res
 import mena.wallet_presentation.generated.resources.download_complete
 import mena.wallet_presentation.generated.resources.download_failed
 import mena.wallet_presentation.generated.resources.download_success
-import mena.wallet_presentation.generated.resources.downloading_started
 import mena.wallet_presentation.generated.resources.error
 import mena.wallet_presentation.generated.resources.error_failed_view
 import mena.wallet_presentation.generated.resources.error_no_transactions
 import mena.wallet_presentation.generated.resources.failed_to_load_date_picker
+import mena.wallet_presentation.generated.resources.no_internet_content
 import mena.wallet_presentation.generated.resources.no_internet_title
 import mena.wallet_presentation.generated.resources.something_went_wrong
 import mena.wallet_presentation.generated.resources.start_date_must_be_before_end_date
@@ -297,7 +297,6 @@ class ExportTransactionsViewModel(
         updateState { oldState ->
             oldState.copy(isDownloadLoading = true, isViewAndShareButtonEnabled = false)
         }
-        showToast(messageRes = Res.string.downloading_started)
     }
 
     @OptIn(ExperimentalTime::class)
@@ -405,8 +404,8 @@ class ExportTransactionsViewModel(
                     )
                 }
                 showSnackBar(
-                    title = stringProvider.getString(Res.string.download_failed),
-                    message = stringProvider.getString(Res.string.no_internet_title),
+                    title = stringProvider.getString(Res.string.no_internet_title),
+                    message = stringProvider.getString(Res.string.no_internet_content),
                     isSuccess = false
                 )
             }

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/statement_details/StatementDetailsScreen.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/statement_details/StatementDetailsScreen.kt
@@ -23,7 +23,6 @@ import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
 import net.thechance.mena.designsystem.presentation.component.button.PrimaryButton
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
-import net.thechance.mena.wallet.presentation.component.ErrorView
 import net.thechance.mena.wallet.presentation.component.WalletScaffold
 import net.thechance.mena.wallet.presentation.navigation.LocalNavController
 import net.thechance.mena.wallet.presentation.screen.statement_details.components.PdfViewer
@@ -92,40 +91,23 @@ private fun StatementDetailsContent(
         isLoading = state.isLoading,
         bottomContent = {
             if (state.statement.isNotEmpty()) {
-                if (!state.statement.isNotEmpty()) {
-                    PrimaryButton(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp)
-                            .padding(bottom = 24.dp)
-                            .height(48.dp),
-                        text = stringResource(Res.string.share_button_title),
-                        onClick = listener::onShareClicked,
-                        trailingIcon = painterResource(Res.drawable.ic_share_),
-                        iconSize = 20.dp,
-                        isLoading = false,
-                    )
-                }
+                PrimaryButton(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                        .padding(bottom = 24.dp)
+                        .height(48.dp),
+                    text = stringResource(Res.string.share_button_title),
+                    onClick = listener::onShareClicked,
+                    trailingIcon = painterResource(Res.drawable.ic_share_),
+                    iconSize = 20.dp,
+                    isLoading = false,
+                )
             }
         },
+        errorState = state.errorState
     ) {
-        StatementViewer(state = state, onRetry = { listener.onRetryClicked() })
-    }
-}
-
-@Composable
-private fun StatementViewer(
-    state: StatementDetailsScreenState,
-    onRetry: () -> Unit
-) {
-    when {
-        state.errorState != null -> {
-            ErrorView(onRetry = onRetry)
-        }
-
-        else -> {
-            PdfViewer(pdf = state.statement)
-        }
+        PdfViewer(pdf = state.statement)
     }
 }
 

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_details/TransactionDetailsScreen.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_details/TransactionDetailsScreen.kt
@@ -1,12 +1,9 @@
 package net.thechance.mena.wallet.presentation.screen.transaction_details
 
-import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
@@ -21,7 +18,6 @@ import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
-import net.thechance.mena.wallet.presentation.component.ErrorView
 import net.thechance.mena.wallet.presentation.component.SnackBarContainer
 import net.thechance.mena.wallet.presentation.component.WalletScaffold
 import net.thechance.mena.wallet.presentation.navigation.LocalNavController
@@ -94,22 +90,12 @@ private fun TransactionDetailsScreenContent(
         isLoading = state.isLoading,
         onRetry = { interactionListener.onRefresh() }
     ) {
-        Crossfade(
-            targetState = state,
-            modifier = Modifier.fillMaxSize()
-        ) {
-            when {
-                state.errorState != null -> ErrorView(onRetry = { interactionListener.onRefresh() })
 
-                else -> {
-                    TransactionDetailsSuccessContent(
-                        state = state,
-                        interactionListener = interactionListener,
-                        captureController = captureController
-                    )
-                }
-            }
-        }
+        TransactionDetailsSuccessContent(
+            state = state,
+            interactionListener = interactionListener,
+            captureController = captureController
+        )
     }
 }
 

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_history/TransactionHistoryScreen.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_history/TransactionHistoryScreen.kt
@@ -26,7 +26,6 @@ import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.wallet.presentation.component.DatePickerBottomSheet
-import net.thechance.mena.wallet.presentation.component.ErrorView
 import net.thechance.mena.wallet.presentation.component.SnackBarContainer
 import net.thechance.mena.wallet.presentation.component.WalletScaffold
 import net.thechance.mena.wallet.presentation.model.FilterStatus

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/wallet/WalletScreen.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/wallet/WalletScreen.kt
@@ -96,7 +96,7 @@ private fun WalletContent(
             modifier = Modifier
                 .fillMaxHeight()
                 .padding(horizontal = 16.dp)
-                .padding(top = 16.dp)
+                .padding(vertical = 16.dp)
                 .verticalScroll(rememberScrollState())
         ) {
             BalanceCard(

--- a/wallet_presentation/src/commonTest/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsViewModelTest.kt
+++ b/wallet_presentation/src/commonTest/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsViewModelTest.kt
@@ -104,27 +104,6 @@ class ExportTransactionsViewModelTest {
     }
 
     @Test
-    fun `onDownloadClicked with empty pdf should show toast`() = runTest {
-        everySuspend { repository.getStatementWithMetadata(any()) } returns createMockStatementWithMetadata(
-            byteArray = byteArrayOf()
-        )
-
-
-        initViewModel()
-
-        viewModel.state.test {
-            viewModel.onDownloadClicked()
-            skipItems(2)
-
-            val toastState = awaitItem().toast
-            assertToastState(isVisible = true, toastState = toastState)
-
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-
-    @Test
     fun `should toggle type in state when onTypeSelected is called`() = runTest {
         initViewModel()
         val type = FilterType.SENT
@@ -261,7 +240,7 @@ class ExportTransactionsViewModelTest {
 
         viewModel.state.test {
             viewModel.onDownloadClicked()
-            skipItems(5)
+            skipItems(3)
             val state = awaitItem()
 
             assertSnackBarState(
@@ -283,7 +262,7 @@ class ExportTransactionsViewModelTest {
 
         viewModel.state.test {
             viewModel.onDownloadClicked()
-            skipItems(5)
+            skipItems(3)
 
             val state = awaitItem()
 
@@ -310,7 +289,7 @@ class ExportTransactionsViewModelTest {
         viewModel.state.test {
             viewModel.onDownloadClicked()
             advanceUntilIdle()
-            skipItems(5)
+            skipItems(3)
 
             val state = awaitItem()
             assertSnackBarState(true, state.snackBar)
@@ -334,30 +313,11 @@ class ExportTransactionsViewModelTest {
         viewModel.state.test {
             viewModel.onDownloadClicked()
             advanceUntilIdle()
-            skipItems(5)
+            skipItems(3)
 
             val state = awaitItem()
             assertSnackBarState(true, state.snackBar)
             assertFalse(state.snackBar.isSuccess)
-
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `toast should disappear after duration`() = runTest {
-        initViewModel()
-
-        viewModel.state.test {
-            viewModel.onDownloadClicked()
-            skipItems(2)
-
-            val toastVisible = awaitItem().toast
-            assertToastState(true, toastVisible)
-
-            advanceTimeBy(2000L)
-            val toastHidden = awaitItem().toast
-            assertToastState(false, toastHidden)
 
             cancelAndIgnoreRemainingEvents()
         }
@@ -503,7 +463,7 @@ class ExportTransactionsViewModelTest {
         initViewModel()
         viewModel.state.test {
             viewModel.onDownloadClicked()
-            skipItems(4)
+            skipItems(2)
 
             val state = awaitItem()
             assertFalse(state.isDownloadLoading)
@@ -537,25 +497,6 @@ class ExportTransactionsViewModelTest {
             assertTrue(state.isDownloadButtonEnabled)
             assertTrue(state.isViewAndShareButtonEnabled)
             assertFalse(state.isCustomFilterCardSelected)
-
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `hideToast should hide toast`() = runTest {
-        initViewModel()
-        viewModel.state.test {
-            viewModel.onDownloadClicked()
-            skipItems(2)
-
-            val toastVisible = awaitItem().toast
-            assertTrue(toastVisible.isVisible)
-
-            advanceTimeBy(2000L)
-
-            val toastHidden = awaitItem().toast
-            assertFalse(toastHidden.isVisible)
 
             cancelAndIgnoreRemainingEvents()
         }


### PR DESCRIPTION
- Removed explicit ErrorView handling from screens since scaffold already handles this.
- Added bottom padding in Wallet main screen for vertical scroll
- Removed `downloading started` toast
- Fixed `share statement` button not showing in statement details screen