### PR TITLE
Feature/idn 150 add loading effect to address screen

### DIFF
--- a/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/addresses/EnableLocationScreenViewModelTest.kt
+++ b/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/addresses/EnableLocationScreenViewModelTest.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.screen.enableLocationScreen
+package net.thechance.mena.identity.presentation.screen.addresses
 
 import app.cash.turbine.test
 import io.mockk.Runs
@@ -12,6 +12,8 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import net.thechance.mena.identity.presentation.screen.addresses.enableLocationScreen.EnableLocationScreenUIEffect
+import net.thechance.mena.identity.presentation.screen.addresses.enableLocationScreen.EnableLocationScreenViewModel
 import net.thechance.mena.identity.presentation.util.permissionHandler.PermissionHandler
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/LoadingProgressBar.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/LoadingProgressBar.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.components.util
+package net.thechance.mena.identity.presentation.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/util/LoadingProgressBar.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/util/LoadingProgressBar.kt
@@ -1,0 +1,27 @@
+package net.thechance.mena.identity.presentation.components.util
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import net.thechance.mena.designsystem.presentation.component.indicator.DotsProgressIndicator
+import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+
+@Composable
+internal fun LoadingProgressBar(
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = Theme.colorScheme.background.surface
+
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(backgroundColor),
+        contentAlignment = Alignment.Center
+    ) {
+        DotsProgressIndicator()
+    }
+}

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/di/identityScreensModule.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/di/identityScreensModule.kt
@@ -5,7 +5,7 @@ import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.Add
 import net.thechance.mena.identity.presentation.screen.addresses.pickLocation.PickLocationScreenViewModel
 import net.thechance.mena.identity.presentation.screen.changePassword.ChangePasswordScreenViewModel
 import net.thechance.mena.identity.presentation.screen.editProfile.EditUserProfileViewModel
-import net.thechance.mena.identity.presentation.screen.enableLocationScreen.EnableLocationScreenViewModel
+import net.thechance.mena.identity.presentation.screen.addresses.enableLocationScreen.EnableLocationScreenViewModel
 import net.thechance.mena.identity.presentation.screen.imageCropper.ImageCropperComponentViewModel
 import net.thechance.mena.identity.presentation.screen.imageCropper.ImageCropperUiState
 import net.thechance.mena.identity.presentation.screen.imageCropper.ImageCropperViewModel

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/addEditLocation/AddEditLocationScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/addEditLocation/AddEditLocationScreen.kt
@@ -34,7 +34,6 @@ import kotlin.uuid.ExperimentalUuidApi
 class AddEditLocationScreen(
     val onSuccess: (SnackBarUiState?) -> Unit,
     private val addressModel: AddressUIState?,
-
     ) : BaseScreen<
         AddEditLocationScreenViewModel,
         AddEditLocationScreenUIState,

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/addEditLocation/AddEditLocationScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/addEditLocation/AddEditLocationScreen.kt
@@ -24,7 +24,7 @@ import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.Add
 import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.SnackBarUiState
 import net.thechance.mena.identity.presentation.screen.addresses.addEditLocation.components.AddressTypeSection
 import net.thechance.mena.identity.presentation.screen.addresses.addEditLocation.components.OtherAddressType
