### PR TITLE
Feature/fth 114 implement calculate distance use case

### DIFF
--- a/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/exception/FaithException.kt
+++ b/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/exception/FaithException.kt
@@ -10,5 +10,6 @@ sealed class FaithException : Throwable() {
     data object FailedToDownloadSurahException : FaithException()
     data object UrlCreationException : FaithException()
     data object FileCreationException : FaithException()
+    data object InvalidCoordinates: FaithException()
 }
 

--- a/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/usecase/CalculateDistanceUseCase.kt
+++ b/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/usecase/CalculateDistanceUseCase.kt
@@ -1,0 +1,44 @@
+package net.thechance.mena.faith.domain.usecase
+
+
+import net.thechance.mena.faith.domain.exception.FaithException
+import kotlin.math.*
+
+
+class CalculateDistanceUseCase {
+
+    operator fun invoke(
+        latitude1: Double,
+        longitude1: Double,
+        latitude2: Double,
+        longitude2: Double
+    ): Double {
+
+        if (latitude1 == latitude2 && longitude1 == longitude2) return 0.0
+
+        if (!isValidCoordinate(latitude1, longitude1) || !isValidCoordinate(latitude2, longitude2)) {
+            throw FaithException.InvalidCoordinates
+        }
+
+        val earthRadiusKm = 6371.0
+
+        val dLat = toRadians(latitude2 - latitude1)
+        val dLon = toRadians(longitude2 - longitude1)
+
+        val haversineComponent = sin(dLat / 2).pow(2.0) +
+                cos(toRadians(latitude1)) *
+                cos(toRadians(latitude2)) *
+                sin(dLon / 2).pow(2.0)
+
+        val centralAngle = 2 * atan2(sqrt(haversineComponent), sqrt(1 - haversineComponent))
+
+        return (earthRadiusKm * centralAngle).coerceAtLeast(0.0)
+    }
+
+    private fun toRadians(degrees: Double): Double = degrees * (PI / 180)
+
+    private fun isValidCoordinate(lat: Double, lon: Double): Boolean {
+        return lat in -90.0..90.0 && lon in -180.0..180.0
+    }
+}
+

--- a/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/usecase/CalculateDistanceUseCase.kt
+++ b/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/usecase/CalculateDistanceUseCase.kt
@@ -1,6 +1,7 @@
 package net.thechance.mena.faith.domain.usecase
 
 
+import net.thechance.mena.faith.domain.entity.Location
 import net.thechance.mena.faith.domain.exception.FaithException
 import kotlin.math.*
 
