### PR TITLE
Fix/IDN-117 fix phone mask to support RTL

### DIFF
--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/PhoneNumberInput.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/PhoneNumberInput.kt
@@ -55,8 +55,8 @@ internal fun PhoneNumberInput(
 }
 
 private val defaultPhoneMasks = mapOf(
-    8 to "## ### ###",
-    9 to "### ### ###",
-    10 to "### ### ####",
-    11 to "#### #### ###",
+    8 to "##\u00A0###\u00A0###",
+    9 to "###\u00A0###\u00A0###",
+    10 to "###\u00A0###\u00A0####",
+    11 to "####\u00A0####\u00A0###",
 )


### PR DESCRIPTION
Fixed phone mask by adding unicode `00A0` to be able to view right number in RTL

Tested loging and everything works

<table>
  <tr>
    <th>
Before
    </th>
    <th>
After
    </th>
    </tr>
  <tr>
    <td>
<img width="1080" height="2280" alt="Screenshot_20251106_234128" src="https://github.com/user-attachments/assets/e2362221-3ae6-477d-a21c-b044041bb6d0" />
    </td>
    <td>
<img width="1080" height="2280" alt="Screenshot_20251106_234104" src="https://github.com/user-attachments/assets/0464ec4d-7ac6-4b36-88f7-dfb08e050bef" />
    </td>
  </tr>
  <tr>
</table>
