### PR TITLE
fix:The “Share Receipt” option shares the image file path of the actu…

### DIFF
--- a/wallet_presentation/src/iosMain/kotlin/net/thechance/mena/wallet/presentation/utils/FileSharer.ios.kt
+++ b/wallet_presentation/src/iosMain/kotlin/net/thechance/mena/wallet/presentation/utils/FileSharer.ios.kt
@@ -5,7 +5,7 @@ import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
-
+import platform.Foundation.NSURL
 @Single
 @OptIn(ExperimentalForeignApi::class)
 actual class FileSharerImpl actual constructor(@Provided private val fileManager: FileManager) : FileSharer {
@@ -16,7 +16,8 @@ actual class FileSharerImpl actual constructor(@Provided private val fileManager
         shareTitle: String
     ) {
         val tempPath = fileManager.saveFile(fileBytes, StorageLocation.Cache(fileName), mimeType)
-        val activityViewController = UIActivityViewController(listOf(tempPath), null)
+        val fileURL = NSURL.fileURLWithPath(tempPath)
+        val activityViewController = UIActivityViewController(listOf(fileURL), null)
         UIApplication.sharedApplication.keyWindow?.rootViewController?.presentViewController(
             activityViewController, animated = true, completion = null
         )


### PR DESCRIPTION
issue:
The “Share Receipt” option shares the image file path of the actual image on iOS cuz we share file path not url 

solution : use a file url not path

before:

https://github.com/user-attachments/assets/632a42d1-72ff-45a3-a399-03d264dcb323

after:

https://github.com/user-attachments/assets/8f801996-c535-4ffe-9037-24c0f8497af6
