### PR TITLE
Dkn 101/favourite product

### DIFF
--- a/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/dto/product/ProductDto.kt
+++ b/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/dto/product/ProductDto.kt
@@ -30,5 +30,8 @@ data class ProductDto(
     val createdAt: String,
 
     @SerialName("quantityInCart")
-    val quantityInCart : Int
+    val quantityInCart : Int,
+
+    @SerialName("isFavorite")
+    val isFavorite: Boolean = false
 )

--- a/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/mapper/ProductMapper.kt
+++ b/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/mapper/ProductMapper.kt
@@ -37,7 +37,8 @@ fun ProductDto.toDomain(): Product = Product(
     imageUrls = imageUrls,
     createdAt = createdAt,
     quantityInCart = quantityInCart,
-    shelfId = shelfId
+    shelfId = shelfId,
+    isFavorite = isFavorite
 )
 
 @OptIn(ExperimentalUuidApi::class)
@@ -49,5 +50,6 @@ fun ProductCartDto.toDomain(): Product = Product(
     imageUrls = listOf(imageUrl),
     quantityInCart = quantityInCart,
     createdAt = "",
-    shelfId = null
+    shelfId = null,
+    isFavorite = false
 )

--- a/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/repository/DukanProductRepositoryImpl.kt
+++ b/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/repository/DukanProductRepositoryImpl.kt
@@ -109,4 +109,12 @@ class DukanProductRepositoryImpl(
             client.delete("${PRODUCT_BASE_PATH}/$productId")
         }
     }
+
+    override suspend fun toggleProductToFavorites(productId: String) {
+        safeApiCall<Unit> {
+            client.post("${PRODUCT_BASE_PATH}/$productId/favorite") {
+                contentType(ContentType.Application.Json)
+            }
+        }
+    }
 }

--- a/dukan_data/src/test/java/net/thechance/mena/dukan/data/repository/DukanProductRepositoryImplTest.kt
+++ b/dukan_data/src/test/java/net/thechance/mena/dukan/data/repository/DukanProductRepositoryImplTest.kt
@@ -171,5 +171,19 @@ class DukanProductRepositoryImplTest {
 
         assertTrue(called, "Expected the mock engine to be called")
     }
+    @Test
+    fun `toggleProductToFavorites calls correct endpoint`() = runTest {
+        var called = false
+        val repo = createProductRepository(
+            toggleFavoriteResponse = {
+                called = true
+                respond("", io.ktor.http.HttpStatusCode.OK, jsonHeaders)
+            }
+        )
+
+        repo.toggleProductToFavorites("product-123")
+
+        assertTrue(called, "Expected the mock engine to be called")
+    }
 
 }

--- a/dukan_data/src/test/java/net/thechance/mena/dukan/data/repository/mapper/ProductMapperKtTest.kt
+++ b/dukan_data/src/test/java/net/thechance/mena/dukan/data/repository/mapper/ProductMapperKtTest.kt
@@ -104,4 +104,54 @@ class ProductMapperKtTest {
     fun `ProductCartDto toDomain quantityInCart maps correctly`() {
         assertEquals(10, product.quantityInCart)
     }
+    @OptIn(ExperimentalUuidApi::class)
+    @Test
+    fun `toDomain maps isFavorite correctly when true`() {
+        val id = Uuid.random()
+        val shelfId = Uuid.random()
+
+        val dto = ProductDto(
+            id = id,
+            name = "Demo Product",
+            description = "A description",
+            price = 10.5,
+            shelfId = shelfId,
+            imageUrls = listOf("url1", "url2"),
+            createdAt = "2025-09-26T15:26:41.300823Z",
+            quantityInCart = 10,
+            isFavorite = true
+        )
+
+        val product: Product = dto.toDomain()
+
+        assertEquals(true, product.isFavorite)
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    @Test
+    fun `toDomain maps isFavorite correctly when false`() {
+        val id = Uuid.random()
+        val shelfId = Uuid.random()
+
+        val dto = ProductDto(
+            id = id,
+            name = "Demo Product",
+            description = "A description",
+            price = 10.5,
+            shelfId = shelfId,
+            imageUrls = listOf("url1", "url2"),
+            createdAt = "2025-09-26T15:26:41.300823Z",
+            quantityInCart = 10,
+            isFavorite = false
+        )
+
+        val product: Product = dto.toDomain()
+
+        assertEquals(false, product.isFavorite)
+    }
+
+    @Test
+    fun `ProductCartDto toDomain isFavorite maps correctly`() {
+        assertEquals(false, product.isFavorite)
+    }
 }

--- a/dukan_data/src/test/java/net/thechance/mena/dukan/data/repository/mockEngine/product/demoData.kt
+++ b/dukan_data/src/test/java/net/thechance/mena/dukan/data/repository/mockEngine/product/demoData.kt
@@ -28,7 +28,8 @@ val productDto1 = ProductDto(
         "https://picsum.photos/200/200?random=2"
     ),
     createdAt = "2025-09-26T15:26:41.300823Z",
-    quantityInCart = 10
+    quantityInCart = 10,
+    isFavorite = true
 )
 
 
