### PR TITLE
Feature/TRN 104 Fix Publish Trend Navigation

### DIFF
--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishScreen.kt
@@ -55,7 +55,6 @@ internal fun CategoryPublishScreen(
             is CategoryPublishEffect.NavigateBack -> navController.popBackStack()
             is CategoryPublishEffect.NavigateToHome -> navController.navigate(Route.Home) {
                 popUpTo(Route.Home)
-                launchSingleTop = true
             }
         }
     }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishScreen.kt
@@ -54,7 +54,8 @@ internal fun CategoryPublishScreen(
         when (effect) {
             is CategoryPublishEffect.NavigateBack -> navController.popBackStack()
             is CategoryPublishEffect.NavigateToHome -> navController.navigate(Route.Home) {
-                popUpTo(Route.MainContainer)
+                popUpTo(Route.Home)
+                launchSingleTop = true
             }
         }
     }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
@@ -1,5 +1,7 @@
 package net.thechance.mena.trends.presentation.screen.home
 
+import androidx.compose.animation.AnimatedVisibility
+import app.cash.paging.compose.itemKey
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -133,7 +135,7 @@ private fun HomeScreenContent(
                         onClickLike = listener::onClickLike,
                         onClickReel = listener::onClickReel,
                         onExpandDescription = listener::onClickExpandDescription,
-                        listState = listState,
+                        listState = listState
                     )
                 }
             )
@@ -174,11 +176,9 @@ private fun ReelsListSection(
     onExpandDescription: (reelId: String) -> Unit
 ) {
     LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = Theme.spacing._16),
+        modifier = Modifier.fillMaxSize(),
         state = listState,
-        contentPadding = PaddingValues(vertical = Theme.spacing._8),
+        contentPadding = PaddingValues(vertical = Theme.spacing._8,horizontal = Theme.spacing._16),
         verticalArrangement = Arrangement.spacedBy(Theme.spacing._16)
     ) {
         items(


### PR DESCRIPTION
### What I did in this PR: 
- Improved back stack cleanup by correctly applying popUpTo with inclusive = true.
- Fixed issue where the default overscroll glow (scroll edge effect) was not visible in the Reels feed due to padding applied on the LazyColumn.

### Preview 

https://github.com/user-attachments/assets/c46aa43a-7e30-4e7b-a81f-14aab9e6b2ec

