### PR TITLE
Fix/idn 154 pick location screen dose not navigate to the current locatin on edit

### DIFF
--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/di/identityScreensModule.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/di/identityScreensModule.kt
@@ -107,7 +107,8 @@ val identityScreensModule = module {
     factory {
         PickLocationScreenViewModel(
             addressesRepository = get(),
-            locationForegroundHandler = get(named(LOCATION_FOREGROUND))
+            locationForegroundHandler = get(named(LOCATION_FOREGROUND)),
+            addressModel = getOrNull()
         )
     }
 

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/addEditLocation/AddEditLocationScreenViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/addEditLocation/AddEditLocationScreenViewModel.kt
@@ -114,8 +114,8 @@ class AddEditLocationScreenViewModel(
     }
 
     override fun onClickEdit() {
-        val currentState = state.value.addressUIState
-        val addressModel = createAddressModelFromCurrentState(currentState)
+        val addressUIState = state.value.addressUIState
+        val addressModel = createAddressModelFromCurrentState(addressUIState)
         sendNewEffect(
             createNavigateToMapEffect(
                 addressModel = addressModel,

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/addEditLocation/AddEditLocationScreenViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/addEditLocation/AddEditLocationScreenViewModel.kt
@@ -22,6 +22,7 @@ import net.thechance.mena.identity.presentation.mapper.mapAuthenticationErrorToM
 import net.thechance.mena.identity.presentation.mapper.mapErrorToMessage
 import net.thechance.mena.identity.presentation.mapper.mapLocationErrorToMessage
 import net.thechance.mena.identity.presentation.mapper.toAddressInput
+import net.thechance.mena.identity.presentation.screen.addresses.addEditLocation.AddEditLocationScreenUIState.AddEditAddressUIState
 import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.AddressUIState
 import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.CoordinatesUiState
 import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.SnackBarType
@@ -113,7 +114,7 @@ class AddEditLocationScreenViewModel(
     }
 
     override fun onClickEdit() {
-        val currentState = state.value
+        val currentState = state.value.addressUIState
         val addressModel = createAddressModelFromCurrentState(currentState)
         sendNewEffect(
             createNavigateToMapEffect(
@@ -160,16 +161,16 @@ class AddEditLocationScreenViewModel(
         sendNewEffect(AddEditLocationScreenUIEffect.NavigateBack(snackBarState))
     }
 
-    private fun createAddressModelFromCurrentState(currentState: AddEditLocationScreenUIState): AddressUIState {
+    private fun createAddressModelFromCurrentState(addressUIState: AddEditAddressUIState): AddressUIState {
         return AddressUIState(
-            id = currentState.addressUIState.addressID,
+            id = addressUIState.addressID,
             coordinates = CoordinatesUiState(
-                currentState.addressUIState.coordinates.latitude,
-                currentState.addressUIState.coordinates.longitude
+                latitude = addressUIState.coordinates.latitude,
+                longitude = addressUIState.coordinates.longitude
             ),
-            addressType = currentState.addressUIState.addressType ?: AddressType.Home,
-            addressDetails = currentState.addressUIState.addressDetails,
-            isMainAddress = currentState.addressUIState.isMainAddress
+            addressType = addressUIState.addressType ?: AddressType.Home,
+            addressDetails = addressUIState.addressDetails,
+            isMainAddress = addressUIState.isMainAddress
         )
     }
 


### PR DESCRIPTION
### pick location screen dose not navigate to the current locatin on edit

<table>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/2bd2b5a2-438f-4935-a1a7-fada7e2b86b8" width="100%" controls></video>
      <p style="text-align:center; font-weight:bold;">Before</p>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/8c8fc0f3-8207-4b85-9855-452dc7f946e4" width="100%" controls></video>
      <p style="text-align:center; font-weight:bold;">After</p>
    </td>
  </tr>
</table>