@@ -44,7 +45,8 @@ val productDto2 = ProductDto(
         "https://picsum.photos/200/200?random=2"
     ),
     createdAt = "2025-09-26T15:26:41.300823Z",
-    quantityInCart = 10
+    quantityInCart = 10,
+    isFavorite = false
 
 )
 

--- a/dukan_data/src/test/java/net/thechance/mena/dukan/data/repository/mockEngine/product/mockProductsEngine.kt
+++ b/dukan_data/src/test/java/net/thechance/mena/dukan/data/repository/mockEngine/product/mockProductsEngine.kt
@@ -82,6 +82,7 @@ fun createProductHttpClient(
     deleteResponse: (suspend MockRequestHandleScope.() -> HttpResponseData)? = null,
     deleteImagesResponse: (suspend MockRequestHandleScope.() -> HttpResponseData)? = null,
     productDetailsResponse: (suspend MockRequestHandleScope.() -> HttpResponseData)? = null,
+    toggleFavoriteResponse: (suspend MockRequestHandleScope.() -> HttpResponseData)? = null
 ): HttpClient {
     val dukanId = "10"
     return HttpClient(MockEngine { request ->
@@ -119,6 +120,10 @@ fun createProductHttpClient(
                     request.method.value == "DELETE" -> deleteResponse?.invoke(this)
                 ?: respond("", HttpStatusCode.OK, jsonHeaders)
 
+            request.url.encodedPath.matches(Regex("/dukan/product/[^/]+/favorite")) &&
+                    request.method.value == "POST" -> toggleFavoriteResponse?.invoke(this)
+                ?: respond("", HttpStatusCode.OK, jsonHeaders)
+
             else -> respond("", HttpStatusCode.BadRequest, jsonHeaders)
         }
     }) {
@@ -138,6 +143,7 @@ fun createProductRepository(
     updateResponse: (suspend MockRequestHandleScope.() -> HttpResponseData)? = null,
     deleteResponse: (suspend MockRequestHandleScope.() -> HttpResponseData)? = null,
     deleteImagesResponse: (suspend MockRequestHandleScope.() -> HttpResponseData)? = null,
+    toggleFavoriteResponse: (suspend MockRequestHandleScope.() -> HttpResponseData)? = null
 ): DukanProductRepositoryImpl {
     return DukanProductRepositoryImpl(
         client = createProductHttpClient(
@@ -148,7 +154,8 @@ fun createProductRepository(
             productByIdResponse = productByIdResponse,
             updateResponse = updateResponse,
             deleteResponse = deleteResponse,
-            deleteImagesResponse = deleteImagesResponse
+            deleteImagesResponse = deleteImagesResponse,
+            toggleFavoriteResponse = toggleFavoriteResponse
         )
     )
 }

--- a/dukan_domain/src/commonMain/kotlin/net/thechance/mena/dukan/domain/entity/Product.kt
+++ b/dukan_domain/src/commonMain/kotlin/net/thechance/mena/dukan/domain/entity/Product.kt
@@ -12,5 +12,6 @@ data class Product(
     val imageUrls: List<String>,
     val createdAt: String,
     val quantityInCart: Int,
-    val shelfId: Uuid?
+    val shelfId: Uuid?,
+    val isFavorite: Boolean
 )

--- a/dukan_domain/src/commonMain/kotlin/net/thechance/mena/dukan/domain/repository/ProductRepository.kt
+++ b/dukan_domain/src/commonMain/kotlin/net/thechance/mena/dukan/domain/repository/ProductRepository.kt
@@ -27,4 +27,5 @@ interface ProductRepository {
     suspend fun updateProduct(productId: String, params: UpdateProductParams)
     suspend fun deleteProductImages(productId: String, imageUrls: List<String>)
     suspend fun deleteProduct(productId: String)
+    suspend fun toggleProductToFavorites(productId: String)
 }

--- a/dukan_presentation/src/commonMain/composeResources/values-ar/strings.xml
+++ b/dukan_presentation/src/commonMain/composeResources/values-ar/strings.xml
@@ -163,4 +163,7 @@
     <string name="delete_product_description">هل أنت متأكد أنك تريد حذف هذا المنتج؟</string>
     <string name="silver_tier_icon">أيقونة الفئة الفضية</string>
     <string name="desc_edit_address_icon">ايقونة تعديل العنوان</string>
+    <string name="added_to_favorites">تمت الإضافة إلى المفضلة</string>
+    <string name="removed_from_favorites">تمت الإزالة من المفضلة</string>
+    <string name="error_updating_favorites">تعذر تحديث المفضلة</string>
 </resources>

--- a/dukan_presentation/src/commonMain/composeResources/values/strings.xml
+++ b/dukan_presentation/src/commonMain/composeResources/values/strings.xml
@@ -163,4 +163,7 @@
     <string name="delete_product_description">Are you sure you want to delete this product?</string>
     <string name="silver_tier_icon">Silver tier icon</string>
     <string name="desc_edit_address_icon">Edit address icon</string>
+    <string name="added_to_favorites">Added to favorites</string>
+    <string name="removed_from_favorites">Removed from favorites</string>
+    <string name="error_updating_favorites">Could not update favorites</string>
 </resources>

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/ProductDetailsTopAppBar.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/ProductDetailsTopAppBar.kt
@@ -16,6 +16,7 @@ import mena.dukan_presentation.generated.resources.back_arrow
 import mena.dukan_presentation.generated.resources.favorite_icon
 import mena.dukan_presentation.generated.resources.ic_arrow_left
 import mena.dukan_presentation.generated.resources.ic_favorite
+import mena.dukan_presentation.generated.resources.ic_favorite_filled
 import mena.dukan_presentation.generated.resources.ic_share
 import mena.dukan_presentation.generated.resources.ic_shopping_basket
 import mena.dukan_presentation.generated.resources.share_icon
@@ -58,9 +59,15 @@ fun ProductDetailsAppBar(
                 onClick = listener::onShareClicked
             )
             AppBarIcon(
-                painter = painterResource(Res.drawable.ic_favorite),
+                painter = painterResource(
+                    if (state.isFavorite) {
+                        Res.drawable.ic_favorite_filled
+                    } else {
+                        Res.drawable.ic_favorite
+                    }
+                ),
                 contentDescription = stringResource(Res.string.favorite_icon),
-                onClick = listener::onAddToFavoritesClicked
+                onClick = listener::onToggleProductToFavoriteClicked
             )
             AppBarIcon(
                 painter = painterResource(Res.drawable.ic_shopping_basket),

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/util/stubPreviews/PreviewProductDetailsInteractionListener.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/util/stubPreviews/PreviewProductDetailsInteractionListener.kt
@@ -22,7 +22,7 @@ object PreviewProductDetailsInteractionListener : ProductDetailsInteractionListe
     override fun onShareClicked() {
     }
 
-    override fun onAddToFavoritesClicked() {
+    override fun onToggleProductToFavoriteClicked() {
     }
 
     override fun onViewCartClicked() {

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsInteractionListener.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsInteractionListener.kt
@@ -9,7 +9,7 @@ interface ProductDetailsInteractionListener {
     fun onDismissSnackBar()
     fun onViewCartClicked()
     fun onShareClicked()
-    fun onAddToFavoritesClicked()
+    fun onToggleProductToFavoriteClicked()
     fun onSecondaryImageClicked(imageUrl: String)
     fun onRetryClicked()
 }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModel.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModel.kt
@@ -9,7 +9,10 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
 import mena.dukan_presentation.generated.resources.Res
 import mena.dukan_presentation.generated.resources.add_product_success
+import mena.dukan_presentation.generated.resources.added_to_favorites
+import mena.dukan_presentation.generated.resources.error_updating_favorites
 import mena.dukan_presentation.generated.resources.no_internet_connection
+import mena.dukan_presentation.generated.resources.removed_from_favorites
 import net.thechance.mena.dukan.domain.entity.Product
 import net.thechance.mena.dukan.domain.exceptions.NoInternetException
 import net.thechance.mena.dukan.domain.model.UpdateProductCartQuantityParams
@@ -53,7 +56,8 @@ class ProductDetailsViewModel(
                 isLoading = false,
                 product = productUiInfo,
                 selectedImageUrl = productUiInfo.images.firstOrNull() ?: "",
-                errorState = null
+                errorState = null,
+                isFavorite = product.isFavorite
             )
         }
     }
@@ -154,12 +158,36 @@ class ProductDetailsViewModel(
     }
 
     override fun onShareClicked() {
-
+        //TODO
     }
 
-    override fun onAddToFavoritesClicked() {
+    override fun onToggleProductToFavoriteClicked() {
+        val currentProduct = state.value.product
+        val isCurrentlyFavorite = state.value.isFavorite
 
+        tryToExecute(
+            block = { productRepository.toggleProductToFavorites(currentProduct.id) },
+            onSuccess = { onFavoriteToggleSuccess(!isCurrentlyFavorite) },
+            onError = ::onFavoriteToggleError
+        )
     }
 
+    private fun onFavoriteToggleSuccess(newFavoriteState: Boolean) {
+        updateState { copy(isFavorite = newFavoriteState) }
+        showSnackBar(
+            message = if (newFavoriteState) {
+                Res.string.added_to_favorites
+            } else {
+                Res.string.removed_from_favorites
+            },
+            type = SnackBarType.SUCCESS
+        )
+    }
 
+    private fun onFavoriteToggleError(throwable: Throwable) {
+        showSnackBar(
+            message = Res.string.error_updating_favorites,
+            type = SnackBarType.ERROR
+        )
+    }
 }

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/checkout/CheckoutMapperTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/checkout/CheckoutMapperTest.kt
@@ -19,7 +19,8 @@ class CheckoutMapperTest {
             imageUrls = listOf("test image url"),
             description = "test description",
             shelfId = null,
-            createdAt = ""
+            createdAt = "",
+            isFavorite = false
         )
 
         val cartItem = productCart.toUiState()

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/createProduct/CreateProductViewModelTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/createProduct/CreateProductViewModelTest.kt
@@ -351,7 +351,8 @@ private fun fakeProducts(): List<Product> = listOf(
         shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000123"),
         imageUrls = emptyList(),
         createdAt = "2025-10-10T12:00:00Z",
-        quantityInCart = 2
+        quantityInCart = 2,
+        isFavorite = false
     )
 )
 

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/dukanCart/DukanCartMapperTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/dukanCart/DukanCartMapperTest.kt
@@ -20,7 +20,8 @@ class DukanCartMapperTest {
             imageUrls = listOf("headphones.png"),
             quantityInCart = 2,
             createdAt = "2023-01-01",
-            shelfId = null
+            shelfId = null,
+            isFavorite = false
         )
 
         val uiState = product.toUiState()
@@ -43,7 +44,8 @@ class DukanCartMapperTest {
             imageUrls = emptyList(),
             quantityInCart = 1,
             createdAt = "2023-01-01",
-            shelfId = null
+            shelfId = null,
+            isFavorite = false
         )
 
         val uiState = product.toUiState()

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/dukanCart/DukanCartViewModelTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/dukanCart/DukanCartViewModelTest.kt
@@ -82,7 +82,8 @@ class DukanCartViewModelTest {
         imageUrls = listOf("phone.png"),
         createdAt = "2025-10-10T12:00:00Z",
         quantityInCart = 2,
-        shelfId = null
+        shelfId = null,
+        isFavorite = false
     )
 
     private fun dummyPagedProducts() = PagedResult(

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/dukanDetails/DukanDetailsViewModelTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/dukanDetails/DukanDetailsViewModelTest.kt
@@ -479,5 +479,6 @@ private fun fakeProducts(): List<Product> = listOf(
         createdAt = "2025-10-10T12:00:00Z",
         quantityInCart = 10,
         shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000123"),
+        isFavorite = false
     )
 )

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/dukanDetails/Mapper.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/dukanDetails/Mapper.kt
@@ -60,7 +60,8 @@ class DukanDetailsMapperTest {
             imageUrls = listOf("img.png"),
             quantityInCart = 0,
             createdAt = "2023-01-01",
-            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000124")
+            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000124"),
+            isFavorite = false
         )
 
         val uiState = product.toUiState()
@@ -82,7 +83,8 @@ class DukanDetailsMapperTest {
             imageUrls = listOf("laptop.png"),
             quantityInCart = 3,
             createdAt = "2023-01-01",
-            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000124")
+            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000124"),
+            isFavorite = false
         )
 
         val uiState = product.toUiState()

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/editProduct/EditProductViewModelTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/editProduct/EditProductViewModelTest.kt
@@ -1499,6 +1499,7 @@ private fun fakeProduct(): Product {
         imageUrls = listOf("image1.jpg", "image2.jpg"),
         createdAt = "2025-09-16T15:06:57.507394",
         quantityInCart = 4,
+        isFavorite = false
     )
 }
 

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/manageDukan/ManageDukanViewModelTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/manageDukan/ManageDukanViewModelTest.kt
@@ -671,7 +671,8 @@ private fun fakeProducts(): List<Product> {
             createdAt = "2023-08-01T10:00:00Z",
             imageUrls = listOf("https://example.com/iphone.jpg"),
             quantityInCart = 10,
-            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000123")
+            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000123"),
+            isFavorite = false
         ),
         Product(
             id = Uuid.random(),
@@ -682,6 +683,7 @@ private fun fakeProducts(): List<Product> {
             createdAt = "2023-08-01T10:00:00Z",
             quantityInCart = 10,
             shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000124"),
+            isFavorite = false
         ),
         Product(
             id = Uuid.random(),
@@ -692,6 +694,7 @@ private fun fakeProducts(): List<Product> {
             imageUrls = listOf("https://example.com/tshirt.jpg"),
             quantityInCart = 20,
             shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000125"),
+            isFavorite = false
         )
     )
 }

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/Mapper.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/Mapper.kt
@@ -22,7 +22,8 @@ class ProductDetailsMapperTest {
             imageUrls = listOf("image.png"),
             quantityInCart = 0,
             createdAt = "2023-01-01",
-            shelfId = null
+            shelfId = null,
+            isFavorite = false
         )
 
         val uiState = product.toUiState()

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModelTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModelTest.kt
@@ -17,7 +17,10 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import mena.dukan_presentation.generated.resources.Res
+import mena.dukan_presentation.generated.resources.added_to_favorites
+import mena.dukan_presentation.generated.resources.error_updating_favorites
 import mena.dukan_presentation.generated.resources.no_internet_connection
+import mena.dukan_presentation.generated.resources.removed_from_favorites
 import net.thechance.mena.dukan.domain.entity.Product
 import net.thechance.mena.dukan.domain.exceptions.NoInternetException
 import net.thechance.mena.dukan.domain.repository.CartRepository
@@ -241,7 +244,7 @@ class ProductDetailsViewModelTest {
             verifySuspend {
                 dukanCartRepository.updateProductQuantity(any())
             }
-            assertTrue (productDetailsViewModel.state.value.snackBarState!=null)
+            assertTrue(productDetailsViewModel.state.value.snackBarState != null)
 
 
         }
@@ -266,7 +269,7 @@ class ProductDetailsViewModelTest {
             verifySuspend {
                 dukanCartRepository.addProductQuantity(any())
             }
-            assertTrue (productDetailsViewModel.state.value.snackBarState!=null)
+            assertTrue(productDetailsViewModel.state.value.snackBarState != null)
 
         }
 
@@ -281,21 +284,221 @@ class ProductDetailsViewModelTest {
     }
 
     @Test
-    fun `onErrorUpdateProductQuantity SHOULD show error snackbar when NoInternetException thrown`() = runTest {
-        // Given
-        val productId = "1"
+    fun `onErrorUpdateProductQuantity SHOULD show error snackbar when NoInternetException thrown`() =
+        runTest {
+            // Given
+            val productId = "1"
 
-        everySuspend { dukanCartRepository.updateProductQuantity(any()) } throws NoInternetException()
+            everySuspend { dukanCartRepository.updateProductQuantity(any()) } throws NoInternetException()
+
+            // When
+            productDetailsViewModel.onAddToCartClicked(productId)
+            advanceUntilIdle()
+
+            // Then
+            val state = productDetailsViewModel.state.value
+            assertEquals(Res.string.no_internet_connection, state.snackBarState?.message)
+            assertEquals(SnackBarType.ERROR, state.snackBarState?.snackBarType)
+        }
+
+    @OptIn(ExperimentalUuidApi::class)
+    private val testProductId = dummyProductDetails().id.toString()
+
+
+    @OptIn(ExperimentalUuidApi::class)
+    @Test
+    fun `onToggleProductToFavoriteClicked_whenAddingToFavorites_SHOULD callRepository`() = runTest {
+        // Given
+        productDetailsViewModel.updateState { copy(isFavorite = false) }
+        everySuspend { productRepository.toggleProductToFavorites(testProductId) } returns Unit
 
         // When
-        productDetailsViewModel.onAddToCartClicked(productId)
+        productDetailsViewModel.onToggleProductToFavoriteClicked()
+        advanceUntilIdle()
+
+        // Then
+        verifySuspend { productRepository.toggleProductToFavorites(testProductId) }
+    }
+
+    @Test
+    fun `onToggleProductToFavoriteClicked_whenAddingToFavorites_SHOULD updateStateToTrue`() =
+        runTest {
+            // Given
+            productDetailsViewModel.updateState { copy(isFavorite = false) }
+            everySuspend { productRepository.toggleProductToFavorites(any()) } returns Unit
+
+            // When
+            productDetailsViewModel.onToggleProductToFavoriteClicked()
+            advanceUntilIdle()
+
+            // Then
+            val state = productDetailsViewModel.state.value
+            assertTrue(state.isFavorite)
+        }
+
+    @Test
+    fun `onToggleProductToFavoriteClicked_whenAddingToFavorites_SHOULD showSuccessMessage`() =
+        runTest {
+            // Given
+            productDetailsViewModel.updateState { copy(isFavorite = false) }
+            everySuspend { productRepository.toggleProductToFavorites(any()) } returns Unit
+
+            // When
+            productDetailsViewModel.onToggleProductToFavoriteClicked()
+            advanceUntilIdle()
+
+            // Then
+            val state = productDetailsViewModel.state.value
+            assertEquals(Res.string.added_to_favorites, state.snackBarState?.message)
+        }
+
+    @Test
+    fun `onToggleProductToFavoriteClicked_whenAddingToFavorites_SHOULD showSuccessSnackBarType`() =
+        runTest {
+            // Given
+            productDetailsViewModel.updateState { copy(isFavorite = false) }
+            everySuspend { productRepository.toggleProductToFavorites(any()) } returns Unit
+
+            // When
+            productDetailsViewModel.onToggleProductToFavoriteClicked()
+            advanceUntilIdle()
+
+            // Then
+            val state = productDetailsViewModel.state.value
+            assertEquals(SnackBarType.SUCCESS, state.snackBarState?.snackBarType)
+        }
+
+
+    @OptIn(ExperimentalUuidApi::class)
+    @Test
+    fun `onToggleProductToFavoriteClicked_whenRemovingFromFavorites_SHOULD callRepository`() =
+        runTest {
+            // Given
+            productDetailsViewModel.updateState { copy(isFavorite = true) }
+            everySuspend { productRepository.toggleProductToFavorites(testProductId) } returns Unit
+
+            // When
+            productDetailsViewModel.onToggleProductToFavoriteClicked()
+            advanceUntilIdle()
+
+            // Then
+            verifySuspend { productRepository.toggleProductToFavorites(testProductId) }
+        }
+
+    @Test
+    fun `onToggleProductToFavoriteClicked_whenRemovingFromFavorites_SHOULD updateStateToFalse`() =
+        runTest {
+            // Given
+            productDetailsViewModel.updateState { copy(isFavorite = true) }
+            everySuspend { productRepository.toggleProductToFavorites(any()) } returns Unit
+
+            // When
+            productDetailsViewModel.onToggleProductToFavoriteClicked()
+            advanceUntilIdle()
+
+            // Then
+            val state = productDetailsViewModel.state.value
+            assertFalse(state.isFavorite)
+        }
+
+    @Test
+    fun `onToggleProductToFavoriteClicked_whenRemovingFromFavorites_SHOULD showRemovedMessage`() =
+        runTest {
+            // Given
+            productDetailsViewModel.updateState { copy(isFavorite = true) }
+            everySuspend { productRepository.toggleProductToFavorites(any()) } returns Unit
+
+            // When
+            productDetailsViewModel.onToggleProductToFavoriteClicked()
+            advanceUntilIdle()
+
+            // Then
+            val state = productDetailsViewModel.state.value
+            assertEquals(Res.string.removed_from_favorites, state.snackBarState?.message)
+        }
+
+    @Test
+    fun `onToggleProductToFavoriteClicked_whenRemovingFromFavorites_SHOULD showSuccessSnackBarType`() =
+        runTest {
+            // Given
+            productDetailsViewModel.updateState { copy(isFavorite = true) }
+            everySuspend { productRepository.toggleProductToFavorites(any()) } returns Unit
+
+            // When
+            productDetailsViewModel.onToggleProductToFavoriteClicked()
+            advanceUntilIdle()
+
+            // Then
+            val state = productDetailsViewModel.state.value
+            assertEquals(SnackBarType.SUCCESS, state.snackBarState?.snackBarType)
+        }
+
+
+    @OptIn(ExperimentalUuidApi::class)
+    @Test
+    fun `onToggleProductToFavoriteClicked_whenErrorOccurs_SHOULD callRepository`() = runTest {
+        // Given
+        val networkError = NoInternetException()
+        productDetailsViewModel.updateState { copy(isFavorite = false) }
+        everySuspend { productRepository.toggleProductToFavorites(testProductId) } throws networkError
+
+        // When
+        productDetailsViewModel.onToggleProductToFavoriteClicked()
+        advanceUntilIdle()
+
+        // Then
+        verifySuspend { productRepository.toggleProductToFavorites(testProductId) }
+    }
+
+    @Test
+    fun `onToggleProductToFavoriteClicked_whenErrorOccurs_SHOULD notChangeFavoriteState`() =
+        runTest {
+            // Given
+            val networkError = NoInternetException()
+            productDetailsViewModel.updateState { copy(isFavorite = false) }
+            everySuspend { productRepository.toggleProductToFavorites(any()) } throws networkError
+
+            // When
+            productDetailsViewModel.onToggleProductToFavoriteClicked()
+            advanceUntilIdle()
+
+            // Then
+            val state = productDetailsViewModel.state.value
+            assertFalse(state.isFavorite)
+        }
+
+    @Test
+    fun `onToggleProductToFavoriteClicked_whenErrorOccurs_SHOULD showErrorMessage`() = runTest {
+        // Given
+        val networkError = NoInternetException()
+        productDetailsViewModel.updateState { copy(isFavorite = false) }
+        everySuspend { productRepository.toggleProductToFavorites(any()) } throws networkError
+
+        // When
+        productDetailsViewModel.onToggleProductToFavoriteClicked()
         advanceUntilIdle()
 
         // Then
         val state = productDetailsViewModel.state.value
-        assertEquals(Res.string.no_internet_connection, state.snackBarState?.message)
-        assertEquals(SnackBarType.ERROR, state.snackBarState?.snackBarType)
+        assertEquals(Res.string.error_updating_favorites, state.snackBarState?.message)
     }
+
+    @Test
+    fun `onToggleProductToFavoriteClicked_whenErrorOccurs_SHOULD showErrorSnackBarType`() =
+        runTest {
+            // Given
+            val networkError = NoInternetException()
+            productDetailsViewModel.updateState { copy(isFavorite = false) }
+            everySuspend { productRepository.toggleProductToFavorites(any()) } throws networkError
+
+            // When
+            productDetailsViewModel.onToggleProductToFavoriteClicked()
+            advanceUntilIdle()
+
+            // Then
+            val state = productDetailsViewModel.state.value
+            assertEquals(SnackBarType.ERROR, state.snackBarState?.snackBarType)
+        }
 
     private fun createViewModel() = ProductDetailsViewModel(
         productRepository = productRepository,
@@ -318,5 +521,6 @@ private fun dummyProductDetails(): Product = Product(
     ),
     createdAt = "2025-10-31T12:00:00Z",
     quantityInCart = 10,
-    shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000124")
-    )
+    shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000124"),
+    isFavorite = false
+)

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/shelfDetails/Mapper.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/shelfDetails/Mapper.kt
@@ -21,7 +21,8 @@ class ShelfDetailsMapperTest {
             imageUrls = listOf("image.png"),
             quantityInCart = 0,
             createdAt = "2023-01-01",
-            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000124")
+            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000124"),
+            isFavorite = false
         )
 
         val uiState = product.toUiState()
@@ -43,7 +44,8 @@ class ShelfDetailsMapperTest {
             imageUrls = listOf("img.jpg"),
             quantityInCart = 3,
             createdAt = "2023-01-01",
-            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000124")
+            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000124"),
+            isFavorite = false
         )
 
         val uiState = product.toUiState()

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/shelfDetails/ShelfDetailsViewModelTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/shelfDetails/ShelfDetailsViewModelTest.kt
@@ -60,7 +60,8 @@ class ShelfDetailsViewModelTest {
             imageUrls = listOf("https://example.com/laptop.jpg"),
             createdAt = "",
             quantityInCart = 10,
-            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000123")
+            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000123"),
+            isFavorite = false
             ),
         Product(
             id = Uuid.parse("4b8f1a92-9d2c-4bde-91ab-5c812dbb4a62"),
@@ -70,7 +71,8 @@ class ShelfDetailsViewModelTest {
             imageUrls = listOf("https://example.com/mouse.jpg"),
             createdAt = "",
             quantityInCart = 10,
-            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000124")
+            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000124"),
+            isFavorite = false
             ),
         Product(
             id = Uuid.parse("a17e3c45-2fd4-4c1d-bb4a-2d5a3c739ef1"),
@@ -80,7 +82,8 @@ class ShelfDetailsViewModelTest {
             imageUrls = listOf("https://example.com/keyboard.jpg"),
             createdAt = "",
             quantityInCart = 10,
-            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000125")
+            shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000125"),
+            isFavorite = false
             )
     )
 


### PR DESCRIPTION
### Feat: Implement "Add to Favorites" on Product Details

This PR introduces the "Add to Favorites" functionality on the product details screen. Users can now tap the heart icon in the app bar to save or remove a product from their favorites.

**What was done:**

* **UI:**
    * The favorite icon (`ic_favorite`) in the `ProductDetailsAppBar` is now functional.
    * The icon's tint dynamically changes based on whether the product is in the user's favorites.
* **State & ViewModel:**
    * Updated `ProductDetailsUiState` and `ProductDetailsViewModel` to manage the `isFavorite` state.
    * Added logic to show a success/error snackbar (e.g., "Added to favorites") when the button is clicked.
* **Repository & Data:**
    * Added `toggleProductToFavorites(productId: String)` to the `ProductRepository` and `DukanProductRepositoryImpl` to call the `POST .../favorite` endpoint.
    * Updated the `Product` (domain) and `ProductDto` (data) models to include the `isFavorite: Boolean` field, aligning the app with the API response.
* **Testing:**
    * Added unit tests for the new ViewModel logic in `ProductDetailsViewModelTest`.
    * Added unit tests for the `isFavorite` field in `ProductMapperKtTest`.
    * Added unit tests for the new repository function in `DukanProductRepositoryImplTest`.