### PR TITLE
fix: update and delete profile image

### DIFF
--- a/identity_data/src/androidUnitTest/kotlin/net/thechance/mena/identity/data/repository/UserRepositoryImplTest.kt
+++ b/identity_data/src/androidUnitTest/kotlin/net/thechance/mena/identity/data/repository/UserRepositoryImplTest.kt
@@ -30,14 +30,12 @@ import net.thechance.mena.identity.data.utils.mockHttpClient
 import net.thechance.mena.identity.data.utils.mockHttpClientError
 import net.thechance.mena.identity.domain.entity.Gender
 import net.thechance.mena.identity.domain.entity.User
-import net.thechance.mena.identity.domain.exception.AuthenticationException
 import net.thechance.mena.identity.domain.exception.InvalidRequestException
 import net.thechance.mena.identity.domain.exception.UnAuthorizedException
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.test.fail
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -156,7 +154,7 @@ UserRepositoryImplTest {
     fun `updateUser() should call upsert user when try to update user`() = runTest {
         val client = mockHttpClient(fakeProfileResponse)
         userRepositoryImpl = UserRepositoryImpl(client, userDao )
-        userRepositoryImpl.updateUser(fakeUser, false)
+        userRepositoryImpl.updateUser(fakeUser)
         coVerify { userDao.upsert(any()) }
     }
 

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/identityDataModule.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/identityDataModule.kt
@@ -32,6 +32,7 @@ import org.koin.dsl.bind
 import org.koin.dsl.module
 
 private const val IDENTITY_CLIENT = "IdentityClient"
+private const val COIL_CLIENT = "CoilClient"
 private const val BASE_URL = "baseUrl"
 
 expect val IdentityPlatformModule: Module
@@ -63,12 +64,16 @@ val identityDataModule = module {
     singleOf(::ImagesRepositoryImpl) bind ImagesRepository::class
     singleOf(::AuthorizationService)
     single(named(IDENTITY_CLIENT)) {
-        provideHttpClient(
+        provideCoilClient(
             engine = get(),
             baseUrl = get<String>(named(BASE_URL)),
             settings = get(),
             refreshToken = { get<AuthorizationService>().refreshToken() }
         )
+    }
+
+    single(named(COIL_CLIENT)) {
+        provideCoilClient(engine = get())
     }
 
     single { provideDatabaseBuilder() }

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/provideHttpClient.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/provideHttpClient.kt
@@ -23,8 +23,11 @@ import net.thechance.mena.identity.data.repository.ResetPasswordRepositoryImpl.C
 import net.thechance.mena.identity.data.repository.ResetPasswordRepositoryImpl.Companion.RESET_PASSWORD
 import net.thechance.mena.identity.data.repository.ResetPasswordRepositoryImpl.Companion.VERIFY_OTP
 
-internal fun provideHttpClient(
-    engine: HttpClientEngine, settings: Settings, baseUrl: String, refreshToken: suspend () -> Unit
+internal fun provideCoilClient(
+    engine: HttpClientEngine,
+    settings: Settings,
+    baseUrl: String,
+    refreshToken: suspend () -> Unit
 ): HttpClient {
     return HttpClient(engine) {
         defaultRequest { url(baseUrl) }
@@ -50,7 +53,7 @@ internal fun provideHttpClient(
                 }
                 sendWithoutRequest { request ->
                     val path = request.url.encodedPath.removePrefix("/")
-                    path !in whiteListEndPoints || path in whitelistPicture
+                    path !in whiteListEndPoints
                 }
             }
         }
@@ -61,11 +64,16 @@ internal fun provideHttpClient(
     }
 }
 
+internal fun provideCoilClient(engine: HttpClientEngine): HttpClient {
+    return HttpClient(engine) {
+        install(HttpTimeout) {
+            connectTimeoutMillis = NETWORK_TIMEOUT_MS
+            requestTimeoutMillis = NETWORK_TIMEOUT_MS
+        }
+    }
+}
+
 const val NETWORK_TIMEOUT_MS = 15_000L
 private val whiteListEndPoints = listOf(
     LOGIN_ENDPOINT, REFRESH_ENDPOINT, REQUEST_OTP, VERIFY_OTP, RESET_PASSWORD
-)
-
-private val whitelistPicture = listOf(
-    "i.pinimg.com", "cdn.marketplaceevents.com", "wallpapers.com"
 )

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/dto/profile/request/UpdateProfileRequestDto.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/dto/profile/request/UpdateProfileRequestDto.kt
@@ -16,7 +16,5 @@ data class UpdateProfileRequestDto(
     @SerialName("birthDate")
     val birthDate: String,
     @SerialName("gender")
-    val gender: Int,
-    @SerialName("updateImage")
-    val updateImage: Boolean,
+    val gender: Int
 )

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/repository/UserRepositoryImpl.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/repository/UserRepositoryImpl.kt
@@ -2,19 +2,19 @@ package net.thechance.mena.identity.data.repository
 
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import net.thechance.mena.identity.data.dataSource.local.database.dao.UserDao
 import net.thechance.mena.identity.data.dataSource.local.database.model.UserEntity
 import net.thechance.mena.identity.data.dto.profile.request.ChangePasswordRequestDto
-import net.thechance.mena.identity.data.dto.profile.response.ProfileResponseDto
 import net.thechance.mena.identity.data.dto.profile.request.UpdateProfileRequestDto
 import net.thechance.mena.identity.data.dto.profile.response.ChangePasswordResponseDto
+import net.thechance.mena.identity.data.dto.profile.response.ProfileResponseDto
 import net.thechance.mena.identity.data.mapper.toDomain
 import net.thechance.mena.identity.data.mapper.toEntity
 import net.thechance.mena.identity.data.utils.deleteJson
@@ -26,7 +26,6 @@ import net.thechance.mena.identity.data.utils.safeWrapper
 import net.thechance.mena.identity.domain.entity.Gender
 import net.thechance.mena.identity.domain.entity.User
 import net.thechance.mena.identity.domain.repository.UserRepository
-import kotlin.uuid.ExperimentalUuidApi
 
 
 class UserRepositoryImpl(
@@ -35,31 +34,28 @@ class UserRepositoryImpl(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : UserRepository {
     override suspend fun getUser(): Flow<User?> {
-        CoroutineScope(dispatcher).launch {
-            try {
-                val user: ProfileResponseDto = client.getJson(path = PROFILE)
-                userDao.upsert(user.toEntity())
-            } catch (_: Exception) {
-
+        return withContext(dispatcher) {
+            launch {
+                try {
+                    val user: ProfileResponseDto = client.getJson(path = PROFILE)
+                    userDao.upsert(user.toEntity())
+                } catch (_: Exception) {
+                }
             }
+
+            userDao.getUser()
+                .map { userEntity ->
+                    userEntity?.toDomain()
+                }
+                .flowOn(dispatcher)
         }
-
-        return userDao.getUser()
-            .map { userEntity ->
-                userEntity?.toDomain()
-            }
-            .flowOn(Dispatchers.IO)
     }
 
-    @OptIn(ExperimentalUuidApi::class)
-    override suspend fun updateUser(
-        user: User,
-        shouldUpdateImage: Boolean,
-    ) {
+    override suspend fun updateUser(user: User) {
         return safeWrapper {
             val user: ProfileResponseDto = client.postJson(
                 path = PROFILE,
-                requestDto = user.toRequest(shouldUpdateImage),
+                requestDto = user.toRequest(),
             )
             userDao.upsert(user.toEntity())
         }
@@ -99,7 +95,7 @@ class UserRepositoryImpl(
 
     }
 
-    fun User.toRequest(shouldUpdateImage: Boolean): UpdateProfileRequestDto {
+    fun User.toRequest(): UpdateProfileRequestDto {
         return UpdateProfileRequestDto(
             firstName = this.firstName,
             lastName = this.lastName,
@@ -109,8 +105,7 @@ class UserRepositoryImpl(
             gender = when (this.gender) {
                 Gender.MALE -> UserEntity.MALE
                 else -> UserEntity.FEMALE
-            },
-            updateImage = shouldUpdateImage
+            }
         )
     }
 

--- a/identity_domain/src/commonMain/kotlin/net/thechance/mena/identity/domain/repository/UserRepository.kt
+++ b/identity_domain/src/commonMain/kotlin/net/thechance/mena/identity/domain/repository/UserRepository.kt
@@ -5,7 +5,7 @@ import net.thechance.mena.identity.domain.entity.User
 
 interface UserRepository {
     suspend fun getUser(): Flow<User?>
-    suspend fun updateUser(user: User, shouldUpdateImage: Boolean)
+    suspend fun updateUser(user: User)
     suspend fun uploadUserProfileImage(imageByteArray: ByteArray?)
     suspend fun deleteUserProfileImage()
     suspend fun changePassword(

--- a/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileViewModelTest.kt
+++ b/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileViewModelTest.kt
@@ -168,10 +168,7 @@ class EditUserProfileViewModelTest() : BaseCoroutineTest() {
             coEvery { userRepository.uploadUserProfileImage(any()) } returns Unit
             coEvery { userRepository.deleteUserProfileImage() } returns Unit
             coEvery {
-                userRepository.updateUser(
-                    user = any(),
-                    shouldUpdateImage = any()
-                )
+                userRepository.updateUser(user = any())
             } returns Unit
 
             viewModel.onChangeFirstName("new User")
@@ -186,10 +183,7 @@ class EditUserProfileViewModelTest() : BaseCoroutineTest() {
             }
 
             coVerify(exactly = 1) {
-                userRepository.updateUser(
-                    user = any(),
-                    shouldUpdateImage = any()
-                )
+                userRepository.updateUser(user = any())
             }
         }
 
@@ -202,10 +196,7 @@ class EditUserProfileViewModelTest() : BaseCoroutineTest() {
             coEvery { userRepository.deleteUserProfileImage() } returns Unit
 
             coEvery {
-                userRepository.updateUser(
-                    user = any(),
-                    shouldUpdateImage = any()
-                )
+                userRepository.updateUser(user = any())
             } throws Exception()
 
             viewModel.onChangeFirstName("new User")
@@ -220,10 +211,7 @@ class EditUserProfileViewModelTest() : BaseCoroutineTest() {
             }
 
             coVerify(exactly = 1) {
-                userRepository.updateUser(
-                    user = any(),
-                    shouldUpdateImage = any()
-                )
+                userRepository.updateUser(user = any())
             }
         }
 

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileUIState.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileUIState.kt
@@ -4,9 +4,8 @@ import androidx.compose.ui.graphics.ImageBitmap
 import kotlinx.datetime.LocalDate
 import net.thechance.mena.identity.domain.entity.Gender
 import org.jetbrains.compose.resources.StringResource
-import kotlin.uuid.ExperimentalUuidApi
 
-data class EditUserProfileUIState @OptIn(ExperimentalUuidApi::class) constructor(
+data class EditUserProfileUIState(
     val username: String = "",
     val firstName: String = "",
     val lastName: String = "",
@@ -20,5 +19,11 @@ data class EditUserProfileUIState @OptIn(ExperimentalUuidApi::class) constructor
     val isLoading: Boolean = false,
     val isSuccess: Boolean = false,
     val errorMessage: StringResource? = null,
-    val shouldUpdateImage: Boolean = false,
-)
+    val profileImageAction: ProfileImageAction = ProfileImageAction.NONE,
+) {
+    enum class ProfileImageAction {
+        UPDATE,
+        DELETE,
+        NONE
+    }
+}

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileViewModel.kt
@@ -69,10 +69,6 @@ class EditUserProfileViewModel(
         }
     }
 
-    private fun onGetUserInfoError(throwable: Throwable) {
-        updateState { copy(errorMessage = mapErrorMessage(throwable)) }
-    }
-
     override fun onChangeFirstName(firstName: String) {
         updateState { copy(firstName = firstName) }
     }
@@ -99,6 +95,65 @@ class EditUserProfileViewModel(
             onError = ::handleSaveError,
             dispatcher = dispatcher
         )
+    }
+
+    override fun onClickCancelButton() {
+        sendNewEffect(EditUserProfileUIEffect.NavigateBackToProfile)
+    }
+
+    override fun onClickShowLogoutOptions() {
+        updateState { copy(showLogoutDialog = true) }
+    }
+
+    override fun onChangeDate(day: Int, month: Int, year: Int) {
+        updateState { copy(birthDate = LocalDate(year, month, day)) }
+    }
+
+    override fun clearErrorMessage() {
+        updateState { copy(errorMessage = null) }
+    }
+
+    override fun onClickEditImage() {
+        updateState { copy(showEditImageDialog = true) }
+    }
+
+    override fun onDismissEditImageDialog() {
+        updateState { copy(showEditImageDialog = false) }
+    }
+
+    override fun onDismissLogoutDialog() {
+        updateState { copy(showLogoutDialog = false) }
+    }
+
+    override fun onRemoveProfileImage() {
+        updateState {
+            copy(
+                profileImageUrl = "",
+                profileImageBitmap = null,
+                profileImageAction = EditUserProfileUIState.ProfileImageAction.DELETE
+            )
+        }
+    }
+
+    override fun onRequireCropImage(imageBitmap: ImageBitmap) {
+        cacheRequiredCropImage(imageBitmap)
+    }
+
+    override fun onOpenCamera() {
+        updateState { copy(showCamera = false) }
+    }
+
+    override fun onTakeImageFromCamera() {
+        tryToExecute(
+            function = ::requestCameraPermission,
+            onSuccess = { onCameraPermissionSuccess() },
+            onError = ::handleCameraPermissionError,
+            dispatcher = dispatcher
+        )
+    }
+
+    private fun onGetUserInfoError(throwable: Throwable) {
+        updateState { copy(errorMessage = mapErrorMessage(throwable)) }
     }
 
     private fun validateFormInputs(): Boolean {
@@ -140,17 +195,28 @@ class EditUserProfileViewModel(
             birthDate = value.birthDate ?: getCurrentDate(),
             gender = value.gender,
         )
+        updateProfileImage()
+        userRepository.updateUser(user = user)
+    }
 
-        value.profileImageBitmap?.let {
-            userRepository.uploadUserProfileImage(
-                imageByteArray = imageDecoder.encodeImage(it)
-            )
+    private suspend fun updateProfileImage() {
+        val imageBitmap = state.value.profileImageBitmap
+        val action = state.value.profileImageAction
+        when (action) {
+            EditUserProfileUIState.ProfileImageAction.UPDATE -> {
+                imageBitmap?.let {
+                    userRepository.uploadUserProfileImage(
+                        imageByteArray = imageDecoder.encodeImage(it)
+                    )
+                }
+            }
+
+            EditUserProfileUIState.ProfileImageAction.DELETE -> {
+                userRepository.deleteUserProfileImage()
+            }
+
+            EditUserProfileUIState.ProfileImageAction.NONE -> Unit
         }
-
-        userRepository.updateUser(
-            user = user,
-            shouldUpdateImage = value.shouldUpdateImage,
-        )
     }
 
     private fun handleSaveSuccess() {
@@ -160,47 +226,6 @@ class EditUserProfileViewModel(
 
     private fun handleSaveError(throwable: Throwable) {
         updateState { copy(isLoading = false, errorMessage = mapErrorMessage(throwable)) }
-    }
-
-    override fun onClickCancelButton() {
-        sendNewEffect(EditUserProfileUIEffect.NavigateBackToProfile)
-    }
-
-    override fun onClickShowLogoutOptions() {
-        updateState { copy(showLogoutDialog = true) }
-    }
-
-    override fun onChangeDate(day: Int, month: Int, year: Int) {
-        updateState { copy(birthDate = LocalDate(year, month, day)) }
-    }
-
-    override fun clearErrorMessage() {
-        updateState { copy(errorMessage = null) }
-    }
-
-    override fun onClickEditImage() {
-        updateState { copy(showEditImageDialog = true) }
-    }
-
-    override fun onDismissEditImageDialog() {
-        updateState { copy(showEditImageDialog = false) }
-    }
-
-    override fun onDismissLogoutDialog() {
-        updateState { copy(showLogoutDialog = false) }
-    }
-
-    override fun onRemoveProfileImage() {
-        updateState {
-            copy(
-                profileImageUrl = "",
-                profileImageBitmap = null,
-            )
-        }
-    }
-
-    override fun onRequireCropImage(imageBitmap: ImageBitmap) {
-        cacheRequiredCropImage(imageBitmap)
     }
 
     private fun cacheRequiredCropImage(imageBitmap: ImageBitmap) {
@@ -226,7 +251,7 @@ class EditUserProfileViewModel(
                     updateState {
                         copy(
                             profileImageBitmap = imageByteArray?.let { imageDecoder.decodeImage(it) },
-                            shouldUpdateImage = true
+                            profileImageAction = EditUserProfileUIState.ProfileImageAction.UPDATE
                         )
                     }
                 }
@@ -237,15 +262,6 @@ class EditUserProfileViewModel(
 
     private fun onCacheCropImageError(throwable: Throwable) {
         updateState { copy(errorMessage = mapErrorMessage(throwable)) }
-    }
-
-    override fun onTakeImageFromCamera() {
-        tryToExecute(
-            function = ::requestCameraPermission,
-            onSuccess = { onCameraPermissionSuccess() },
-            onError = ::handleCameraPermissionError,
-            dispatcher = dispatcher
-        )
     }
 
     private suspend fun requestCameraPermission() {
@@ -270,10 +286,6 @@ class EditUserProfileViewModel(
 
             else -> updateState { copy(errorMessage = mapErrorMessage(throwable)) }
         }
-    }
-
-    override fun onOpenCamera() {
-        updateState { copy(showCamera = false) }
     }
 
     private fun mapErrorMessage(throwable: Throwable): StringResource {

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/components/EditProfileImage.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/components/EditProfileImage.kt
@@ -26,7 +26,6 @@ import coil3.ImageLoader
 import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.network.ktor3.KtorNetworkFetcherFactory
-import coil3.svg.SvgDecoder
 import io.ktor.client.HttpClient
 import mena.identity_presentation.generated.resources.Res
 import mena.identity_presentation.generated.resources.not_user_image
@@ -93,14 +92,15 @@ fun EditProfileImage(
 }
 
 @Composable
-fun AsyncProfileImage(imageUrl: String) {
-    val networkClient = koinInject<HttpClient>(named("IdentityClient"))
+fun AsyncProfileImage(
+    imageUrl: String,
+    networkClient: HttpClient = koinInject<HttpClient>(named("CoilClient"))
+) {
     SubcomposeAsyncImage(
         model = imageUrl,
         imageLoader = ImageLoader.Builder(LocalPlatformContext.current)
             .components {
                 add(KtorNetworkFetcherFactory(networkClient))
-                add(SvgDecoder.Factory())
             }.build(),
         contentScale = ContentScale.Crop,
         contentDescription = stringResource(Res.string.profile_profile_picture_content_description),


### PR DESCRIPTION
## PR Scope
Fix bug in edit, add, update and delete profile image

## Changes
- Add ProfileImageAction in edit profile state to control whether user needs to update or delete profile image
- Add HttpClient specific for coil to work with ios and android

## Video

https://github.com/user-attachments/assets/2409961c-89cc-4bc5-b34c-c67475e1c8d5