-import net.thechance.mena.identity.presentation.screen.addresses.components.MapSection
+import net.thechance.mena.identity.presentation.screen.addresses.addEditLocation.components.MapSection
 import net.thechance.mena.identity.presentation.screen.addresses.pickLocation.PickLocationScreen
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/addEditLocation/components/MapSection.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/addEditLocation/components/MapSection.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.screen.addresses.components
+package net.thechance.mena.identity.presentation.screen.addresses.addEditLocation.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,6 +15,7 @@ import mena.identity_presentation.generated.resources.location
 import mena.identity_presentation.generated.resources.pick_on_map
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.components.AddLocationMap
 import org.jetbrains.compose.resources.stringResource
 import org.maplibre.compose.camera.CameraPosition
 import sv.lib.squircleshape.SquircleShape

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/enableLocationScreen/EnableLocationScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/enableLocationScreen/EnableLocationScreen.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.screen.enableLocationScreen
+package net.thechance.mena.identity.presentation.screen.addresses.enableLocationScreen
 
 
 import androidx.compose.foundation.layout.Box

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/enableLocationScreen/EnableLocationScreenInteractionListener.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/enableLocationScreen/EnableLocationScreenInteractionListener.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.screen.enableLocationScreen
+package net.thechance.mena.identity.presentation.screen.addresses.enableLocationScreen
 
 import net.thechance.mena.identity.presentation.base.BaseInteractionListener
 

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/enableLocationScreen/EnableLocationScreenUIEffect.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/enableLocationScreen/EnableLocationScreenUIEffect.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.screen.enableLocationScreen
+package net.thechance.mena.identity.presentation.screen.addresses.enableLocationScreen
 
 sealed interface EnableLocationScreenUIEffect {
     data object NavigateBack : EnableLocationScreenUIEffect

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/enableLocationScreen/EnableLocationScreenUIState.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/enableLocationScreen/EnableLocationScreenUIState.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.screen.enableLocationScreen
+package net.thechance.mena.identity.presentation.screen.addresses.enableLocationScreen
 
 import org.jetbrains.compose.resources.StringResource
 

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/enableLocationScreen/EnableLocationScreenViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/enableLocationScreen/EnableLocationScreenViewModel.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.screen.enableLocationScreen
+package net.thechance.mena.identity.presentation.screen.addresses.enableLocationScreen
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/AddressesScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/AddressesScreen.kt
@@ -1,5 +1,9 @@
 package net.thechance.mena.identity.presentation.screen.addresses.myAddresses
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -21,6 +25,7 @@ import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.identity.presentation.base.BaseScreen
 import net.thechance.mena.identity.presentation.components.AddressSnackBar
 import net.thechance.mena.identity.presentation.components.NoSavedLocationsLayout
+import net.thechance.mena.identity.presentation.components.util.LoadingProgressBar
 import net.thechance.mena.identity.presentation.screen.addresses.addEditLocation.AddEditLocationScreen
 import net.thechance.mena.identity.presentation.screen.addresses.components.AddressCard
 import net.thechance.mena.identity.presentation.screen.addresses.components.MyAddressesAppBar
@@ -102,13 +107,23 @@ class AddressesScreen :
             }
         }
 
-        if (state.addresses.isEmpty() && !state.isLoading) {
+        AnimatedVisibility(
+            visible = state.addresses.isEmpty() && !state.isLoading,
+            enter = fadeIn(animationSpec = tween(durationMillis = 500)),
+            exit = fadeOut(animationSpec = tween(durationMillis = 500))
+        ) {
             NoSavedLocationsLayout(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 28.dp),
+                modifier = Modifier.fillMaxSize().padding(horizontal = 28.dp),
                 onAddLocationClicked = listener::onAddButtonClicked
             )
+        }
+
+        AnimatedVisibility(
+            visible = state.isLoading,
+            enter = fadeIn(animationSpec = tween(durationMillis = 500)),
+            exit = fadeOut(animationSpec = tween(durationMillis = 500))
+        ) {
+            LoadingProgressBar()
         }
     }
 

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/AddressesScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/AddressesScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -27,11 +28,12 @@ import net.thechance.mena.identity.presentation.components.AddressSnackBar
 import net.thechance.mena.identity.presentation.components.NoSavedLocationsLayout
 import net.thechance.mena.identity.presentation.components.util.LoadingProgressBar
 import net.thechance.mena.identity.presentation.screen.addresses.addEditLocation.AddEditLocationScreen
-import net.thechance.mena.identity.presentation.screen.addresses.components.AddressCard
-import net.thechance.mena.identity.presentation.screen.addresses.components.MyAddressesAppBar
+import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.components.AddressCard
+import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.components.MyAddressesAppBar
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 class AddressesScreen :
     BaseScreen<AddressesScreenViewModel, AddressesScreenUIState, AddressesScreenUIEffect, AddressesScreenInteractionListener>() {
@@ -71,6 +73,13 @@ class AddressesScreen :
                     )
                 }
             },
+            topBar = {
+                MyAddressesAppBar(
+                    title = stringResource(Res.string.my_location_app_bar_title),
+                    onBackClicked = listener::onBackButtonClicked,
+                    onAddClicked = listener::onAddButtonClicked
+                )
+            },
             snakeBar = {
                 AddressSnackBar(
                     snackBarState = state.snackBarUiState,
@@ -78,52 +87,40 @@ class AddressesScreen :
                 )
             }
         ) {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = Theme.spacing._16),
