### PR TITLE
Fix/idn 156 fix show invalid number instead of otp expired in phone entry

### DIFF
--- a/identity_data/src/androidUnitTest/kotlin/net/thechance/mena/identity/data/repository/RegisterRepositoryImplTest.kt
+++ b/identity_data/src/androidUnitTest/kotlin/net/thechance/mena/identity/data/repository/RegisterRepositoryImplTest.kt
@@ -2,7 +2,6 @@ package net.thechance.mena.identity.data.repository
 
 import assertk.assertFailure
 import assertk.assertions.isInstanceOf
-import com.russhwolf.settings.Settings
 import io.ktor.client.HttpClient
 import io.ktor.http.HttpStatusCode
 import io.mockk.mockk
@@ -18,15 +17,14 @@ import kotlin.test.Test
 
 class RegisterRepositoryImplTest {
     private val client: HttpClient = mockk(relaxed = true)
-    private val settings: Settings = mockk(relaxed = true)
     private var registerRepository: RegisterRepositoryImpl =
-        RegisterRepositoryImpl(client, settings)
+        RegisterRepositoryImpl(client)
 
     @Test
     fun `requestOTP() should return session id when server returns 200`() = runTest {
         val client = mockHttpClient(OtpResponse("session123"))
 
-        registerRepository = RegisterRepositoryImpl(client, settings)
+        registerRepository = RegisterRepositoryImpl(client)
 
         registerRepository.requestOTP(phoneNumber, countryCode)
     }
@@ -36,7 +34,7 @@ class RegisterRepositoryImplTest {
         runTest {
             val client = mockHttpClientError(HttpStatusCode.Conflict)
 
-            registerRepository = RegisterRepositoryImpl(client, settings)
+            registerRepository = RegisterRepositoryImpl(client)
 
             assertFailure {
                 registerRepository.requestOTP(
@@ -51,10 +49,10 @@ class RegisterRepositoryImplTest {
         val client = mockHttpClient(Unit)
         val requestOtpClient = mockHttpClient(OtpResponse("session123"))
 
-        registerRepository = RegisterRepositoryImpl(requestOtpClient, settings)
+        registerRepository = RegisterRepositoryImpl(requestOtpClient)
         registerRepository.requestOTP(phoneNumber, countryCode)
 
-        registerRepository = RegisterRepositoryImpl(client, settings)
+        registerRepository = RegisterRepositoryImpl(client)
         registerRepository.verifyOTPCode("123456")
     }
 
@@ -63,10 +61,10 @@ class RegisterRepositoryImplTest {
         val requestOtpClient = mockHttpClient(OtpResponse("session123"))
         val client = mockHttpClientError(HttpStatusCode.Unauthorized)
 
-        registerRepository = RegisterRepositoryImpl(requestOtpClient, settings)
+        registerRepository = RegisterRepositoryImpl(requestOtpClient)
         registerRepository.requestOTP(phoneNumber, countryCode)
 
-        registerRepository = RegisterRepositoryImpl(client, settings)
+        registerRepository = RegisterRepositoryImpl(client)
 
         assertFailure {
             registerRepository.verifyOTPCode(otpCode = "123456")
@@ -78,10 +76,10 @@ class RegisterRepositoryImplTest {
         val requestOtpClient = mockHttpClient(OtpResponse("session123"))
         val client = mockHttpClientError(HttpStatusCode.BadRequest)
 
-        registerRepository = RegisterRepositoryImpl(requestOtpClient, settings)
+        registerRepository = RegisterRepositoryImpl(requestOtpClient)
         registerRepository.requestOTP(phoneNumber, countryCode)
 
-        registerRepository = RegisterRepositoryImpl(client, settings)
+        registerRepository = RegisterRepositoryImpl(client)
 
         assertFailure {
             registerRepository.verifyOTPCode(otpCode = "123456")
@@ -94,10 +92,10 @@ class RegisterRepositoryImplTest {
             val requestOtpClient = mockHttpClient(OtpResponse("session123"))
             val client = mockHttpClientError(HttpStatusCode.Conflict)
 
-            registerRepository = RegisterRepositoryImpl(requestOtpClient, settings)
+            registerRepository = RegisterRepositoryImpl(requestOtpClient)
             registerRepository.requestOTP(phoneNumber, countryCode)
 
-            registerRepository = RegisterRepositoryImpl(client, settings)
+            registerRepository = RegisterRepositoryImpl(client)
 
             assertFailure {
                 registerRepository.verifyOTPCode(otpCode = "123456")

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/identityDataModule.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/identityDataModule.kt
@@ -57,7 +57,7 @@ val identityDataModule = module {
     }
 
     single<RegisterRepository> {
-        RegisterRepositoryImpl(client = get(named(IDENTITY_CLIENT)), settings = get())
+        RegisterRepositoryImpl(client = get(named(IDENTITY_CLIENT)))
     }
 
     single<RegistrationDraftRepository> {

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/dto/auth/request/CheckUserExistenceRequestDto.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/dto/auth/request/CheckUserExistenceRequestDto.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.data.dto.auth
+package net.thechance.mena.identity.data.dto.auth.request
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/dto/auth/request/LoginRequestDto.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/dto/auth/request/LoginRequestDto.kt
@@ -1,9 +1,12 @@
 package net.thechance.mena.identity.data.dto.auth.request
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class LoginRequestDto(
+    @SerialName("phoneNumber")
     val phoneNumber: String,
+    @SerialName("password")
     val password: String
 )

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/dto/auth/request/RefreshRequestDto.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/dto/auth/request/RefreshRequestDto.kt
@@ -1,8 +1,10 @@
 package net.thechance.mena.identity.data.dto.auth.request
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class RefreshRequestDto(
+    @SerialName("refreshToken")
     val refreshToken: String
 )

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/dto/auth/request/RegisterRequestDto.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/dto/auth/request/RegisterRequestDto.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.data.dto.auth
+package net.thechance.mena.identity.data.dto.auth.request
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/mapper/RegisterMapper.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/mapper/RegisterMapper.kt
@@ -1,7 +1,7 @@
 package net.thechance.mena.identity.data.mapper
 
 import net.thechance.mena.identity.data.dataSource.local.database.model.UserEntity
-import net.thechance.mena.identity.data.dto.auth.RegisterRequestDto
+import net.thechance.mena.identity.data.dto.auth.request.RegisterRequestDto
 import net.thechance.mena.identity.data.dto.auth.response.AuthenticationResponse
 import net.thechance.mena.identity.domain.entity.Gender
 import net.thechance.mena.identity.domain.model.AuthenticationTokens

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/repository/RegisterRepositoryImpl.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/repository/RegisterRepositoryImpl.kt
@@ -1,10 +1,9 @@
 package net.thechance.mena.identity.data.repository
 
-import com.russhwolf.settings.Settings
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.http.HttpStatusCode
-import net.thechance.mena.identity.data.dto.auth.CheckUserExistenceRequestDto
+import net.thechance.mena.identity.data.dto.auth.request.CheckUserExistenceRequestDto
 import net.thechance.mena.identity.data.dto.auth.response.AuthenticationResponse
 import net.thechance.mena.identity.data.dto.resetPassword.request.OtpRequestDto
 import net.thechance.mena.identity.data.dto.resetPassword.request.VerifyOtpRequestDto
@@ -23,7 +22,7 @@ import net.thechance.mena.identity.domain.model.RegisterRequest
 import net.thechance.mena.identity.domain.repository.RegisterRepository
 
 class RegisterRepositoryImpl(
-    private val client: HttpClient, private val settings: Settings
+    private val client: HttpClient
 ) : RegisterRepository {
     private var sessionId = ""
 
@@ -51,8 +50,7 @@ class RegisterRepositoryImpl(
             runCatching {
                 fetchUsernameExistence(username)
             }.fold(onSuccess = { exists ->
-                exists.takeUnless { it }?.let { false }
-                    ?: throw UsernameAlreadyExistsException()
+                exists.takeUnless { it }?.let { false } ?: throw UsernameAlreadyExistsException()
             }, onFailure = { throwable ->
                 handleUsernameCheckExceptionOrRethrow(throwable)
             })

--- a/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/register/CreatePasswordViewModelTest.kt
+++ b/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/register/CreatePasswordViewModelTest.kt
@@ -10,47 +10,46 @@ import net.thechance.mena.identity.domain.entity.PhoneNumber
 import net.thechance.mena.identity.domain.model.RegistrationDraft
 import net.thechance.mena.identity.domain.repository.RegistrationDraftRepository
 import net.thechance.mena.identity.domain.useCase.validation.mobileNumber.PasswordValidator
+import net.thechance.mena.identity.helper.BaseCoroutineTest
 import net.thechance.mena.identity.presentation.screen.register.createPassword.CreatePasswordViewModel
-import org.junit.Before
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 import org.junit.Test
+import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
-class CreatePasswordViewModelTest {
+class CreatePasswordViewModelTest : BaseCoroutineTest() {
     private val passwordValidator = mockk<PasswordValidator>()
     private val registrationDraftRepository = mockk<RegistrationDraftRepository>()
     private val testDispatcher = StandardTestDispatcher()
     private val phoneNumber = PhoneNumber("+964", "7901234567")
     private lateinit var createPasswordViewModel: CreatePasswordViewModel
 
-    @Before
-    fun setup(){
+    @BeforeTest
+    fun setup() {
         createPasswordViewModel = CreatePasswordViewModel(
             passwordValidator = passwordValidator,
             registrationDraftRepository = registrationDraftRepository,
-            phoneNumber = phoneNumber,
-            firstName = "Mohammed",
-            lastName = "Ahmed",
-            username = "mohammed123",
+            registerUIState = RegisterUIState(phoneNumber),
             dispatcher = testDispatcher
         )
     }
 
+
     @Test
-    fun `onChangeNewPassword should update state with new password`(){
+    fun `onChangeNewPassword should update state with new password`() {
         val newPassword = "password123"
 
-        every { passwordValidator.isValid(newPassword)  } returns true
+        every { passwordValidator.isValid(newPassword) } returns true
         createPasswordViewModel.onChangeNewPassword(newPassword)
 
         assert(createPasswordViewModel.state.value.newPassword == newPassword)
     }
 
     @Test
-    fun `onChangeConfirmPassword should update state with new password`(){
+    fun `onChangeConfirmPassword should update state with new password`() {
         val newPassword = "password123"
 
-        every { passwordValidator.isValid(newPassword)  } returns true
+        every { passwordValidator.isValid(newPassword) } returns true
         createPasswordViewModel.onChangeNewPassword(newPassword)
         createPasswordViewModel.onChangeConfirmPassword(newPassword)
 
@@ -58,21 +57,21 @@ class CreatePasswordViewModelTest {
     }
 
     @Test
-    fun `onToggleNewPasswordVisibility should toggle new password visibility`(){
+    fun `onToggleNewPasswordVisibility should toggle new password visibility`() {
         createPasswordViewModel.onToggleNewPasswordVisibility()
 
         assert(createPasswordViewModel.state.value.isNewPasswordVisible)
     }
 
     @Test
-    fun `onToggleConfirmPasswordVisibility should toggle confirm password visibility`(){
+    fun `onToggleConfirmPasswordVisibility should toggle confirm password visibility`() {
         createPasswordViewModel.onToggleConfirmPasswordVisibility()
 
         assert(createPasswordViewModel.state.value.isConfirmPasswordVisible)
     }
 
     @Test
-    fun `onClearErrorMessage should clear error message`(){
+    fun `onClearErrorMessage should clear error message`() {
         createPasswordViewModel.onClearErrorMessage()
 
         assert(createPasswordViewModel.state.value.errorMessage == null)
@@ -88,10 +87,7 @@ class CreatePasswordViewModelTest {
         val viewModel = CreatePasswordViewModel(
             passwordValidator = passwordValidator,
             registrationDraftRepository = registrationDraftRepository,
-            phoneNumber = phoneNumber,
-            firstName = "Mohammed",
-            lastName = "Ahmed",
-            username = "mohammed123",
+            registerUIState = RegisterUIState(phoneNumber),
             dispatcher = testDispatcher
         )
         testDispatcher.scheduler.advanceUntilIdle()
@@ -109,7 +105,12 @@ class CreatePasswordViewModelTest {
         createPasswordViewModel.onChangeNewPassword(password)
         testDispatcher.scheduler.advanceUntilIdle()
 
-        coVerify { registrationDraftRepository.saveDraft(phoneNumber, RegistrationDraft(password = password)) }
+        coVerify {
+            registrationDraftRepository.saveDraft(
+                phoneNumber,
+                RegistrationDraft(password = password)
+            )
+        }
     }
 
     @Test

--- a/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/register/DatePickerScreenViewModelTest.kt
+++ b/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/register/DatePickerScreenViewModelTest.kt
@@ -14,10 +14,10 @@ import net.thechance.mena.identity.domain.useCase.validation.age.AgeValidator
 import net.thechance.mena.identity.helper.BaseCoroutineTest
 import net.thechance.mena.identity.presentation.screen.register.datePicker.DatePickerScreenUIEffect
 import net.thechance.mena.identity.presentation.screen.register.datePicker.DatePickerScreenViewModel
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class DatePickerScreenViewModelTest : BaseCoroutineTest() {
@@ -33,11 +33,7 @@ class DatePickerScreenViewModelTest : BaseCoroutineTest() {
         datePickerScreenViewModel = DatePickerScreenViewModel(
             ageValidator = ageValidator,
             registrationDraftRepository = registrationDraftRepository,
-            phoneNumber = phoneNumber,
-            firstName = "Mohammed",
-            lastName = "Ahmed",
-            username = "mohammed123",
-            password = "Password123",
+            registerUIState = RegisterUIState(phoneNumber),
             dispatcher = testDispatcher
         )
     }
@@ -115,11 +111,7 @@ class DatePickerScreenViewModelTest : BaseCoroutineTest() {
         val viewModel = DatePickerScreenViewModel(
             ageValidator = ageValidator,
             registrationDraftRepository = registrationDraftRepository,
-            phoneNumber = phoneNumber,
-            firstName = "Mohammed",
-            lastName = "Ahmed",
-            username = "mohammed123",
-            password = "Password123",
+            registerUIState = RegisterUIState(phoneNumber),
             dispatcher = testDispatcher
         )
         testDispatcher.scheduler.advanceUntilIdle()
@@ -137,11 +129,7 @@ class DatePickerScreenViewModelTest : BaseCoroutineTest() {
         val viewModel = DatePickerScreenViewModel(
             ageValidator = ageValidator,
             registrationDraftRepository = registrationDraftRepository,
-            phoneNumber = phoneNumber,
-            firstName = "Mohammed",
-            lastName = "Ahmed",
-            username = "mohammed123",
-            password = "Password123",
+            registerUIState = RegisterUIState(phoneNumber),
             dispatcher = testDispatcher
         )
         testDispatcher.scheduler.advanceUntilIdle()

--- a/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/register/RegisterOtpViewModelTest.kt
+++ b/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/register/RegisterOtpViewModelTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import net.thechance.mena.identity.domain.repository.RegisterRepository
 import net.thechance.mena.identity.helper.BaseCoroutineTest
 import net.thechance.mena.identity.presentation.screen.register.otp.RegisterOtpViewModel
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 import org.junit.Before
 import org.junit.Test
 
@@ -12,18 +13,14 @@ class RegisterOtpViewModelTest : BaseCoroutineTest() {
     private lateinit var registerOtpViewModel: RegisterOtpViewModel
     private val testDispatcher = StandardTestDispatcher()
     private val registerRepository = mockk<RegisterRepository>()
-    private val phoneNumber = "123456789"
-    private val callingCode = "+1"
-    private val countryCode = "US"
+
 
 
     @Before
     fun setup() {
         registerOtpViewModel = RegisterOtpViewModel(
-            registerRepository = mockk(),
-            phoneNumber = phoneNumber,
-            callingCode = callingCode,
-            countryCode = countryCode,
+            registerRepository = registerRepository,
+            registerUIState = RegisterUIState(),
             dispatcher = testDispatcher
         )
     }

--- a/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/register/SelectGenderScreenViewModelTest.kt
+++ b/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/register/SelectGenderScreenViewModelTest.kt
@@ -6,7 +6,6 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.LocalDate
 import net.thechance.mena.identity.domain.entity.Gender
 import net.thechance.mena.identity.domain.entity.PhoneNumber
 import net.thechance.mena.identity.domain.model.AuthenticationTokens
@@ -18,6 +17,7 @@ import net.thechance.mena.identity.domain.repository.RegistrationDraftRepository
 import net.thechance.mena.identity.helper.BaseCoroutineTest
 import net.thechance.mena.identity.presentation.screen.register.selectGender.SelectGenderScreenUIEffect
 import net.thechance.mena.identity.presentation.screen.register.selectGender.SelectGenderScreenViewModel
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -37,12 +37,7 @@ class SelectGenderScreenViewModelTest: BaseCoroutineTest() {
             registerRepository = registerRepository,
             registrationDraftRepository = registrationDraftRepository,
             authenticationRepository = authenticationRepository,
-            phoneNumber = phoneNumber,
-            firstName = "Mohammed",
-            lastName = "Ahmed",
-            username = "mohammed123",
-            password = "Password123",
-            birthDate = LocalDate(2000, 1, 1),
+            registerUIState = RegisterUIState(phoneNumber),
             dispatcher = testDispatcher
         )
     }
@@ -121,12 +116,7 @@ class SelectGenderScreenViewModelTest: BaseCoroutineTest() {
             registerRepository = registerRepository,
             registrationDraftRepository = registrationDraftRepository,
             authenticationRepository = authenticationRepository,
-            phoneNumber = phoneNumber,
-            firstName = "Mohammed",
-            lastName = "Ahmed",
-            username = "mohammed123",
-            password = "Password123",
-            birthDate = LocalDate(2000, 1, 1),
+            registerUIState = RegisterUIState(phoneNumber),
             dispatcher = testDispatcher
         )
         testDispatcher.scheduler.advanceUntilIdle()
@@ -144,12 +134,7 @@ class SelectGenderScreenViewModelTest: BaseCoroutineTest() {
             registerRepository = registerRepository,
             registrationDraftRepository = registrationDraftRepository,
             authenticationRepository = authenticationRepository,
-            phoneNumber = phoneNumber,
-            firstName = "Mohammed",
-            lastName = "Ahmed",
-            username = "mohammed123",
-            password = "Password123",
-            birthDate = LocalDate(2000, 1, 1),
+            registerUIState = RegisterUIState(phoneNumber),
             dispatcher = testDispatcher
         )
         testDispatcher.scheduler.advanceUntilIdle()

--- a/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/register/enterName/EnterNameViewModelTest.kt
+++ b/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/register/enterName/EnterNameViewModelTest.kt
@@ -156,7 +156,7 @@ class EnterNameViewModelTest : BaseCoroutineTest() {
             testDispatcher.scheduler.advanceUntilIdle()
 
             val effect = awaitItem() as EnterNameUIEffect.NavigateToPassword
-            assert(effect.firstName == "Mohammed")
+            assert(effect.registerUIState.firstName == "Mohammed")
         }
     }
 
@@ -172,7 +172,7 @@ class EnterNameViewModelTest : BaseCoroutineTest() {
             testDispatcher.scheduler.advanceUntilIdle()
 
             val effect = awaitItem() as EnterNameUIEffect.NavigateToPassword
-            assert(effect.lastName == "Ahmed")
+            assert(effect.registerUIState.lastName == "Ahmed")
         }
     }
 
@@ -188,7 +188,7 @@ class EnterNameViewModelTest : BaseCoroutineTest() {
             testDispatcher.scheduler.advanceUntilIdle()
 
             val effect = awaitItem() as EnterNameUIEffect.NavigateToPassword
-            assert(effect.username == "mohammed123")
+            assert(effect.registerUIState.username == "mohammed123")
         }
     }
 

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/di/identityScreensModule.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/di/identityScreensModule.kt
@@ -1,8 +1,5 @@
 package net.thechance.mena.identity.presentation.di
 
-import kotlinx.datetime.LocalDate
-import net.thechance.mena.identity.domain.entity.PhoneNumber
-import net.thechance.mena.identity.domain.model.AuthenticationTokens
 import net.thechance.mena.identity.presentation.screen.addresses.addEditLocation.AddEditLocationScreenViewModel
 import net.thechance.mena.identity.presentation.screen.addresses.enableLocationScreen.EnableLocationScreenViewModel
 import net.thechance.mena.identity.presentation.screen.addresses.myAddresses.AddressesScreenViewModel

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/di/identityScreensModule.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/di/identityScreensModule.kt
@@ -50,54 +50,23 @@ val identityScreensModule = module {
     factoryOf(::ImageCropperViewModel)
     factoryOf(::LoginScreenViewModel)
     factoryOf(::NotImplementedScreenViewModel)
-    factoryOf(::RegisterPhoneEntryViewModel)
-    factoryOf(::RegisterOtpViewModel)
-    factoryOf(::EnterNameViewModel)
     factoryOf(::CreatePasswordViewModel)
     factoryOf(::AccountCreatedViewModel)
     factoryOf(::ForgetPasswordPhoneEntryScreenViewModel)
     factoryOf(::ForgetPasswordOtpScreenViewModel)
     factoryOf(::EditUserProfileViewModel)
-    factory { (authTokens: AuthenticationTokens?, phoneNumber: PhoneNumber?) ->
-        UploadProfileImageViewModel(
-            cachedImageRepository = get(),
-            userRepository = get(),
-            imageDecoder = get(),
-            authenticationRepository = get(),
-            registrationDraftRepository = get(),
-            authTokens = authTokens,
-            phoneNumber = phoneNumber
-        )
-    }
     factoryOf(::SetNewPasswordScreenViewModel)
     factoryOf(::AddressesScreenViewModel)
     factoryOf(::EnableLocationScreenViewModel)
     factoryOf(::ShareDialogViewModel)
-    factory {
-        DatePickerScreenViewModel(
-            ageValidator = get(),
-            registrationDraftRepository = get(),
-            phoneNumber = it[0] as PhoneNumber,
-            firstName = it[1] as String,
-            lastName = it[2] as String,
-            username = it[3] as String,
-            password = it[4] as String
-        )
-    }
-    factory {
-        SelectGenderScreenViewModel(
-            registerRepository = get(),
-            registrationDraftRepository = get(),
-            authenticationRepository = get(),
-            phoneNumber = it[0] as PhoneNumber,
-            firstName = it[1] as String,
-            lastName = it[2] as String,
-            username = it[3] as String,
-            password = it[4] as String,
-            birthDate = it[5] as LocalDate
-        )
-    }
+    factoryOf(::RegisterPhoneEntryViewModel)
+    factoryOf(::RegisterOtpViewModel)
+    factoryOf(::EnterNameViewModel)
+    factoryOf(::UploadProfileImageViewModel)
+    factoryOf(::DatePickerScreenViewModel)
+    factoryOf(::SelectGenderScreenViewModel)
     factoryOf(::ChangePasswordScreenViewModel)
+
     factoryOf(::ImageDecoderImpl) bind ImageDecoder::class
     viewModel { (minScale: Float, maxScale: Float, initialState: ImageCropperUiState) ->
         ImageCropperComponentViewModel(minScale, maxScale, initialState)

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/accountCreated/AccountCreatedScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/accountCreated/AccountCreatedScreen.kt
@@ -37,12 +37,12 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
 
 class AccountCreatedScreen(
-    private val authTokens: AuthenticationTokens? = null
-) :
-            BaseScreen<AccountCreatedViewModel,
-            AccountCreatedUIState,
-            AccountCreatedUIEffect,
-            AccountCreatedInteractionListener>() {
+    private val authTokens: AuthenticationTokens?
+) : BaseScreen<
+        AccountCreatedViewModel,
+        AccountCreatedUIState,
+        AccountCreatedUIEffect,
+        AccountCreatedInteractionListener>() {
 
     @Composable
     override fun Content() {
@@ -71,9 +71,7 @@ class AccountCreatedScreen(
                     painter = painterResource(Res.drawable.login_background),
                     contentDescription = null,
                     contentScale = ContentScale.FillBounds,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .align(Alignment.Center)
+                    modifier = Modifier.fillMaxSize().align(Alignment.Center)
                 )
 
                 Column(
@@ -83,9 +81,7 @@ class AccountCreatedScreen(
                         .padding(top = Theme.spacing._24)
                 ) {
                     Column(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxWidth(),
+                        modifier = Modifier.weight(1f).fillMaxWidth(),
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.Center,
                     ) {
@@ -107,37 +103,6 @@ class AccountCreatedScreen(
         }
     }
 
-    @Composable
-    private fun SuccessMessageBlock(
-        modifier: Modifier = Modifier
-    ) {
-        Column(
-            modifier = modifier,
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Image(
-                painter = painterResource(Res.drawable.ic_account_shield),
-                contentDescription = stringResource(Res.string.success_account_created_title),
-                modifier = Modifier
-                    .size(128.dp)
-                    .padding(bottom = Theme.spacing._12)
-            )
-            Text(
-                text = stringResource(Res.string.success_account_created_title),
-                style = Theme.typography.title.medium,
-                color = Theme.colorScheme.shadePrimary,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(bottom = Theme.spacing._2)
-            )
-            Text(
-                text = stringResource(Res.string.success_account_created_description),
-                style = Theme.typography.label.large,
-                color = Theme.colorScheme.shadeSecondary,
-                textAlign = TextAlign.Center
-            )
-        }
-    }
-
     override fun onEffect(
         effect: AccountCreatedUIEffect,
         navigator: Navigator
@@ -146,11 +111,42 @@ class AccountCreatedScreen(
     }
 }
 
+@Composable
+private fun SuccessMessageBlock(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Image(
+            painter = painterResource(Res.drawable.ic_account_shield),
+            contentDescription = stringResource(Res.string.success_account_created_title),
+            modifier = Modifier.size(128.dp).padding(bottom = Theme.spacing._12)
+        )
+        Text(
+            text = stringResource(Res.string.success_account_created_title),
+            style = Theme.typography.title.medium,
+            color = Theme.colorScheme.shadePrimary,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = Theme.spacing._2)
+        )
+        Text(
+            text = stringResource(Res.string.success_account_created_description),
+            style = Theme.typography.label.large,
+            color = Theme.colorScheme.shadeSecondary,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
 @Preview
 @Composable
 private fun Preview() {
     MenaTheme {
-        AccountCreatedScreen().OnRender(
+        AccountCreatedScreen(
+            authTokens = null
+        ).OnRender(
             state = AccountCreatedUIState,
             listener = object : AccountCreatedInteractionListener {
                 override fun onClickGoToHome() {}

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/accountCreated/AccountCreatedViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/accountCreated/AccountCreatedViewModel.kt
@@ -12,7 +12,7 @@ class AccountCreatedViewModel(
     private val authenticationRepository: AuthenticationRepository,
     private val registrationDraftRepository: RegistrationDraftRepository,
     private val authTokens: AuthenticationTokens? = null,
-    val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : BaseScreenModel<AccountCreatedUIState, AccountCreatedUIEffect>
     (AccountCreatedUIState),
     AccountCreatedInteractionListener {
@@ -29,8 +29,6 @@ class AccountCreatedViewModel(
                 authenticationRepository.saveAuthTokensAndEmit(tokens)
                 registrationDraftRepository.clearLastPhoneNumber()
             },
-            onSuccess = {},
-            onError = {},
             dispatcher = dispatcher
         )
     }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/createPassword/CreatePasswordScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/createPassword/CreatePasswordScreen.kt
@@ -30,15 +30,13 @@ import net.thechance.mena.identity.presentation.components.ErrorSnackBar
 import net.thechance.mena.identity.presentation.components.LabeledInputPassword
 import net.thechance.mena.identity.presentation.components.PageDescription
 import net.thechance.mena.identity.presentation.screen.register.datePicker.DatePickerScreen
+import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
 
 class CreatePasswordScreen(
-    private val phoneNumber: PhoneNumber,
-    private val firstName: String,
-    private val lastName: String,
-    private val username: String
+    private val registerUIState: RegisterUIState
 ) : BaseScreen<
         CreatePasswordViewModel,
         CreatePasswordUIState,
@@ -47,13 +45,7 @@ class CreatePasswordScreen(
 
     @Composable
     override fun Content() {
-        InitScreen(
-            getScreenModel(
-                parameters = {
-                    parametersOf(phoneNumber, firstName, lastName, username)
-                }
-            )
-        )
+        InitScreen(getScreenModel(parameters = { parametersOf(registerUIState) }))
     }
 
     @Composable
@@ -122,15 +114,7 @@ class CreatePasswordScreen(
     ) {
         when (effect) {
             is CreatePasswordUIEffect.NavigateToDatePicker -> {
-                navigator.push(
-                    DatePickerScreen(
-                        phoneNumber = effect.phoneNumber,
-                        firstName = effect.firstName,
-                        lastName = effect.lastName,
-                        username = effect.username,
-                        password = effect.password
-                    )
-                )
+                navigator.push(DatePickerScreen(registerUIState = effect.registerUIState))
             }
         }
     }
@@ -141,13 +125,13 @@ class CreatePasswordScreen(
 fun PreviewCreatePasswordScreen() {
     MenaTheme {
         CreatePasswordScreen(
-            phoneNumber = net.thechance.mena.identity.domain.entity.PhoneNumber(
-                "+964",
-                "7901234567"
-            ),
-            firstName = "Mohammed",
-            lastName = "Ahmed",
-            username = "mohammed123"
+            registerUIState = RegisterUIState(
+                phoneNumber = PhoneNumber(
+                    countryCode = "+971",
+                    localNumber = "555555555"
+                ),
+                countryCode = "AE"
+            )
         ).OnRender(
             state = CreatePasswordUIState(
                 newPassword = "Password123",

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/createPassword/CreatePasswordScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/createPassword/CreatePasswordScreen.kt
@@ -30,7 +30,7 @@ import net.thechance.mena.identity.presentation.components.ErrorSnackBar
 import net.thechance.mena.identity.presentation.components.LabeledInputPassword
 import net.thechance.mena.identity.presentation.components.PageDescription
 import net.thechance.mena.identity.presentation.screen.register.datePicker.DatePickerScreen
-import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/createPassword/CreatePasswordUIEffect.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/createPassword/CreatePasswordUIEffect.kt
@@ -1,6 +1,6 @@
 package net.thechance.mena.identity.presentation.screen.register.createPassword
 
-import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 
 sealed interface CreatePasswordUIEffect {
     data class NavigateToDatePicker(val registerUIState: RegisterUIState) : CreatePasswordUIEffect

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/createPassword/CreatePasswordUIEffect.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/createPassword/CreatePasswordUIEffect.kt
@@ -1,6 +1,5 @@
 package net.thechance.mena.identity.presentation.screen.register.createPassword
 
-import net.thechance.mena.identity.domain.entity.PhoneNumber
 import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
 
 sealed interface CreatePasswordUIEffect {

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/createPassword/CreatePasswordUIEffect.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/createPassword/CreatePasswordUIEffect.kt
@@ -1,13 +1,8 @@
 package net.thechance.mena.identity.presentation.screen.register.createPassword
 
 import net.thechance.mena.identity.domain.entity.PhoneNumber
+import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
 
 sealed interface CreatePasswordUIEffect {
-    data class NavigateToDatePicker(
-        val phoneNumber: PhoneNumber,
-        val firstName: String,
-        val lastName: String,
-        val username: String,
-        val password: String
-    ) : CreatePasswordUIEffect
+    data class NavigateToDatePicker(val registerUIState: RegisterUIState) : CreatePasswordUIEffect
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/createPassword/CreatePasswordViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/createPassword/CreatePasswordViewModel.kt
@@ -6,20 +6,17 @@ import kotlinx.coroutines.IO
 import mena.identity_presentation.generated.resources.Res
 import mena.identity_presentation.generated.resources.error_password_mismatch
 import mena.identity_presentation.generated.resources.error_password_validation
-import net.thechance.mena.identity.domain.entity.PhoneNumber
 import net.thechance.mena.identity.domain.model.RegistrationDraft
 import net.thechance.mena.identity.domain.repository.RegistrationDraftRepository
 import net.thechance.mena.identity.domain.useCase.validation.mobileNumber.PasswordValidator
 import net.thechance.mena.identity.presentation.base.BaseScreenModel
+import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
 import net.thechance.mena.identity.presentation.util.validatePasswordConfirmation
 
 class CreatePasswordViewModel(
     private val passwordValidator: PasswordValidator,
     private val registrationDraftRepository: RegistrationDraftRepository,
-    private val phoneNumber: PhoneNumber,
-    private val firstName: String,
-    private val lastName: String,
-    private val username: String,
+    private val registerUIState: RegisterUIState,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : BaseScreenModel<CreatePasswordUIState, CreatePasswordUIEffect>(
     CreatePasswordUIState()
@@ -67,9 +64,8 @@ class CreatePasswordViewModel(
 
     private fun loadSavedData() {
         tryToExecute(
-            function = { registrationDraftRepository.getDraft(phoneNumber) },
+            function = { registrationDraftRepository.getDraft(registerUIState.phoneNumber) },
             onSuccess = ::handleSavedDraft,
-            onError = {},
             dispatcher = dispatcher
         )
     }
@@ -95,11 +91,13 @@ class CreatePasswordViewModel(
     private fun savePassword(password: String) {
         tryToExecute(
             function = {
-                val draft = registrationDraftRepository.getDraft(phoneNumber) ?: RegistrationDraft()
-                registrationDraftRepository.saveDraft(phoneNumber, draft.copy(password = password))
+                val draft = registrationDraftRepository.getDraft(registerUIState.phoneNumber)
+                    ?: RegistrationDraft()
+                registrationDraftRepository.saveDraft(
+                    registerUIState.phoneNumber,
+                    draft.copy(password = password)
+                )
             },
-            onSuccess = {},
-            onError = {},
             dispatcher = dispatcher
         )
     }
@@ -112,11 +110,7 @@ class CreatePasswordViewModel(
     }
 
     private fun createNavigateToDatePickerEffect() = CreatePasswordUIEffect.NavigateToDatePicker(
-        phoneNumber = phoneNumber,
-        firstName = firstName,
-        lastName = lastName,
-        username = username,
-        password = state.value.newPassword
+        registerUIState = registerUIState.copy(password = state.value.newPassword)
     )
 
     private fun checkCreateButtonEnabled() {

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/createPassword/CreatePasswordViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/createPassword/CreatePasswordViewModel.kt
@@ -10,7 +10,7 @@ import net.thechance.mena.identity.domain.model.RegistrationDraft
 import net.thechance.mena.identity.domain.repository.RegistrationDraftRepository
 import net.thechance.mena.identity.domain.useCase.validation.mobileNumber.PasswordValidator
 import net.thechance.mena.identity.presentation.base.BaseScreenModel
-import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 import net.thechance.mena.identity.presentation.util.validatePasswordConfirmation
 
 class CreatePasswordViewModel(

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreen.kt
@@ -22,7 +22,7 @@ import net.thechance.mena.identity.presentation.components.AuthScreenContainer
 import net.thechance.mena.identity.presentation.components.GregorianDatePicker
 import net.thechance.mena.identity.presentation.components.PageDescription
 import net.thechance.mena.identity.presentation.screen.register.selectGender.SelectGenderScreen
-import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 import org.jetbrains.compose.resources.stringResource
 import org.koin.core.parameter.parametersOf
 

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreen.kt
@@ -24,7 +24,6 @@ import net.thechance.mena.identity.presentation.components.PageDescription
 import net.thechance.mena.identity.presentation.screen.register.selectGender.SelectGenderScreen
 import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
 
 class DatePickerScreen(

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreen.kt
@@ -17,32 +17,23 @@ import mena.identity_presentation.generated.resources.date_picker_screen_prompt_
 import mena.identity_presentation.generated.resources.next
 import net.thechance.mena.designsystem.presentation.component.button.PrimaryButton
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
-import net.thechance.mena.identity.domain.entity.PhoneNumber
 import net.thechance.mena.identity.presentation.base.BaseScreen
 import net.thechance.mena.identity.presentation.components.AuthScreenContainer
 import net.thechance.mena.identity.presentation.components.GregorianDatePicker
 import net.thechance.mena.identity.presentation.components.PageDescription
 import net.thechance.mena.identity.presentation.screen.register.selectGender.SelectGenderScreen
+import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
 
 class DatePickerScreen(
-    private val phoneNumber: PhoneNumber,
-    private val firstName: String,
-    private val lastName: String,
-    private val username: String,
-    private val password: String
+    private val registerUIState: RegisterUIState
 ) :
     BaseScreen<DatePickerScreenViewModel, DatePickerScreenUIState, DatePickerScreenUIEffect, DatePickerScreenInteractionListener>() {
     @Composable
     override fun Content() {
-        InitScreen(
-            getScreenModel(
-                parameters = {
-                    parametersOf(phoneNumber, firstName, lastName, username, password)
-                }
-            )
-        )
+        InitScreen(getScreenModel(parameters = { parametersOf(registerUIState) }))
     }
 
     @Composable
@@ -92,16 +83,7 @@ class DatePickerScreen(
     ) {
         when (effect) {
             is DatePickerScreenUIEffect.NavigateToSelectGender -> {
-                navigator.push(
-                    SelectGenderScreen(
-                        phoneNumber = effect.phoneNumber,
-                        firstName = effect.firstName,
-                        lastName = effect.lastName,
-                        username = effect.username,
-                        password = effect.password,
-                        birthDate = effect.birthDate
-                    )
-                )
+                navigator.push(SelectGenderScreen(effect.registerUIState))
             }
         }
     }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreenInteractionListener.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreenInteractionListener.kt
@@ -5,5 +5,4 @@ import net.thechance.mena.identity.presentation.base.BaseInteractionListener
 interface DatePickerScreenInteractionListener : BaseInteractionListener {
     fun onClickNext()
     fun onChangeDate(day: Int, month: Int, year: Int)
-
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreenUIEffect.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreenUIEffect.kt
@@ -1,15 +1,7 @@
 package net.thechance.mena.identity.presentation.screen.register.datePicker
 
-import kotlinx.datetime.LocalDate
-import net.thechance.mena.identity.domain.entity.PhoneNumber
+import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
 
 sealed interface DatePickerScreenUIEffect {
-    data class NavigateToSelectGender(
-        val phoneNumber: PhoneNumber,
-        val firstName: String,
-        val lastName: String,
-        val username: String,
-        val password: String,
-        val birthDate: LocalDate
-    ) : DatePickerScreenUIEffect
+    data class NavigateToSelectGender(val registerUIState: RegisterUIState) : DatePickerScreenUIEffect
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreenUIEffect.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreenUIEffect.kt
@@ -1,6 +1,6 @@
 package net.thechance.mena.identity.presentation.screen.register.datePicker
 
-import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 
 sealed interface DatePickerScreenUIEffect {
     data class NavigateToSelectGender(val registerUIState: RegisterUIState) : DatePickerScreenUIEffect

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreenViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreenViewModel.kt
@@ -13,7 +13,7 @@ import net.thechance.mena.identity.domain.model.RegistrationDraft
 import net.thechance.mena.identity.domain.repository.RegistrationDraftRepository
 import net.thechance.mena.identity.domain.useCase.validation.age.AgeValidator
 import net.thechance.mena.identity.presentation.base.BaseScreenModel
-import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreenViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreenViewModel.kt
@@ -20,8 +20,8 @@ import kotlin.time.ExperimentalTime
 class DatePickerScreenViewModel(
     private val ageValidator: AgeValidator,
     private val registrationDraftRepository: RegistrationDraftRepository,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
-    private val registerUIState: RegisterUIState
+    private val registerUIState: RegisterUIState,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) :
     BaseScreenModel<DatePickerScreenUIState, DatePickerScreenUIEffect>(
         DatePickerScreenUIState()

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreenViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreenViewModel.kt
@@ -9,23 +9,19 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
-import net.thechance.mena.identity.domain.entity.PhoneNumber
 import net.thechance.mena.identity.domain.model.RegistrationDraft
 import net.thechance.mena.identity.domain.repository.RegistrationDraftRepository
 import net.thechance.mena.identity.domain.useCase.validation.age.AgeValidator
 import net.thechance.mena.identity.presentation.base.BaseScreenModel
+import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 class DatePickerScreenViewModel(
     private val ageValidator: AgeValidator,
     private val registrationDraftRepository: RegistrationDraftRepository,
-    private val phoneNumber: PhoneNumber,
-    private val firstName: String,
-    private val lastName: String,
-    private val username: String,
-    private val password: String,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val registerUIState: RegisterUIState
 ) :
     BaseScreenModel<DatePickerScreenUIState, DatePickerScreenUIEffect>(
         DatePickerScreenUIState()
@@ -57,9 +53,8 @@ class DatePickerScreenViewModel(
 
     private fun loadSavedData() {
         tryToExecute(
-            function = { registrationDraftRepository.getDraft(phoneNumber) },
+            function = { registrationDraftRepository.getDraft(registerUIState.phoneNumber) },
             onSuccess = ::handleSavedDraft,
-            onError = {},
             dispatcher = dispatcher
         )
     }
@@ -94,12 +89,7 @@ class DatePickerScreenViewModel(
 
     private fun createNavigationEffect(selectedDate: LocalDate) =
         DatePickerScreenUIEffect.NavigateToSelectGender(
-            phoneNumber = phoneNumber,
-            firstName = firstName,
-            lastName = lastName,
-            username = username,
-            password = password,
-            birthDate = selectedDate
+            registerUIState = registerUIState.copy(birthDate = selectedDate),
         )
 
     @OptIn(ExperimentalTime::class)
@@ -144,11 +134,9 @@ class DatePickerScreenViewModel(
     private fun saveBirthDate(birthDate: LocalDate) {
         tryToExecute(
             function = {
-                val draft = registrationDraftRepository.getDraft(phoneNumber) ?: RegistrationDraft()
-                registrationDraftRepository.saveDraft(phoneNumber, draft.copy(birthDate = birthDate))
+                val draft = registrationDraftRepository.getDraft(registerUIState.phoneNumber) ?: RegistrationDraft()
+                registrationDraftRepository.saveDraft(registerUIState.phoneNumber, draft.copy(birthDate = birthDate))
             },
-            onSuccess = {},
-            onError = {},
             dispatcher = dispatcher
         )
     }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreenViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreenViewModel.kt
@@ -120,7 +120,7 @@ class DatePickerScreenViewModel(
     }
 
     private fun updateNextButtonState() {
-        state.value.selectedDate?.let { date ->
+        state.value.selectedDate.let { date ->
             updateState { copy(isNextEnabled = ageValidator.isValid(date)) }
         }
     }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/enterName/EnterNameScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/enterName/EnterNameScreen.kt
@@ -41,11 +41,11 @@ import org.koin.core.parameter.parametersOf
 
 class EnterNameScreen(
     private val phoneNumber: PhoneNumber
-) :
-    BaseScreen<EnterNameViewModel,
-            EnterNameUIState,
-            EnterNameUIEffect,
-            EnterNameInteractionListener>() {
+) : BaseScreen<
+        EnterNameViewModel,
+        EnterNameUIState,
+        EnterNameUIEffect,
+        EnterNameInteractionListener>() {
 
     @Composable
     override fun Content() {
@@ -129,71 +129,64 @@ class EnterNameScreen(
     ) {
         when (effect) {
             is EnterNameUIEffect.NavigateToPassword -> {
-                navigator.push(
-                    CreatePasswordScreen(
-                        phoneNumber = effect.phoneNumber,
-                        firstName = effect.firstName,
-                        lastName = effect.lastName,
-                        username = effect.username
-                    )
-                )
+                navigator.push(CreatePasswordScreen(registerUIState = effect.registerUIState))
             }
         }
     }
+}
 
-    @Preview
-    @Composable
-    private fun Preview_Empty() {
-        MenaTheme {
-            EnterNameScreen(
-                phoneNumber = net.thechance.mena.identity.domain.entity.PhoneNumber(
-                    "+964",
-                    "7901234567"
-                )
-            ).OnRender(
-                state = EnterNameUIState(
-                    firstName = "",
-                    lastName = "",
-                    username = "",
-                    isNextEnabled = false,
-                    isLoading = false,
-                ),
-                listener = object : EnterNameInteractionListener {
-                    override fun onChangeFirstName(name: String) {}
-                    override fun onLastNameChange(name: String) {}
-                    override fun onUsernameChange(username: String) {}
-                    override fun onClickNext() {}
-                    override fun onClearErrorMessage() {}
-                }
+@Preview
+@Composable
+private fun Preview_Empty() {
+    MenaTheme {
+        EnterNameScreen(
+            phoneNumber = PhoneNumber(
+                "+964",
+                "7901234567"
             )
-        }
+        ).OnRender(
+            state = EnterNameUIState(
+                firstName = "",
+                lastName = "",
+                username = "",
+                isNextEnabled = false,
+                isLoading = false,
+            ),
+            listener = object : EnterNameInteractionListener {
+                override fun onChangeFirstName(name: String) {}
+                override fun onLastNameChange(name: String) {}
+                override fun onUsernameChange(username: String) {}
+                override fun onClickNext() {}
+                override fun onClearErrorMessage() {}
+            }
+        )
     }
+}
 
-    @Preview
-    @Composable
-    private fun Preview_Filled() {
-        MenaTheme {
-            EnterNameScreen(
-                phoneNumber = net.thechance.mena.identity.domain.entity.PhoneNumber(
-                    "+964",
-                    "7901234567"
-                )
-            ).OnRender(
-                state = EnterNameUIState(
-                    firstName = "Mohammed",
-                    lastName = "Ahmed",
-                    username = "mohammed_2025",
-                    isNextEnabled = true,
-                    isLoading = false
-                ),
-                listener = object : EnterNameInteractionListener {
-                    override fun onChangeFirstName(name: String) {}
-                    override fun onLastNameChange(name: String) {}
-                    override fun onUsernameChange(username: String) {}
-                    override fun onClickNext() {}
-                    override fun onClearErrorMessage() {}
-                }
+@Preview
+@Composable
+private fun Preview_Filled() {
+    MenaTheme {
+        EnterNameScreen(
+            phoneNumber = PhoneNumber(
+                "+964",
+                "7901234567"
             )
-        }
+        ).OnRender(
+            state = EnterNameUIState(
+                firstName = "Mohammed",
+                lastName = "Ahmed",
+                username = "mohammed_2025",
+                isNextEnabled = true,
+                isLoading = false
+            ),
+            listener = object : EnterNameInteractionListener {
+                override fun onChangeFirstName(name: String) {}
+                override fun onLastNameChange(name: String) {}
+                override fun onUsernameChange(username: String) {}
+                override fun onClickNext() {}
+                override fun onClearErrorMessage() {}
+            }
+        )
     }
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/enterName/EnterNameUIEffect.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/enterName/EnterNameUIEffect.kt
@@ -1,12 +1,7 @@
 package net.thechance.mena.identity.presentation.screen.register.enterName
 
-import net.thechance.mena.identity.domain.entity.PhoneNumber
+import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
 
 sealed interface EnterNameUIEffect {
-    data class NavigateToPassword(
-        val phoneNumber: PhoneNumber,
-        val firstName: String,
-        val lastName: String,
-        val username: String
-    ) : EnterNameUIEffect
+    data class NavigateToPassword(val registerUIState: RegisterUIState) : EnterNameUIEffect
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/enterName/EnterNameUIEffect.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/enterName/EnterNameUIEffect.kt
@@ -1,6 +1,6 @@
 package net.thechance.mena.identity.presentation.screen.register.enterName
 
-import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 
 sealed interface EnterNameUIEffect {
     data class NavigateToPassword(val registerUIState: RegisterUIState) : EnterNameUIEffect

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/enterName/EnterNameViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/enterName/EnterNameViewModel.kt
@@ -13,7 +13,7 @@ import net.thechance.mena.identity.presentation.base.error.ErrorState
 import net.thechance.mena.identity.presentation.base.error.handleAuthenticationException
 import net.thechance.mena.identity.presentation.mapper.mapAuthenticationErrorToMessage
 import net.thechance.mena.identity.presentation.mapper.mapErrorToMessage
-import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 import org.jetbrains.compose.resources.StringResource
 
 class EnterNameViewModel(

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/enterName/EnterNameViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/enterName/EnterNameViewModel.kt
@@ -13,6 +13,7 @@ import net.thechance.mena.identity.presentation.base.error.ErrorState
 import net.thechance.mena.identity.presentation.base.error.handleAuthenticationException
 import net.thechance.mena.identity.presentation.mapper.mapAuthenticationErrorToMessage
 import net.thechance.mena.identity.presentation.mapper.mapErrorToMessage
+import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
 import org.jetbrains.compose.resources.StringResource
 
 class EnterNameViewModel(
@@ -112,10 +113,12 @@ class EnterNameViewModel(
     }
 
     private fun createNavigateToPasswordEffect() = EnterNameUIEffect.NavigateToPassword(
-        phoneNumber = phoneNumber,
-        firstName = state.value.firstName,
-        lastName = state.value.lastName,
-        username = state.value.username
+        registerUIState = RegisterUIState(
+            phoneNumber = phoneNumber,
+            firstName = state.value.firstName,
+            lastName = state.value.lastName,
+            username = state.value.username
+        )
     )
 
     private fun onUsernameCheckError(throwable: Throwable) {

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/otp/RegisterOtpScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/otp/RegisterOtpScreen.kt
@@ -23,6 +23,7 @@ import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.identity.domain.entity.PhoneNumber
 import net.thechance.mena.identity.presentation.base.BaseScreen
 import net.thechance.mena.identity.presentation.components.AuthPrompt
 import net.thechance.mena.identity.presentation.components.AuthScreenContainer
@@ -30,14 +31,13 @@ import net.thechance.mena.identity.presentation.components.ErrorSnackBar
 import net.thechance.mena.identity.presentation.components.OtpInput
 import net.thechance.mena.identity.presentation.components.PageDescription
 import net.thechance.mena.identity.presentation.screen.register.enterName.EnterNameScreen
+import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
 
 class RegisterOtpScreen(
-    private val phoneNumber: String,
-    private val countryCode: String,
-    private val callingCode: String
+    private val registerUIState: RegisterUIState
 ) : BaseScreen<
         RegisterOtpViewModel,
         RegisterOtpUIState,
@@ -45,11 +45,7 @@ class RegisterOtpScreen(
         RegisterOtpInteractionListener>() {
     @Composable
     override fun Content() {
-        InitScreen(
-            getScreenModel(parameters = {
-                parametersOf(phoneNumber, callingCode, countryCode)
-            })
-        )
+        InitScreen(getScreenModel(parameters = { parametersOf(registerUIState) }))
     }
 
     @Composable
@@ -63,7 +59,7 @@ class RegisterOtpScreen(
                     title = stringResource(Res.string.validation_code),
                     subtitle = stringResource(
                         Res.string.register_otp_prompt,
-                        phoneNumber.takeLast(2)
+                        registerUIState.phoneNumber.localNumber.takeLast(2)
                     )
                 )
 
@@ -140,9 +136,13 @@ private fun getTimerSeconds(timer: String): String {
 fun PreviewRegisterOtpScreen() {
     MenaTheme {
         RegisterOtpScreen(
-            phoneNumber = "7901234567",
-            countryCode = "IQ",
-            callingCode = "+964"
+            RegisterUIState(
+                phoneNumber = PhoneNumber(
+                    countryCode = "+964",
+                    localNumber = "790123456"
+                ),
+                countryCode = "+964"
+            )
         ).OnRender(
             state = RegisterOtpUIState(
                 otpValue = "123456",

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/otp/RegisterOtpScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/otp/RegisterOtpScreen.kt
@@ -31,7 +31,7 @@ import net.thechance.mena.identity.presentation.components.ErrorSnackBar
 import net.thechance.mena.identity.presentation.components.OtpInput
 import net.thechance.mena.identity.presentation.components.PageDescription
 import net.thechance.mena.identity.presentation.screen.register.enterName.EnterNameScreen
-import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/otp/RegisterOtpUIEffect.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/otp/RegisterOtpUIEffect.kt
@@ -3,7 +3,5 @@ package net.thechance.mena.identity.presentation.screen.register.otp
 import net.thechance.mena.identity.domain.entity.PhoneNumber
 
 sealed interface RegisterOtpUIEffect {
-    data class NavigateToEnterName(
-        val phoneNumber: PhoneNumber
-    ) : RegisterOtpUIEffect
+    data class NavigateToEnterName(val phoneNumber: PhoneNumber) : RegisterOtpUIEffect
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/otp/RegisterOtpViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/otp/RegisterOtpViewModel.kt
@@ -13,7 +13,7 @@ import net.thechance.mena.identity.presentation.base.error.ErrorState
 import net.thechance.mena.identity.presentation.base.error.handleAuthenticationException
 import net.thechance.mena.identity.presentation.mapper.mapAuthenticationErrorToMessage
 import net.thechance.mena.identity.presentation.mapper.mapErrorToMessage
-import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 import org.jetbrains.compose.resources.StringResource
 
 class RegisterOtpViewModel(

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/otp/RegisterOtpViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/otp/RegisterOtpViewModel.kt
@@ -13,14 +13,12 @@ import net.thechance.mena.identity.presentation.base.error.ErrorState
 import net.thechance.mena.identity.presentation.base.error.handleAuthenticationException
 import net.thechance.mena.identity.presentation.mapper.mapAuthenticationErrorToMessage
 import net.thechance.mena.identity.presentation.mapper.mapErrorToMessage
+import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
 import org.jetbrains.compose.resources.StringResource
-import net.thechance.mena.identity.domain.entity.PhoneNumber as PhoneNumberEntity
 
 class RegisterOtpViewModel(
     private val registerRepository: RegisterRepository,
-    private val phoneNumber: String,
-    private val callingCode: String,
-    private val countryCode: String,
+    private val registerUIState: RegisterUIState,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : BaseScreenModel<RegisterOtpUIState, RegisterOtpUIEffect>(RegisterOtpUIState()),
     RegisterOtpInteractionListener {
@@ -50,14 +48,7 @@ class RegisterOtpViewModel(
 
     private fun createNavigateToEnterNameEffect(): RegisterOtpUIEffect.NavigateToEnterName {
         return RegisterOtpUIEffect.NavigateToEnterName(
-            phoneNumber = createPhoneNumber()
-        )
-    }
-
-    private fun createPhoneNumber(): PhoneNumberEntity {
-        return PhoneNumberEntity(
-            countryCode = callingCode,
-            localNumber = phoneNumber
+            phoneNumber = registerUIState.phoneNumber
         )
     }
 
@@ -92,8 +83,8 @@ class RegisterOtpViewModel(
 
     private suspend fun requestNewOTP() {
         registerRepository.requestOTP(
-            phoneNumber = createPhoneNumber(),
-            countryCodeName = countryCode
+            phoneNumber = registerUIState.phoneNumber,
+            countryCodeName = registerUIState.countryCode
         )
     }
 

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/phoneEntry/RegisterPhoneEntryScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/phoneEntry/RegisterPhoneEntryScreen.kt
@@ -16,28 +16,28 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.Navigator
 import mena.identity_presentation.generated.resources.Res
-import mena.identity_presentation.generated.resources.register_prompt_title
-import mena.identity_presentation.generated.resources.you_already_have_account
 import mena.identity_presentation.generated.resources.login
 import mena.identity_presentation.generated.resources.register
 import mena.identity_presentation.generated.resources.register_prompt_description
+import mena.identity_presentation.generated.resources.register_prompt_title
+import mena.identity_presentation.generated.resources.you_already_have_account
 import net.thechance.mena.designsystem.presentation.component.button.PrimaryButton
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
+import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.identity.presentation.base.BaseScreen
-import net.thechance.mena.identity.presentation.screen.countryPicker.CountryPicker
+import net.thechance.mena.identity.presentation.components.AuthPrompt
 import net.thechance.mena.identity.presentation.components.AuthScreenContainer
 import net.thechance.mena.identity.presentation.components.ErrorSnackBar
 import net.thechance.mena.identity.presentation.components.LabeledInputPhoneNumber
 import net.thechance.mena.identity.presentation.components.PageDescription
-import net.thechance.mena.identity.presentation.screen.register.otp.RegisterOtpScreen
-import net.thechance.mena.identity.presentation.screen.login.LoginScreen
-import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
-import net.thechance.mena.identity.presentation.components.AuthPrompt
+import net.thechance.mena.identity.presentation.screen.countryPicker.CountryPicker
 import net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries.MenaCountry
-import org.jetbrains.compose.ui.tooling.preview.Preview
-import org.jetbrains.compose.resources.stringResource
+import net.thechance.mena.identity.presentation.screen.login.LoginScreen
+import net.thechance.mena.identity.presentation.screen.register.otp.RegisterOtpScreen
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 class RegisterPhoneEntryScreen : BaseScreen<
         RegisterPhoneEntryViewModel,
@@ -125,12 +125,9 @@ class RegisterPhoneEntryScreen : BaseScreen<
     ) {
         when (effect) {
             is RegisterPhoneEntryUIEffect.NavigateToOTP -> navigator.push(
-                item = RegisterOtpScreen(
-                    phoneNumber = effect.phoneNumber,
-                    countryCode = effect.countryCode,
-                    callingCode = effect.callingCode
-                )
+                item = RegisterOtpScreen(effect.registerUIState)
             )
+
             RegisterPhoneEntryUIEffect.NavigateToLogin -> navigator.push(LoginScreen())
         }
     }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/phoneEntry/RegisterPhoneEntryUIEffect.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/phoneEntry/RegisterPhoneEntryUIEffect.kt
@@ -1,6 +1,6 @@
 package net.thechance.mena.identity.presentation.screen.register.phoneEntry
 
-import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 
 sealed interface RegisterPhoneEntryUIEffect {
     data class NavigateToOTP(val registerUIState: RegisterUIState) : RegisterPhoneEntryUIEffect

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/phoneEntry/RegisterPhoneEntryUIEffect.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/phoneEntry/RegisterPhoneEntryUIEffect.kt
@@ -1,11 +1,8 @@
 package net.thechance.mena.identity.presentation.screen.register.phoneEntry
 
-sealed interface RegisterPhoneEntryUIEffect {
-    data class NavigateToOTP(
-        val phoneNumber: String,
-        val callingCode: String,
-        val countryCode: String
-    ) : RegisterPhoneEntryUIEffect
+import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
 
+sealed interface RegisterPhoneEntryUIEffect {
+    data class NavigateToOTP(val registerUIState: RegisterUIState) : RegisterPhoneEntryUIEffect
     data object NavigateToLogin : RegisterPhoneEntryUIEffect
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/phoneEntry/RegisterPhoneEntryViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/phoneEntry/RegisterPhoneEntryViewModel.kt
@@ -5,15 +5,19 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import net.thechance.mena.identity.domain.entity.PhoneNumber
 import net.thechance.mena.identity.domain.exception.AuthenticationException
+import net.thechance.mena.identity.domain.exception.OtpExpiredException
+import net.thechance.mena.identity.domain.model.RegistrationDraft
 import net.thechance.mena.identity.domain.repository.RegisterRepository
 import net.thechance.mena.identity.domain.repository.RegistrationDraftRepository
 import net.thechance.mena.identity.domain.useCase.LoginUseCase
 import net.thechance.mena.identity.presentation.base.BaseScreenModel
+import net.thechance.mena.identity.presentation.base.error.AuthenticationErrorState
 import net.thechance.mena.identity.presentation.base.error.ErrorState
 import net.thechance.mena.identity.presentation.base.error.handleAuthenticationException
 import net.thechance.mena.identity.presentation.mapper.mapAuthenticationErrorToMessage
 import net.thechance.mena.identity.presentation.mapper.mapErrorToMessage
 import net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries.MenaCountry
+import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
 import org.jetbrains.compose.resources.StringResource
 
 class RegisterPhoneEntryViewModel(
@@ -37,21 +41,20 @@ class RegisterPhoneEntryViewModel(
                     registrationDraftRepository.getDraft(phoneNumber)
                 }
             },
-            onSuccess = { savedDraft ->
-                savedDraft?.let { draft ->
-                    val phoneNumber = draft.phoneNumber ?: return@let
-                    updateState {
-                        copy(
-                            phoneNumber = phoneNumber.localNumber,
-                            currentCountry = findCountryByCallingCode(phoneNumber.countryCode)
-                        )
-                    }
-                    changeIsContinueEnabled()
-                }
-            },
-            onError = {},
+            onSuccess = ::onLoadSavedDataSuccess,
             dispatcher = dispatcher
         )
+    }
+
+    private fun onLoadSavedDataSuccess(savedDraft: RegistrationDraft?) {
+        savedDraft?.phoneNumber?.let { phoneNumber ->
+            updateState {
+                copy(
+                    phoneNumber = phoneNumber.localNumber,
+                    currentCountry = findCountryByCallingCode(phoneNumber.countryCode)
+                )
+            }
+        }
     }
 
     private fun findCountryByCallingCode(callingCode: String): MenaCountry {
@@ -100,9 +103,13 @@ class RegisterPhoneEntryViewModel(
 
     private fun createNavigateToOTPEffect(): RegisterPhoneEntryUIEffect.NavigateToOTP {
         return RegisterPhoneEntryUIEffect.NavigateToOTP(
-            phoneNumber = state.value.phoneNumber,
-            callingCode = state.value.currentCountry.callingCode,
-            countryCode = state.value.currentCountry.countryCodeName
+            registerUIState = RegisterUIState(
+                phoneNumber = PhoneNumber(
+                    countryCode = state.value.currentCountry.callingCode,
+                    localNumber = state.value.phoneNumber
+                ),
+                countryCode = state.value.currentCountry.countryCodeName
+            )
         )
     }
 
@@ -125,15 +132,13 @@ class RegisterPhoneEntryViewModel(
             val phoneNumber = createPhoneNumber()
             tryToExecute(
                 function = {
-                    val existingDraft = registrationDraftRepository.getDraft(phoneNumber)
-                        ?: net.thechance.mena.identity.domain.model.RegistrationDraft()
+                    val existingDraft =
+                        registrationDraftRepository.getDraft(phoneNumber) ?: RegistrationDraft()
                     registrationDraftRepository.saveDraft(
                         phoneNumber,
                         existingDraft.copy(phoneNumber = phoneNumber)
                     )
                 },
-                onSuccess = {},
-                onError = {},
                 dispatcher = dispatcher
             )
         }
@@ -157,6 +162,8 @@ class RegisterPhoneEntryViewModel(
 
     private fun mapErrorMessage(throwable: Throwable): StringResource {
         return when (throwable) {
+            is OtpExpiredException -> mapAuthenticationErrorToMessage(AuthenticationErrorState.InvalidMobileNumber)
+
             is AuthenticationException -> mapAuthenticationErrorToMessage(
                 handleAuthenticationException(throwable)
             )

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/phoneEntry/RegisterPhoneEntryViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/phoneEntry/RegisterPhoneEntryViewModel.kt
@@ -55,6 +55,7 @@ class RegisterPhoneEntryViewModel(
                 )
             }
         }
+        changeIsContinueEnabled()
     }
 
     private fun findCountryByCallingCode(callingCode: String): MenaCountry {

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/phoneEntry/RegisterPhoneEntryViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/phoneEntry/RegisterPhoneEntryViewModel.kt
@@ -17,7 +17,7 @@ import net.thechance.mena.identity.presentation.base.error.handleAuthenticationE
 import net.thechance.mena.identity.presentation.mapper.mapAuthenticationErrorToMessage
 import net.thechance.mena.identity.presentation.mapper.mapErrorToMessage
 import net.thechance.mena.identity.presentation.screen.countryPicker.menaCountries.MenaCountry
-import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 import org.jetbrains.compose.resources.StringResource
 
 class RegisterPhoneEntryViewModel(

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/selectGender/SelectGenderScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/selectGender/SelectGenderScreen.kt
@@ -22,7 +22,7 @@ import net.thechance.mena.identity.presentation.components.AuthScreenContainer
 import net.thechance.mena.identity.presentation.components.ErrorSnackBar
 import net.thechance.mena.identity.presentation.components.PageDescription
 import net.thechance.mena.identity.presentation.screen.editProfile.components.GenderToggle
-import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
 import net.thechance.mena.identity.presentation.screen.register.uploadProfileImage.UploadProfileImageScreen
 import org.jetbrains.compose.resources.stringResource
 import org.koin.core.parameter.parametersOf

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/selectGender/SelectGenderScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/selectGender/SelectGenderScreen.kt
@@ -11,41 +11,33 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.Navigator
-import kotlinx.datetime.LocalDate
 import mena.identity_presentation.generated.resources.Res
 import mena.identity_presentation.generated.resources.register
 import mena.identity_presentation.generated.resources.select_gender_screen_prompt
 import mena.identity_presentation.generated.resources.select_gender_screen_prompt_title
 import net.thechance.mena.designsystem.presentation.component.button.PrimaryButton
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
-import net.thechance.mena.identity.domain.entity.PhoneNumber
 import net.thechance.mena.identity.presentation.base.BaseScreen
 import net.thechance.mena.identity.presentation.components.AuthScreenContainer
 import net.thechance.mena.identity.presentation.components.ErrorSnackBar
 import net.thechance.mena.identity.presentation.components.PageDescription
 import net.thechance.mena.identity.presentation.screen.editProfile.components.GenderToggle
+import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
 import net.thechance.mena.identity.presentation.screen.register.uploadProfileImage.UploadProfileImageScreen
 import org.jetbrains.compose.resources.stringResource
 import org.koin.core.parameter.parametersOf
 
 class SelectGenderScreen(
-    private val firstName: String,
-    private val lastName: String,
-    private val username: String,
-    private val password: String,
-    private val birthDate: LocalDate,
-    private val phoneNumber: PhoneNumber
-) :
-    BaseScreen<SelectGenderScreenViewModel, SelectGenderScreenUIState, SelectGenderScreenUIEffect, SelectGenderScreenInteractionListener>() {
+    private val registerUIState: RegisterUIState
+) : BaseScreen<
+        SelectGenderScreenViewModel,
+        SelectGenderScreenUIState,
+        SelectGenderScreenUIEffect,
+        SelectGenderScreenInteractionListener>() {
+
     @Composable
     override fun Content() {
-        InitScreen(
-            getScreenModel(
-                parameters = {
-                    parametersOf(phoneNumber, firstName, lastName, username, password, birthDate)
-                }
-            )
-        )
+        InitScreen(getScreenModel(parameters = { parametersOf(registerUIState) }))
     }
 
     @Composable
@@ -66,10 +58,7 @@ class SelectGenderScreen(
                         subtitle = stringResource(Res.string.select_gender_screen_prompt),
                     )
 
-                    GenderToggle(
-                        gender = state.gender,
-                        onChangeGender = listener::onChangeGender
-                    )
+                    GenderToggle(gender = state.gender, onChangeGender = listener::onChangeGender)
 
                     Spacer(modifier = Modifier.weight(1f))
 
@@ -96,10 +85,12 @@ class SelectGenderScreen(
     ) {
         when (effect) {
             is SelectGenderScreenUIEffect.NavigateToUploadProfileImage -> {
-                navigator.push(UploadProfileImageScreen(
-                    authTokens = effect.authTokens,
-                    phoneNumber = effect.phoneNumber
-                ))
+                navigator.push(
+                    UploadProfileImageScreen(
+                        authTokens = effect.authTokens,
+                        phoneNumber = effect.phoneNumber
+                    )
+                )
             }
         }
     }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/selectGender/SelectGenderScreenViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/selectGender/SelectGenderScreenViewModel.kt
@@ -3,12 +3,9 @@ package net.thechance.mena.identity.presentation.screen.register.selectGender
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
-import kotlinx.datetime.LocalDate
 import net.thechance.mena.identity.domain.entity.Gender
-import net.thechance.mena.identity.domain.entity.PhoneNumber
 import net.thechance.mena.identity.domain.exception.AuthenticationException
 import net.thechance.mena.identity.domain.model.AuthenticationTokens
-import net.thechance.mena.identity.domain.model.RegisterRequest
 import net.thechance.mena.identity.domain.model.RegistrationDraft
 import net.thechance.mena.identity.domain.repository.AuthenticationRepository
 import net.thechance.mena.identity.domain.repository.RegisterRepository
@@ -18,32 +15,25 @@ import net.thechance.mena.identity.presentation.base.error.ErrorState
 import net.thechance.mena.identity.presentation.base.error.handleAuthenticationException
 import net.thechance.mena.identity.presentation.mapper.mapAuthenticationErrorToMessage
 import net.thechance.mena.identity.presentation.mapper.mapErrorToMessage
+import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
+import net.thechance.mena.identity.presentation.screen.register.shared.toRegisterRequest
 import org.jetbrains.compose.resources.StringResource
 
 class SelectGenderScreenViewModel(
     private val registerRepository: RegisterRepository,
     private val registrationDraftRepository: RegistrationDraftRepository,
     private val authenticationRepository: AuthenticationRepository,
-    private val phoneNumber: PhoneNumber,
-    private val firstName: String,
-    private val lastName: String,
-    private val username: String,
-    private val password: String,
-    private val birthDate: LocalDate,
+    private val registerUIState: RegisterUIState,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) :
     BaseScreenModel<SelectGenderScreenUIState, SelectGenderScreenUIEffect>(
         SelectGenderScreenUIState()
     ), SelectGenderScreenInteractionListener {
 
-    init {
-        loadSavedData()
-    }
+    init { loadSavedData() }
 
     override fun onClickRegister() {
-        state.value.gender?.let { gender ->
-            startRegistration(gender)
-        }
+        state.value.gender?.let { gender -> startRegistration(gender) }
     }
 
     override fun onChangeGender(gender: Gender) {
@@ -57,9 +47,8 @@ class SelectGenderScreenViewModel(
 
     private fun loadSavedData() {
         tryToExecute(
-            function = { registrationDraftRepository.getDraft(phoneNumber) },
+            function = { registrationDraftRepository.getDraft(registerUIState.phoneNumber) },
             onSuccess = ::handleSavedDraft,
-            onError = {},
             dispatcher = dispatcher
         )
     }
@@ -81,17 +70,8 @@ class SelectGenderScreenViewModel(
     }
 
     private suspend fun register(gender: Gender): AuthenticationTokens =
-        registerRepository.register(createRegisterRequest(gender))
+        registerRepository.register(registerUIState.toRegisterRequest(gender))
 
-    private fun createRegisterRequest(gender: Gender) = RegisterRequest(
-        phoneNumber = phoneNumber,
-        username = username,
-        firstName = firstName,
-        lastName = lastName,
-        birthDate = birthDate,
-        gender = gender,
-        password = password
-    )
 
     private fun onRegisterSuccess(authTokens: AuthenticationTokens) {
         updateState { copy(isRegisterLoading = false) }
@@ -102,24 +82,20 @@ class SelectGenderScreenViewModel(
 
     private fun navigateToUploadScreen(authTokens: AuthenticationTokens) {
         sendNewEffect(
-            SelectGenderScreenUIEffect.NavigateToUploadProfileImage(authTokens, phoneNumber)
+            SelectGenderScreenUIEffect.NavigateToUploadProfileImage(authTokens, registerUIState.phoneNumber)
         )
     }
 
     private fun saveTokensTemporarily(authTokens: AuthenticationTokens) {
         tryToExecute(
             function = { authenticationRepository.saveAuthTokensWithoutEmit(authTokens) },
-            onSuccess = {},
-            onError = {},
             dispatcher = dispatcher
         )
     }
 
     private fun clearDraft() {
         tryToExecute(
-            function = { registrationDraftRepository.clearDraft(phoneNumber) },
-            onSuccess = {},
-            onError = {},
+            function = { registrationDraftRepository.clearDraft(registerUIState.phoneNumber) },
             dispatcher = dispatcher
         )
     }
@@ -136,11 +112,9 @@ class SelectGenderScreenViewModel(
     private fun saveGender(gender: Gender) {
         tryToExecute(
             function = {
-                val draft = registrationDraftRepository.getDraft(phoneNumber) ?: RegistrationDraft()
-                registrationDraftRepository.saveDraft(phoneNumber, draft.copy(gender = gender))
+                val draft = registrationDraftRepository.getDraft(registerUIState.phoneNumber) ?: RegistrationDraft()
+                registrationDraftRepository.saveDraft(registerUIState.phoneNumber, draft.copy(gender = gender))
             },
-            onSuccess = {},
-            onError = {},
             dispatcher = dispatcher
         )
     }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/selectGender/SelectGenderScreenViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/selectGender/SelectGenderScreenViewModel.kt
@@ -15,8 +15,8 @@ import net.thechance.mena.identity.presentation.base.error.ErrorState
 import net.thechance.mena.identity.presentation.base.error.handleAuthenticationException
 import net.thechance.mena.identity.presentation.mapper.mapAuthenticationErrorToMessage
 import net.thechance.mena.identity.presentation.mapper.mapErrorToMessage
-import net.thechance.mena.identity.presentation.screen.register.shared.RegisterUIState
-import net.thechance.mena.identity.presentation.screen.register.shared.toRegisterRequest
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.RegisterUIState
+import net.thechance.mena.identity.presentation.screen.register.shared.uiState.toRegisterRequest
 import org.jetbrains.compose.resources.StringResource
 
 class SelectGenderScreenViewModel(

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/shared/RegisterUIState.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/shared/RegisterUIState.kt
@@ -1,0 +1,31 @@
+package net.thechance.mena.identity.presentation.screen.register.shared
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import net.thechance.mena.identity.domain.entity.Gender
+import net.thechance.mena.identity.domain.entity.PhoneNumber
+import net.thechance.mena.identity.domain.model.RegisterRequest
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+data class RegisterUIState @OptIn(ExperimentalTime::class) constructor(
+    val phoneNumber: PhoneNumber = PhoneNumber(countryCode = "", localNumber = "00"),
+    val countryCode: String = "",
+    val firstName: String = "",
+    val lastName: String = "",
+    val username: String = "",
+    val password: String = "",
+    val birthDate: LocalDate = Clock.System.now()
+        .toLocalDateTime(TimeZone.currentSystemDefault()).date,
+)
+
+fun RegisterUIState.toRegisterRequest(gender: Gender) = RegisterRequest(
+    phoneNumber = phoneNumber,
+    username = username,
+    firstName = firstName,
+    lastName = lastName,
+    birthDate = birthDate,
+    gender = gender,
+    password = password
+)

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/shared/uiState/RegisterUIState.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/shared/uiState/RegisterUIState.kt
@@ -1,4 +1,4 @@
-package net.thechance.mena.identity.presentation.screen.register.shared
+package net.thechance.mena.identity.presentation.screen.register.shared.uiState
 
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/uploadProfileImage/UploadProfileImageScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/uploadProfileImage/UploadProfileImageScreen.kt
@@ -40,8 +40,12 @@ import org.koin.core.parameter.parametersOf
 class UploadProfileImageScreen(
     private val authTokens: AuthenticationTokens? = null,
     private val phoneNumber: PhoneNumber? = null
-) :
-    BaseScreen<UploadProfileImageViewModel, UploadProfileImageUIState, UploadProfileImageUIEffect, UploadProfileImageInteractionListener>() {
+) : BaseScreen<
+        UploadProfileImageViewModel,
+        UploadProfileImageUIState,
+        UploadProfileImageUIEffect,
+        UploadProfileImageInteractionListener>() {
+
     @Composable
     override fun OnRender(
         state: UploadProfileImageUIState,

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/uploadProfileImage/UploadProfileImageUIEffect.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/uploadProfileImage/UploadProfileImageUIEffect.kt
@@ -3,7 +3,7 @@ package net.thechance.mena.identity.presentation.screen.register.uploadProfileIm
 import net.thechance.mena.identity.domain.model.AuthenticationTokens
 
 sealed interface UploadProfileImageUIEffect {
-    data class NavigateToAccountCreated(val authTokens: AuthenticationTokens) : UploadProfileImageUIEffect
+    data class NavigateToAccountCreated(val authTokens: AuthenticationTokens? = null) : UploadProfileImageUIEffect
     data class NavigateToCropScreen(
         val imageKey: String,
         val onResult: (String) -> Unit


### PR DESCRIPTION
### fix show invalid number instead of otp expired in phone entry
1 - fix show invalid number instead of otp expired in phone entry as showing in the video 
2 - make a shared ui state to be used in register flow 
3 - move request dto to request package in auth dto directory
4 - add SerialName annotations to request DTOs for consistency 
5 - remove not used settings in register repo 
6 - clean the view model di 


#### video that show the before and after fix the bug 
<table>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/67978d58-199e-412f-868a-1ae9134b9402" width="100%" controls></video>
      <p style="text-align:center; font-weight:bold;">Before</p>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/66c16cda-5007-4b8b-95de-1509d93778ab" width="100%" controls></video>
      <p style="text-align:center; font-weight:bold;">After</p>
    </td>
  </tr>
</table>