### PR TITLE
Refactor/cht 99 fix messages layout

### DIFF
--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatScreen.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatScreen.kt
@@ -53,15 +53,13 @@ import kotlin.uuid.ExperimentalUuidApi
 fun ChatScreen(onClickBackFromChat: () -> Unit = {}) {
     val factory = rememberPermissionsControllerFactory()
     val controller = remember(factory) { factory.createPermissionsController() }
-    val navController = LocalNavController.current
 
     val viewModel: ChatViewModel = koinViewModel(parameters = { parametersOf(controller) })
 
     BindEffect(controller)
 
     BackHandler(enabled = true) {
-        onClickBackFromChat()
-        navController.popBackStack()
+        viewModel.onBackClicked()
     }
 
     val state by viewModel.state.collectAsStateWithLifecycle()

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatScreen.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatScreen.kt
@@ -43,6 +43,7 @@ import net.thechance.mena.core_chat.presentation.utils.EffectHandler
 import net.thechance.mena.core_chat.presentation.utils.PaginationTrigger
 import net.thechance.mena.core_chat.presentation.utils.rememberCameraManager
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
+import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
@@ -95,6 +96,8 @@ fun ChatScreenContent(
         contentAlignment = Alignment.Center
     ) {
         Scaffold(
+            statusBarColor = Theme.colorScheme.background.surfaceLow,
+            backgroundColor = Theme.colorScheme.background.surface,
             topBar = {
                 ChatHeader(
                     chatName = state.chatName,

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModel.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModel.kt
@@ -430,8 +430,6 @@ class ChatViewModel(
         }
     }
 
-
-
     override fun onChatActionsMenuClicked() {
         updateState { it.copy(isChatActionsDialogVisible = true) }
     }
@@ -484,6 +482,8 @@ class ChatViewModel(
     }
 
     override fun onMessageLongClicked(message: MessageUiState) {
+        if (message.content is MessageContent.Image && message.content.data !is ImageData.ImageUrl) return
+
         updateState {
             it.copy(
                 isReactionDialogVisible = true,
@@ -505,53 +505,20 @@ class ChatViewModel(
     override fun onReactionSelected(messageId: Uuid, reaction: String) {
         val currentUserId = state.value.chatRequesterId ?: return
         val message = _messages.value.firstOrNull { it.id == messageId } ?: return
-        val hasSameReaction = message.reactions.any { it.userId == currentUserId && it.emoji == reaction }
+        val hasSameReaction =
+            message.reactions.any { it.userId == currentUserId && it.emoji == reaction }
 
         if (hasSameReaction) {
             tryToExecute(
                 execute = { messageRepository.removeMessageReaction(messageId, reaction) },
-                onSuccess = { removeReactionFromMessages(messageId, reaction) }
             )
         } else {
             tryToExecute(
                 execute = { messageRepository.addMessageReaction(messageId, reaction) },
-                onSuccess = { updateReactionInMessages(messageId, reaction) }
             )
         }
     }
-    private suspend fun removeReactionFromMessages(messageId: Uuid, emoji: String) {
-        val currentUserId = state.value.chatRequesterId ?: return
-        safeUpdateMessages { messages ->
-            messages.map { message ->
-                if (message.id == messageId) {
-                    val updatedReactions = message.reactions.filterNot {
-                        it.userId == currentUserId && it.emoji == emoji
-                    }
-                    message.copy(reactions = updatedReactions)
-                } else message
-            }
-        }
-    }
 
-
-    private suspend fun updateReactionInMessages(messageId: Uuid, emoji: String) {
-        val currentUserId = state.value.chatRequesterId ?: return
-        safeUpdateMessages { messages ->
-            messages.map { message ->
-                if (message.id == messageId) {
-                    val newReaction = MessageReaction(emoji, currentUserId, messageId)
-                    val updatedReactions = message.reactions
-                        .filter { it.userId != currentUserId }
-                        .toMutableList()
-                        .apply { add(newReaction) }
-
-                    message.copy(reactions = updatedReactions)
-                } else {
-                    message
-                }
-            }
-        }
-    }
     private fun observeMessageReactions() {
         tryToCollect(
             collect = { messageRepository.observeMessageReactions() },
@@ -577,6 +544,20 @@ class ChatViewModel(
                 } else message
             }
         }
+
+        if (state.value.selectedImageMessages.isNotEmpty() && state.value.selectedImageMessages.any { it.id == reaction.messageId }) {
+            updateState {
+                it.copy(selectedImageMessages = it.selectedImageMessages.map { msg ->
+                    if (msg.id == reaction.messageId) {
+                        val updatedReactions = msg.reactions
+                            .filter { it.userId != reaction.userId }
+                            .toMutableList()
+                            .apply { add(reaction) }
+                        msg.copy(reactions = updatedReactions)
+                    } else msg
+                })
+            }
+        }
     }
 
     private suspend fun onCollectRemoveReaction(reaction: MessageReaction?) {
@@ -589,6 +570,16 @@ class ChatViewModel(
                     }
                     message.copy(reactions = filtered)
                 } else message
+            }
+        }
+
+        if (state.value.selectedImageMessages.isNotEmpty() && state.value.selectedImageMessages.any { it.id == reaction.messageId }) {
+            updateState {
+                it.copy(selectedImageMessages = it.selectedImageMessages.map {
+                    if (it.id == reaction.messageId) it.copy(
+                        reactions = it.reactions.filterNot { it == reaction }) else it
+                }
+                )
             }
         }
     }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatInputBar.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatInputBar.kt
@@ -24,12 +24,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.shadow.Shadow
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import mena.core_chat_presentation.generated.resources.Res
 import mena.core_chat_presentation.generated.resources.ic_add
-import mena.core_chat_presentation.generated.resources.message_holder
 import mena.core_chat_presentation.generated.resources.ic_mic
 import mena.core_chat_presentation.generated.resources.ic_send
+import mena.core_chat_presentation.generated.resources.message_holder
 import net.thechance.mena.designsystem.presentation.component.button.FabButton
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.textField.MultiLineTextField
@@ -50,7 +56,17 @@ fun ChatInputBar(
     onAttachButtonClick: () -> Unit = {}
 ) {
     Row(
-        modifier = modifier.fillMaxWidth().padding(Theme.spacing._16),
+        modifier = modifier.fillMaxWidth()
+            .dropShadow(
+                shape = RectangleShape, shadow = Shadow(
+                    radius = Theme.spacing._8,
+                    spread = 0.dp,
+                    color = Color.Black.copy(alpha = .06f),
+                    offset = DpOffset(0.dp, 2.dp),
+                    blendMode = BlendMode.SrcOver
+                )
+            ).background(Theme.colorScheme.background.surface)
+            .padding(Theme.spacing._16),
         horizontalArrangement = Arrangement.spacedBy(Theme.spacing._2),
     ) {
         Row(
@@ -69,7 +85,7 @@ fun ChatInputBar(
                 hint = stringResource(Res.string.message_holder),
                 modifier = Modifier.weight(1f),
                 minLines = 1,
-                maxLines = 5
+                maxLines = 4
             )
             AnimatedVisibility(
                 visible = userInput.isBlank(),

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/FullImagePagerView.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/FullImagePagerView.kt
@@ -208,9 +208,8 @@ private fun PagerOverlay(
             )
         }
         Row(
-            modifier = Modifier,
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(Theme.spacing._8)
+            horizontalArrangement = Arrangement.spacedBy(Theme.spacing._8, Alignment.CenterHorizontally)
         ) {
             if (message.reactions.isNotEmpty()) {
                 ReactionBubble(reactions = message.reactions)

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/FullImagePagerView.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/FullImagePagerView.kt
@@ -209,6 +209,7 @@ private fun PagerOverlay(
         }
         Row(
             modifier = Modifier,
+            verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(Theme.spacing._8)
         ) {
             if (message.reactions.isNotEmpty()) {

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ReactionBubble.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ReactionBubble.kt
@@ -3,22 +3,22 @@ package net.thechance.mena.core_chat.presentation.screen.chat.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import net.thechance.mena.core_chat.domain.entity.MessageReaction
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.foundation.shape.CircleShape
 
 @Composable
 fun ReactionBubble(
     reactions: List<MessageReaction>,
+    modifier: Modifier = Modifier
 ) {
     val grouped = reactions.groupBy { it.emoji }
 
@@ -27,8 +27,7 @@ fun ReactionBubble(
         val label = if (count > 1) "$count $emoji" else emoji
 
         Box(
-            modifier = Modifier
-                .offset(y = (-8).dp)
+            modifier = modifier
                 .sizeIn(minWidth = 22.dp)
                 .clip(CircleShape)
                 .background(Theme.colorScheme.background.surface)

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/TextMessageLayout.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/TextMessageLayout.kt
@@ -80,6 +80,7 @@ fun TextMessageLayout(
     val avatarSpacing = Theme.spacing._8
     val myMessageMarginStart = Theme.spacing._24
     val otherMessageMarginEnd = Theme.spacing._8
+    val messageInfoAlignment = if (message.isMine) Alignment.Start else Alignment.End
 
     val messageBubblePaddingStart = if (message.isMine) myMessageMarginStart else 0.dp
     val messageBubblePaddingEnd = if (message.isMine) 0.dp else otherMessageMarginEnd
@@ -151,7 +152,7 @@ fun TextMessageLayout(
             }
 
             Row(
-                modifier = Modifier
+                modifier = Modifier.align(messageInfoAlignment)
                     .padding(start = infoRowPaddingStart, end = infoRowPaddingEnd),
                 horizontalArrangement = Arrangement.spacedBy(Theme.spacing._4),
                 verticalAlignment = Alignment.CenterVertically

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/TextMessageLayout.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/TextMessageLayout.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
@@ -158,7 +159,10 @@ fun TextMessageLayout(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 if (!message.isMine && message.reactions.isNotEmpty()) {
-                    ReactionBubble(reactions = message.reactions)
+                    ReactionBubble(
+                        reactions = message.reactions,
+                        modifier= Modifier.offset(y = (-8).dp)
+                    )
                 }
 
                 AnimatedVisibility(visible = showMessageInfo) {
@@ -171,8 +175,10 @@ fun TextMessageLayout(
                 }
 
                 if (message.isMine && message.reactions.isNotEmpty()) {
-                    ReactionBubble(reactions = message.reactions)
-                }
+                    ReactionBubble(
+                        reactions = message.reactions,
+                        modifier= Modifier.offset(y = (-8).dp)
+                    )                }
             }
         }
     }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/VoiceMessagesLayout.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/VoiceMessagesLayout.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -166,7 +167,10 @@ fun VoiceMessageLayout(
             verticalAlignment = Alignment.CenterVertically
         ) {
             if (!message.isMine && message.reactions.isNotEmpty()) {
-                ReactionBubble(reactions = message.reactions)
+                ReactionBubble(
+                    reactions = message.reactions,
+                    modifier= Modifier.offset(y = (-8).dp)
+                )
             }
 
             AnimatedVisibility(visible = showMessageInfo) {
@@ -179,7 +183,10 @@ fun VoiceMessageLayout(
             }
 
             if (message.isMine && message.reactions.isNotEmpty()) {
-                ReactionBubble(reactions = message.reactions)
+                ReactionBubble(
+                    reactions = message.reactions,
+                    modifier= Modifier.offset(y = (-8).dp)
+                )
             }
         }
     }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/contacts/ContactsScreen.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/contacts/ContactsScreen.kt
@@ -1,11 +1,8 @@
 package net.thechance.mena.core_chat.presentation.screen.contacts
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -36,6 +33,7 @@ import net.thechance.mena.core_chat.presentation.utils.EffectHandler
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBarOptionContainer
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
+import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -66,42 +64,41 @@ private fun ContactsContent(
 ) {
     val contacts = state.contacts.collectAsLazyPagingItems()
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(color = Theme.colorScheme.background.surface)
-            .navigationBarsPadding()
-    ) {
-        AppBar(
-            modifier = Modifier,
-            title = stringResource(Res.string.contacts_title),
-            contentPadding = PaddingValues(
-                horizontal = Theme.spacing._12,
-                vertical = Theme.spacing._8
-            ),
-            leadingContent = {
-                Icon(
-                    painter = painterResource(Res.drawable.ic_arrow_left),
-                    modifier = Modifier.size(20.dp),
-                    contentDescription = null,
-                    tint = Theme.colorScheme.primary.primary,
-                )
-            },
-            onLeadingClick = interactionListener::onBackClicked,
-            trailingContent = {
-                AppBarOptionContainer(
-                    badgeColor = Theme.colorScheme.primary.primary,
-                    onClick = interactionListener::onReSyncClicked
-                ) {
+    Scaffold(
+        topBar = {
+            AppBar(
+                modifier = Modifier,
+                title = stringResource(Res.string.contacts_title),
+                contentPadding = PaddingValues(
+                    horizontal = Theme.spacing._12,
+                    vertical = Theme.spacing._8
+                ),
+                leadingContent = {
                     Icon(
-                        painter = painterResource(Res.drawable.ic_resync),
-                        contentDescription = null,
+                        painter = painterResource(Res.drawable.ic_arrow_left),
                         modifier = Modifier.size(20.dp),
-                        tint = Theme.colorScheme.shadePrimary,
+                        contentDescription = null,
+                        tint = Theme.colorScheme.primary.primary,
                     )
+                },
+                onLeadingClick = interactionListener::onBackClicked,
+                trailingContent = {
+                    AppBarOptionContainer(
+                        badgeColor = Theme.colorScheme.primary.primary,
+                        onClick = interactionListener::onReSyncClicked
+                    ) {
+                        Icon(
+                            painter = painterResource(Res.drawable.ic_resync),
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                            tint = Theme.colorScheme.shadePrimary,
+                        )
+                    }
                 }
-            }
-        )
+            )
+        }
+    ) {
+
         AnimatedContent(
             targetState = contacts.loadState.refresh,
             modifier = Modifier.fillMaxSize(),

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/scaffold/Scaffold.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/scaffold/Scaffold.kt
@@ -50,11 +50,12 @@ fun Scaffold(
             .systemBarsPadding(),
         contentAlignment = Alignment.Center
     ) {
-        Column {
+        Column(
+            modifier = Modifier.background(backgroundColor)
+        ) {
             topBar()
             Box(
                 modifier = Modifier
-                    .background(backgroundColor)
                     .fillMaxWidth()
                     .weight(1f)
             ) {

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/scaffold/Scaffold.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/scaffold/Scaffold.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -56,7 +55,6 @@ fun Scaffold(
             Box(
                 modifier = Modifier
                     .background(backgroundColor)
-                    .windowInsetsPadding(WindowInsets.safeDrawing)
                     .fillMaxWidth()
                     .weight(1f)
             ) {


### PR DESCRIPTION
before and after screen:
<img width="319" height="720" alt="image" src="https://github.com/user-attachments/assets/6e5e0a25-3e9b-4128-965e-0476fa263d3a" />
<img width="319" height="720" alt="image" src="https://github.com/user-attachments/assets/1e286e13-3670-45eb-9481-e194685d1c9d" />