-                verticalArrangement = Arrangement.spacedBy(Theme.spacing._12)
-            ) {
-                item {
-                    MyAddressesAppBar(
-                        title = stringResource(Res.string.my_location_app_bar_title),
-                        onBackClicked = listener::onBackButtonClicked,
-                        onAddClicked = listener::onAddButtonClicked
+            Box(Modifier.fillMaxSize()) {
+                AnimatedVisibility(
+                    visible = state.addresses.isNotEmpty() && !state.isLoading,
+                    enter = fadeIn(animationSpec = tween(durationMillis = 500)),
+                    exit = fadeOut(animationSpec = tween(durationMillis = 500))
+                ) {
+                    AddressesSection(
+                        addresses = state.addresses,
+                        onEditAddressClicked = listener::onEditAddressClicked,
+                        onDeleteAddressClicked = listener::onDeleteAddressClicked,
+                        onClickAddress = listener::onClickAddress,
+                        animateToCurrentLocation = state.animateToCurrentLocation
                     )
                 }
-                items(state.addresses) {
-                    AddressCard(
-                        addressType = it.addressType,
-                        onEditClick = { listener.onEditAddressClicked(it) },
-                        isMainAddress = it.isMainAddress,
-                        addressDetails = it.addressDetails,
-                        onDeleteClick = { it.id?.let { id -> listener.onDeleteAddressClicked(id) } },
-                        onClickAddress = { it.id?.let { id -> listener.onClickAddress(id) } },
-                        animateToCurrentLocation = state.animateToCurrentLocation,
-                        longitude = it.coordinates.longitude,
-                        latitude = it.coordinates.latitude,
+
+                AnimatedVisibility(
+                    visible = state.addresses.isEmpty() && !state.isLoading,
+                    enter = fadeIn(animationSpec = tween(durationMillis = 500)),
+                    exit = fadeOut(animationSpec = tween(durationMillis = 500))
+                ) {
+                    NoSavedLocationsLayout(
+                        modifier = Modifier.fillMaxSize().padding(horizontal = 28.dp),
+                        onAddLocationClicked = listener::onAddButtonClicked
                     )
+                }
+
+                AnimatedVisibility(
+                    visible = state.isLoading,
+                    enter = fadeIn(animationSpec = tween(durationMillis = 500)),
+                    exit = fadeOut(animationSpec = tween(durationMillis = 500))
+                ) {
+                    LoadingProgressBar()
                 }
             }
-        }
-
-        AnimatedVisibility(
-            visible = state.addresses.isEmpty() && !state.isLoading,
-            enter = fadeIn(animationSpec = tween(durationMillis = 500)),
-            exit = fadeOut(animationSpec = tween(durationMillis = 500))
-        ) {
-            NoSavedLocationsLayout(
-                modifier = Modifier.fillMaxSize().padding(horizontal = 28.dp),
-                onAddLocationClicked = listener::onAddButtonClicked
-            )
-        }
-
-        AnimatedVisibility(
-            visible = state.isLoading,
-            enter = fadeIn(animationSpec = tween(durationMillis = 500)),
-            exit = fadeOut(animationSpec = tween(durationMillis = 500))
-        ) {
-            LoadingProgressBar()
         }
     }
 
@@ -141,6 +138,37 @@ class AddressesScreen :
                     )
                 )
             }
+        }
+    }
+}
+
+@OptIn(ExperimentalUuidApi::class)
+@Composable
+private fun AddressesSection(
+    addresses: List<AddressUIState>,
+    onEditAddressClicked: (AddressUIState) -> Unit,
+    onDeleteAddressClicked: (Uuid) -> Unit,
+    onClickAddress: (Uuid) -> Unit,
+    animateToCurrentLocation: Boolean
+) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = Theme.spacing._16),
+        verticalArrangement = Arrangement.spacedBy(Theme.spacing._12)
+    ) {
+        items(addresses) {
+            AddressCard(
+                addressType = it.addressType,
+                onEditClick = { onEditAddressClicked(it) },
+                isMainAddress = it.isMainAddress,
+                addressDetails = it.addressDetails,
+                onDeleteClick = { it.id?.let { id -> onDeleteAddressClicked(id) } },
+                onClickAddress = { it.id?.let { id -> onClickAddress(id) } },
+                animateToCurrentLocation = animateToCurrentLocation,
+                longitude = it.coordinates.longitude,
+                latitude = it.coordinates.latitude,
+            )
         }
     }
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/AddressesScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/AddressesScreen.kt
@@ -11,25 +11,22 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.Navigator
 import mena.identity_presentation.generated.resources.Res