@@ -8,31 +9,30 @@ import kotlin.math.*
 class CalculateDistanceUseCase {
 
     operator fun invoke(
-        latitude1: Double,
-        longitude1: Double,
-        latitude2: Double,
-        longitude2: Double
+        location1: Location,
+        location2: Location,
+
     ): Double {
 
-        if (latitude1 == latitude2 && longitude1 == longitude2) return 0.0
+        if (location1.latitude == location2.latitude && location1.longitude == location2.longitude) return 0.0
 
-        if (!isValidCoordinate(latitude1, longitude1) || !isValidCoordinate(latitude2, longitude2)) {
+        if (!isValidCoordinate(location1.latitude, location1.longitude) || !isValidCoordinate(location2.latitude, location2.longitude)) {
             throw FaithException.InvalidCoordinates
         }
 
         val earthRadiusKm = 6371.0
 
-        val dLat = toRadians(latitude2 - latitude1)
-        val dLon = toRadians(longitude2 - longitude1)
+        val dLat = toRadians(degrees = location2.latitude - location1.latitude)
+        val dLon = toRadians(degrees = location2.longitude - location1.longitude)
 
         val haversineComponent = sin(dLat / 2).pow(2.0) +
-                cos(toRadians(latitude1)) *
-                cos(toRadians(latitude2)) *
-                sin(dLon / 2).pow(2.0)
+                cos(x = toRadians(degrees = location1.latitude)) *
+                cos(x = toRadians(degrees = location2.latitude)) *
+                sin(x = dLon / 2).pow(x = 2.0)
 
-        val centralAngle = 2 * atan2(sqrt(haversineComponent), sqrt(1 - haversineComponent))
+        val centralAngle = 2 * atan2(sqrt(x = haversineComponent), x = sqrt(1 - haversineComponent))
 
-        return (earthRadiusKm * centralAngle).coerceAtLeast(0.0)
+        return (earthRadiusKm * centralAngle).coerceAtLeast(minimumValue = 0.0)
     }
 
     private fun toRadians(degrees: Double): Double = degrees * (PI / 180)

--- a/faith_domain/src/jvmTest/kotlin/net/thechance/mena/faith/domain/usecase/CalculateDistanceUseCaseTest.kt
+++ b/faith_domain/src/jvmTest/kotlin/net/thechance/mena/faith/domain/usecase/CalculateDistanceUseCaseTest.kt
@@ -1,5 +1,6 @@
 package net.thechance.mena.faith.domain.usecase
 
+import net.thechance.mena.faith.domain.entity.Location
 import net.thechance.mena.faith.domain.exception.FaithException
 import org.junit.Test
 
@@ -12,10 +13,8 @@ class CalculateDistanceUseCaseTest {
     @Test
     fun `invoke should return zero when coordinates are identical`() {
         val result = useCase(
-            latitude1 = 21.4225,
-            longitude1 = 39.8262,
-            latitude2 = 21.4225,
-            longitude2 = 39.8262
+            location1 = Location(latitude = 21.4225, longitude = 39.8262),
+            location2 = Location(latitude = 21.4225, longitude = 39.8262),
         )
         assertEquals(0.0, result)
     }
@@ -24,10 +23,8 @@ class CalculateDistanceUseCaseTest {
     fun `invoke should throw InvalidCoordinates when first coordinate latitude is invalid`() {
         assertFailsWith<FaithException.InvalidCoordinates> {
             useCase(
-                latitude1 = 91.0,
-                longitude1 = 0.0,
-                latitude2 = 0.0,
-                longitude2 = 0.0
+                location1 = Location(latitude = 91.0, longitude = 0.0),
+                location2 = Location(latitude = 0.0, longitude = 0.0),
             )
         }
     }
@@ -36,10 +33,8 @@ class CalculateDistanceUseCaseTest {
     fun `invoke should throw InvalidCoordinates when first coordinate longitude is invalid`() {
         assertFailsWith<FaithException.InvalidCoordinates> {
             useCase(
-                latitude1 = 0.0,
-                longitude1 = 200.0,
-                latitude2 = 0.0,
-                longitude2 = 0.0
+                location1 = Location(latitude = 0.0, longitude = 200.0),
+                location2 = Location(latitude = 0.0, longitude = 0.0)
             )
         }
     }
@@ -48,10 +43,8 @@ class CalculateDistanceUseCaseTest {
     fun `invoke should throw InvalidCoordinates when second coordinate latitude is invalid`() {
         assertFailsWith<FaithException.InvalidCoordinates> {
             useCase(
-                latitude1 = 0.0,
-                longitude1 = 0.0,
-                latitude2 = -100.0,
-                longitude2 = 0.0
+                location1 = Location(latitude = 0.0, longitude = 0.0),
+                location2 = Location(latitude = -100.0, longitude = 0.0)
             )
         }
     }
@@ -60,10 +53,8 @@ class CalculateDistanceUseCaseTest {
     fun `invoke should throw InvalidCoordinates when second coordinate longitude is invalid`() {
         assertFailsWith<FaithException.InvalidCoordinates> {
             useCase(
-                latitude1 = 0.0,
-                longitude1 = 0.0,
-                latitude2 = 0.0,
-                longitude2 = -200.0
+                location1 = Location(latitude = 0.0, longitude = 0.0),
+                location2 = Location(latitude = 0.0, longitude = 200.0)
             )
         }
     }
@@ -75,9 +66,11 @@ class CalculateDistanceUseCaseTest {
         val meccaLon = 39.8579
         val medinaLat = 24.5247
         val medinaLon = 39.5692
+        val meccaLocation = Location(latitude = meccaLat, longitude =  meccaLon)
+        val medinaLocation = Location(latitude = medinaLat, longitude = medinaLon)
 
         // When
-        val distance = useCase(meccaLat, meccaLon, medinaLat, medinaLon)
+        val distance = useCase(location1 = meccaLocation, location2 = medinaLocation)
 
         // Then: Real-world distance ≈ 340 km (allow ±10 km tolerance)
         assertTrue(distance in 330.0..350.0, "Expected ≈340 km but got $distance")
@@ -90,9 +83,11 @@ class CalculateDistanceUseCaseTest {
         val newYorkLon = -74.0060
         val londonLat = 51.5074
         val londonLon = -0.1278
+        val newYorkLocation = Location(latitude = newYorkLat, longitude =  newYorkLon)
+        val londonLocation = Location(latitude = londonLat, longitude = londonLon)
 
         // When
-        val distance = useCase(newYorkLat, newYorkLon, londonLat, londonLon)
+        val distance = useCase(location1 = newYorkLocation, location2 = londonLocation)
 
         // Then
         assertTrue(distance in 5470.0..5670.0, "Expected ≈5570 km but got $distance")
@@ -100,31 +95,32 @@ class CalculateDistanceUseCaseTest {
 
     @Test
     fun `invoke should handle valid boundary coordinates -90 latitude`() {
-        val result = useCase(-90.0, 0.0, 0.0, 0.0)
+        val result = useCase(Location(-90.0, 0.0), location2 = Location(0.0, 0.0))
         assertTrue(result >= 0.0)
     }
 
     @Test
     fun `invoke should handle valid boundary coordinates +90 latitude`() {
-        val result = useCase(90.0, 0.0, 0.0, 0.0)
+        val result = useCase(location1 = Location(90.0, 0.0), location2 = Location( 0.0, 0.0))
         assertTrue(result >= 0.0)
     }
 
     @Test
     fun `invoke should handle valid boundary coordinates -180 longitude`() {
-        val result = useCase(0.0, -180.0, 0.0, 0.0)
+        val result = useCase(Location(latitude = 0.0, longitude =  -180.0), location2 = Location(latitude = 0.0, longitude =  0.0))
         assertTrue(result >= 0.0)
     }
 
     @Test
     fun `invoke should handle valid boundary coordinates +180 longitude`() {
-        val result = useCase(0.0, 180.0, 0.0, 0.0)
+        val result = useCase(Location(latitude = 0.0, longitude = 180.0), location2 = Location( latitude = 0.0, longitude =  0.0))
         assertTrue(result >= 0.0)
     }
 
     @Test
     fun `toRadians should correctly convert degrees to radians`() {
-        val method = CalculateDistanceUseCase::class.java.getDeclaredMethod("toRadians", Double::class.java)
+        val method =
+            CalculateDistanceUseCase::class.java.getDeclaredMethod("toRadians", Double::class.java)
         method.isAccessible = true
 
         val radians = method.invoke(useCase, 180.0) as Double
@@ -133,7 +129,11 @@ class CalculateDistanceUseCaseTest {
 
     @Test
     fun `isValidCoordinate should return true for valid range`() {
-        val method = CalculateDistanceUseCase::class.java.getDeclaredMethod("isValidCoordinate", Double::class.java, Double::class.java)
+        val method = CalculateDistanceUseCase::class.java.getDeclaredMethod(
+            "isValidCoordinate",
+            Double::class.java,
+            Double::class.java
+        )
         method.isAccessible = true
 
         val result = method.invoke(useCase, 45.0, 90.0) as Boolean
@@ -142,7 +142,11 @@ class CalculateDistanceUseCaseTest {
 
     @Test
     fun `isValidCoordinate should return false for invalid latitude`() {
-        val method = CalculateDistanceUseCase::class.java.getDeclaredMethod("isValidCoordinate", Double::class.java, Double::class.java)
+        val method = CalculateDistanceUseCase::class.java.getDeclaredMethod(
+            "isValidCoordinate",
+            Double::class.java,
+            Double::class.java
+        )
         method.isAccessible = true
 
         val result = method.invoke(useCase, -91.0, 0.0) as Boolean
@@ -151,7 +155,11 @@ class CalculateDistanceUseCaseTest {
 
     @Test
     fun `isValidCoordinate should return false for invalid longitude`() {
-        val method = CalculateDistanceUseCase::class.java.getDeclaredMethod("isValidCoordinate", Double::class.java, Double::class.java)
+        val method = CalculateDistanceUseCase::class.java.getDeclaredMethod(
+            "isValidCoordinate",
+            Double::class.java,
+            Double::class.java
+        )
         method.isAccessible = true
 
         val result = method.invoke(useCase, 0.0, 181.0) as Boolean
@@ -160,7 +168,7 @@ class CalculateDistanceUseCaseTest {
 
     @Test
     fun `invoke should coerce negative values to zero`() {
-        val result = useCase(0.0, 0.0, 0.0, 0.0)
+        val result = useCase(Location(0.0, 0.0), location2 = Location( 0.0, 0.0))
         assertEquals(0.0, result)
     }
 }

--- a/faith_domain/src/jvmTest/kotlin/net/thechance/mena/faith/domain/usecase/CalculateDistanceUseCaseTest.kt
+++ b/faith_domain/src/jvmTest/kotlin/net/thechance/mena/faith/domain/usecase/CalculateDistanceUseCaseTest.kt
@@ -1,0 +1,166 @@
+package net.thechance.mena.faith.domain.usecase
+
+import net.thechance.mena.faith.domain.exception.FaithException
+import org.junit.Test
+
+import kotlin.test.*
+
+class CalculateDistanceUseCaseTest {
+
+    private val useCase = CalculateDistanceUseCase()
+
+    @Test
+    fun `invoke should return zero when coordinates are identical`() {
+        val result = useCase(
+            latitude1 = 21.4225,
+            longitude1 = 39.8262,
+            latitude2 = 21.4225,
+            longitude2 = 39.8262
+        )
+        assertEquals(0.0, result)
+    }
+
+    @Test
+    fun `invoke should throw InvalidCoordinates when first coordinate latitude is invalid`() {
+        assertFailsWith<FaithException.InvalidCoordinates> {
+            useCase(
+                latitude1 = 91.0,
+                longitude1 = 0.0,
+                latitude2 = 0.0,
+                longitude2 = 0.0
+            )
+        }
+    }
+
+    @Test
+    fun `invoke should throw InvalidCoordinates when first coordinate longitude is invalid`() {
+        assertFailsWith<FaithException.InvalidCoordinates> {
+            useCase(
+                latitude1 = 0.0,
+                longitude1 = 200.0,
+                latitude2 = 0.0,
+                longitude2 = 0.0
+            )
+        }
+    }
+
+    @Test
+    fun `invoke should throw InvalidCoordinates when second coordinate latitude is invalid`() {
+        assertFailsWith<FaithException.InvalidCoordinates> {
+            useCase(
+                latitude1 = 0.0,
+                longitude1 = 0.0,
+                latitude2 = -100.0,
+                longitude2 = 0.0
+            )
+        }
+    }
+
+    @Test
+    fun `invoke should throw InvalidCoordinates when second coordinate longitude is invalid`() {
+        assertFailsWith<FaithException.InvalidCoordinates> {
+            useCase(
+                latitude1 = 0.0,
+                longitude1 = 0.0,
+                latitude2 = 0.0,
+                longitude2 = -200.0
+            )
+        }
+    }
+
+    @Test
+    fun `invoke should return correct distance between Mecca and Medina`() {
+        // Given: Approximate coordinates of Mecca and Medina
+        val meccaLat = 21.3891
+        val meccaLon = 39.8579
+        val medinaLat = 24.5247
+        val medinaLon = 39.5692
+
+        // When
+        val distance = useCase(meccaLat, meccaLon, medinaLat, medinaLon)
+
+        // Then: Real-world distance ≈ 340 km (allow ±10 km tolerance)
+        assertTrue(distance in 330.0..350.0, "Expected ≈340 km but got $distance")
+    }
+
+    @Test
+    fun `invoke should return correct distance between New York and London`() {
+        // Given
+        val newYorkLat = 40.7128
+        val newYorkLon = -74.0060
+        val londonLat = 51.5074
+        val londonLon = -0.1278
+
+        // When
+        val distance = useCase(newYorkLat, newYorkLon, londonLat, londonLon)
+
+        // Then
+        assertTrue(distance in 5470.0..5670.0, "Expected ≈5570 km but got $distance")
+    }
+
+    @Test
+    fun `invoke should handle valid boundary coordinates -90 latitude`() {
+        val result = useCase(-90.0, 0.0, 0.0, 0.0)
+        assertTrue(result >= 0.0)
+    }
+
+    @Test
+    fun `invoke should handle valid boundary coordinates +90 latitude`() {
+        val result = useCase(90.0, 0.0, 0.0, 0.0)
+        assertTrue(result >= 0.0)
+    }
+
+    @Test
+    fun `invoke should handle valid boundary coordinates -180 longitude`() {
+        val result = useCase(0.0, -180.0, 0.0, 0.0)
+        assertTrue(result >= 0.0)
+    }
+
+    @Test
+    fun `invoke should handle valid boundary coordinates +180 longitude`() {
+        val result = useCase(0.0, 180.0, 0.0, 0.0)
+        assertTrue(result >= 0.0)
+    }
+
+    @Test
+    fun `toRadians should correctly convert degrees to radians`() {
+        val method = CalculateDistanceUseCase::class.java.getDeclaredMethod("toRadians", Double::class.java)
+        method.isAccessible = true
+
+        val radians = method.invoke(useCase, 180.0) as Double
+        assertEquals(Math.PI, radians, 1e-9)
+    }
+
+    @Test
+    fun `isValidCoordinate should return true for valid range`() {
+        val method = CalculateDistanceUseCase::class.java.getDeclaredMethod("isValidCoordinate", Double::class.java, Double::class.java)
+        method.isAccessible = true
+
+        val result = method.invoke(useCase, 45.0, 90.0) as Boolean
+        assertTrue(result)
+    }
+
+    @Test
+    fun `isValidCoordinate should return false for invalid latitude`() {
+        val method = CalculateDistanceUseCase::class.java.getDeclaredMethod("isValidCoordinate", Double::class.java, Double::class.java)
+        method.isAccessible = true
+
+        val result = method.invoke(useCase, -91.0, 0.0) as Boolean
+        assertFalse(result)
+    }
+
+    @Test
+    fun `isValidCoordinate should return false for invalid longitude`() {
+        val method = CalculateDistanceUseCase::class.java.getDeclaredMethod("isValidCoordinate", Double::class.java, Double::class.java)
+        method.isAccessible = true
+
+        val result = method.invoke(useCase, 0.0, 181.0) as Boolean
+        assertFalse(result)
+    }
+
+    @Test
+    fun `invoke should coerce negative values to zero`() {
+        val result = useCase(0.0, 0.0, 0.0, 0.0)
+        assertEquals(0.0, result)
+    }
+}

--- a/faith_presentation/src/commonMain/composeResources/values-ar/strings.xml
+++ b/faith_presentation/src/commonMain/composeResources/values-ar/strings.xml
@@ -64,6 +64,7 @@
         <item quantity="other">منذ %1$d عام</item>
     </plurals>
     <string name="error_unknown">حدث خطأ ما. يرجى المحاولة مرة أخرى.</string>
+    <string name="error_coordinates">الإحداثيات غير صحيحة</string>
     <string name="error_no_internet">لا يوجد اتصال بالإنترنت. يرجى التحقق من الشبكة.</string>
     <string name="error_unauthorized">لست مخولاً للقيام بهذا الإجراء.</string>
     <string name="error_network">خطأ في الشبكة. يرجى المحاولة لاحقاً.</string>

--- a/faith_presentation/src/commonMain/composeResources/values/strings.xml
+++ b/faith_presentation/src/commonMain/composeResources/values/strings.xml
@@ -111,6 +111,7 @@
 
     <!-- Error Messages -->
     <string name="error_unknown">Something went wrong. Please try again.</string>
+    <string name="error_coordinates">Invalid coordinates</string>
     <string name="error_no_internet">No internet connection. Please check your network.</string>
     <string name="error_unauthorized">You’re not authorized to perform this action.</string>
     <string name="error_network">Network error. Please try again later.</string>

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/base/BaseViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/base/BaseViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import mena.faith_presentation.generated.resources.Res
+import mena.faith_presentation.generated.resources.error_coordinates
 import mena.faith_presentation.generated.resources.error_latitude
 import mena.faith_presentation.generated.resources.error_longitude
 import mena.faith_presentation.generated.resources.error_network
@@ -119,5 +120,6 @@ abstract class BaseViewModel<UI_STATE, UI_EFFECT>(
         FaithException.FailedToDownloadSurahException -> Res.string.surah_download_failed
         FaithException.FileCreationException -> Res.string.surah_download_failed
         FaithException.UrlCreationException -> Res.string.surah_download_failed
+        FaithException.InvalidCoordinates -> Res.string.error_coordinates
     }
 }


### PR DESCRIPTION
Implement a use case that calculates the distance (in kilometers) between two geographical points defined by latitude and longitude coordinates.