### PR TITLE
Add microphone permission to iOS

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -16,6 +16,8 @@
     <string>We need access to your camera.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>We need access to your photo library.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>We need access to your microphone to record audio messages.</string>
     <key>UIFileSharingEnabled</key>
     <true/>
     <key>LSSupportsOpeningDocumentsInPlace</key>


### PR DESCRIPTION
What has been done
Add the needed permission to run the chat feature on iOS 
- microphone permission