-import mena.identity_presentation.generated.resources.confirmation_dialog_delete
 import mena.identity_presentation.generated.resources.my_location_app_bar_title
-import net.thechance.mena.designsystem.presentation.component.button.TextButton
-import net.thechance.mena.designsystem.presentation.component.dialog.Dialog
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.identity.presentation.base.BaseScreen
 import net.thechance.mena.identity.presentation.components.AddressSnackBar
-import net.thechance.mena.identity.presentation.components.NoSavedLocationsLayout
 import net.thechance.mena.identity.presentation.components.LoadingProgressBar
+import net.thechance.mena.identity.presentation.components.NoSavedLocationsLayout
 import net.thechance.mena.identity.presentation.screen.addresses.addEditLocation.AddEditLocationScreen
 import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.components.AddressCard
 import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.components.MyAddressesAppBar
+import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.components.deleteAddressDialog
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import kotlin.uuid.ExperimentalUuidApi
@@ -49,29 +46,11 @@ class AddressesScreen :
     ) {
         Scaffold(
             overlays = {
-                dialog(state.deleteDialogUIState.isVisible) {
-                    Dialog(
-                        isVisible = it,
-                        title = stringResource(state.deleteDialogUIState.title),
-                        message = stringResource(state.deleteDialogUIState.description),
-                        onDismiss = listener::onDismissDeleteDialog,
-                        onCancelClick = listener::onDismissDeleteDialog,
-                        actionButtons = {
-                            TextButton(
-                                modifier = Modifier
-                                    .padding(
-                                        vertical = Theme.spacing._24,
-                                        horizontal = Theme.spacing._8
-                                    )
-                                    .align(Alignment.End),
-                                text = stringResource(Res.string.confirmation_dialog_delete),
-                                onClick = listener::onConfirmDeleteAddress,
-                                iconSize = Theme.spacing._16,
-                                contentColor = Theme.colorScheme.error
-                            )
-                        }
-                    )
-                }
+                deleteAddressDialog(
+                    deleteDialogUIState = state.deleteDialogUIState,
+                    onDismissDeleteDialog = listener::onDismissDeleteDialog,
+                    onConfirmDeleteAddress = listener::onConfirmDeleteAddress
+                )
             },
             topBar = {
                 MyAddressesAppBar(
@@ -172,7 +151,6 @@ private fun AddressesSection(
         }
     }
 }
-
 
 @Preview
 @Composable

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/AddressesScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/AddressesScreen.kt
@@ -32,8 +32,11 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-class AddressesScreen :
-    BaseScreen<AddressesScreenViewModel, AddressesScreenUIState, AddressesScreenUIEffect, AddressesScreenInteractionListener>() {
+class AddressesScreen : BaseScreen<
+        AddressesScreenViewModel,
+        AddressesScreenUIState,
+        AddressesScreenUIEffect,
+        AddressesScreenInteractionListener>() {
     @Composable
     override fun Content() {
         InitScreen(getScreenModel())

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/AddressesScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/AddressesScreen.kt
@@ -26,7 +26,7 @@ import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.identity.presentation.base.BaseScreen
 import net.thechance.mena.identity.presentation.components.AddressSnackBar
 import net.thechance.mena.identity.presentation.components.NoSavedLocationsLayout
-import net.thechance.mena.identity.presentation.components.util.LoadingProgressBar
+import net.thechance.mena.identity.presentation.components.LoadingProgressBar
 import net.thechance.mena.identity.presentation.screen.addresses.addEditLocation.AddEditLocationScreen
 import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.components.AddressCard
 import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.components.MyAddressesAppBar

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/components/AddLocationMap.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/components/AddLocationMap.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.screen.addresses.components
+package net.thechance.mena.identity.presentation.screen.addresses.myAddresses.components
 
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.BoxWithConstraints

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/components/AddressActions.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/components/AddressActions.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.screen.addresses.components
+package net.thechance.mena.identity.presentation.screen.addresses.myAddresses.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/components/AddressCard.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/components/AddressCard.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.screen.addresses.components
+package net.thechance.mena.identity.presentation.screen.addresses.myAddresses.components
 
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.Image

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/components/AddressHeader.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/components/AddressHeader.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.screen.addresses.components
+package net.thechance.mena.identity.presentation.screen.addresses.myAddresses.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/components/DeleteAddressDialog.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/components/DeleteAddressDialog.kt
@@ -1,0 +1,43 @@
+package net.thechance.mena.identity.presentation.screen.addresses.myAddresses.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import mena.identity_presentation.generated.resources.Res
+import mena.identity_presentation.generated.resources.confirmation_dialog_delete
+import net.thechance.mena.designsystem.presentation.component.button.TextButton
+import net.thechance.mena.designsystem.presentation.component.dialog.Dialog
+import net.thechance.mena.designsystem.presentation.component.scaffold.ScaffoldScope
+import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.DeleteDialogUIState
+import org.jetbrains.compose.resources.stringResource
+
+internal fun ScaffoldScope.deleteAddressDialog(
+    deleteDialogUIState: DeleteDialogUIState,
+    onDismissDeleteDialog: () -> Unit,
+    onConfirmDeleteAddress: () -> Unit,
+) {
+    dialog(deleteDialogUIState.isVisible) {
+        Dialog(
+            isVisible = it,
+            title = stringResource(deleteDialogUIState.title),
+            message = stringResource(deleteDialogUIState.description),
+            onDismiss = onDismissDeleteDialog,
+            onCancelClick = onDismissDeleteDialog,
+            actionButtons = {
+                TextButton(
+                    modifier = Modifier
+                        .padding(
+                            vertical = Theme.spacing._24,
+                            horizontal = Theme.spacing._8
+                        )
+                        .align(Alignment.End),
+                    text = stringResource(Res.string.confirmation_dialog_delete),
+                    onClick = onConfirmDeleteAddress,
+                    iconSize = Theme.spacing._16,
+                    contentColor = Theme.colorScheme.error
+                )
+            }
+        )
+    }
+}

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/components/MyAddressesAppBar.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/myAddresses/components/MyAddressesAppBar.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.screen.addresses.components
+package net.thechance.mena.identity.presentation.screen.addresses.myAddresses.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -29,7 +29,7 @@ fun MyAddressesAppBar(
     onAddClicked: () -> Unit,
 ) {
     AppBar(
-        contentPadding = PaddingValues(horizontal = 0.dp, vertical = 14.dp),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 14.dp),
         title = title,
         leadingContent = {
             Icon(

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/pickLocation/PickLocationScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/pickLocation/PickLocationScreen.kt
@@ -32,7 +32,8 @@ import org.koin.core.parameter.parametersOf
 data class PickLocationScreen(
     private val addressModel: AddressUIState?,
     private val onUpdateLocation: (AddressUIState) -> Unit,
-) : BaseScreen<PickLocationScreenViewModel,
+) : BaseScreen<
+        PickLocationScreenViewModel,
         PickLocationScreenUIState,
         PickLocationScreenUIEffect,
         PickLocationScreenInteractionListener>() {

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/pickLocation/PickLocationScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/pickLocation/PickLocationScreen.kt
@@ -22,7 +22,7 @@ import net.thechance.mena.identity.presentation.base.BaseScreen
 import net.thechance.mena.identity.presentation.components.AuthAppBar
 import net.thechance.mena.identity.presentation.components.ErrorSnackBar
 import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.AddressUIState
-import net.thechance.mena.identity.presentation.screen.enableLocationScreen.EnableLocationScreen
+import net.thechance.mena.identity.presentation.screen.addresses.enableLocationScreen.EnableLocationScreen
 import net.thechance.mena.identity.presentation.screen.addresses.pickLocation.components.EditMapButton
 import net.thechance.mena.identity.presentation.screen.addresses.pickLocation.components.GpsFabButton
 import net.thechance.mena.identity.presentation.screen.addresses.pickLocation.components.PickLocationMap


### PR DESCRIPTION
### add loading effect to address screen 
1 - add loading effect 
2 - move enable location screen to addresses directory 
3 - move not shared component to my address screen 
4 - fix scrollable appbar in address screen 
5 - extract delete address dialog to a separate component

<table>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/28519640-57f3-4d0e-89e8-aa3fd2bfaf7f" width="100%" controls></video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/f8abec81-44bf-4909-85be-8b375042f28c" width="100%" controls></video>
    </td>
  </tr>
</table>