### PR TITLE
fix: remove multiple launching of file picker in upload video screen

### DIFF
--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/upload_reel/UploadReelInteractionListener.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/upload_reel/UploadReelInteractionListener.kt
@@ -5,6 +5,7 @@ import net.thechance.mena.trends.presentation.shared.model.FileUiState
 interface UploadReelInteractionListener {
     fun onClickBack()
     fun onRetrieveVideo(file: FileUiState)
+    fun onClickUploadCard()
     fun onClickCancelUpload()
     fun onClickDeleteVideo()
     fun onClickRetryUpload()

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/upload_reel/UploadReelScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/upload_reel/UploadReelScreen.kt
@@ -59,6 +59,18 @@ internal fun UploadReelScreen(
     val navController = LocalNavController.current
     val snackBarController = LocalSnackbarController.current
 
+    val coroutineScope = rememberCoroutineScope()
+    val launcher = rememberFilePickerLauncher(
+        type = FileKitType.Video,
+        onResult = { file ->
+            launchFilePicker(
+                file = file,
+                coroutineScope = coroutineScope,
+                onRetrieveVideo = viewModel::onRetrieveVideo
+            )
+        }
+    )
+
     ObserveAsEffect(viewModel.effect) { effect ->
         when (effect) {
             is UploadReelScreenEffect.NavigateToAddDescription -> {
@@ -75,6 +87,7 @@ internal fun UploadReelScreen(
             }
 
             UploadReelScreenEffect.NavigateBack -> navController.popBackStack()
+            UploadReelScreenEffect.LaunchFilePicker -> launcher.launch()
         }
     }
 
@@ -89,18 +102,6 @@ private fun UploadReelScreenContent(
     state: UploadReelScreenState,
     listener: UploadReelInteractionListener
 ) {
-    val coroutineScope = rememberCoroutineScope()
-    val launcher = rememberFilePickerLauncher(
-        type = FileKitType.Video,
-        onResult = { file ->
-            launchFilePicker(
-                file = file,
-                coroutineScope = coroutineScope,
-                onRetrieveVideo = listener::onRetrieveVideo
-            )
-        }
-    )
-
     Scaffold(
         topBar = { UploadReelScreenTopBar(onBackClick = listener::onClickBack) }
     ) {
@@ -117,8 +118,8 @@ private fun UploadReelScreenContent(
                 thumbnail = state.thumbnail,
                 isEnabled = state.isUploadVideoCardEnabled,
                 isLoading = state.isThumbnailLoading,
-                onCardClick = launcher::launch,
-                onEditClick = launcher::launch
+                onCardClick = listener::onClickUploadCard,
+                onEditClick = listener::onClickUploadCard
             )
             TrendsAnimatedVisibility(visible = !state.uploadingState.isIdle) {
                 VideoLoadingCardItem(

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/upload_reel/UploadReelScreenEffect.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/upload_reel/UploadReelScreenEffect.kt
@@ -6,4 +6,5 @@ sealed interface UploadReelScreenEffect {
     data object NavigateBack : UploadReelScreenEffect
     data class NavigateToAddDescription(val reelId: String) : UploadReelScreenEffect
     data class ShowErrorSnackbar(val errorState: ErrorState) : UploadReelScreenEffect
+    data object LaunchFilePicker : UploadReelScreenEffect
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/upload_reel/UploadReelViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/upload_reel/UploadReelViewModel.kt
@@ -70,6 +70,10 @@ internal class UploadReelViewModel(
         )
     }
 
+    override fun onClickUploadCard() {
+        sendEffect(UploadReelScreenEffect.LaunchFilePicker)
+    }
+
     private suspend fun validateFile() {
         val selectedFile = state.value.selectedFile
 

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/base/BaseViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/base/BaseViewModel.kt
@@ -119,7 +119,7 @@ internal abstract class BaseViewModel<State, Effect>(
     }
 
     companion object {
-        private const val THROTTLE_WINDOW_DURATION = 300L
+        private const val THROTTLE_WINDOW_DURATION = 800L
         private const val LOG_TAG = "BaseViewModel"
     }
 }

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/upload_reel/UploadReelViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/upload_reel/UploadReelViewModelTest.kt
@@ -148,6 +148,15 @@ class UploadReelViewModelTest : TestExtensions() {
     }
 
     @Test
+    fun `onClickUploadCard should send LaunchFilePicker effect`() = runTest(testDispatcher) {
+        viewModel.onClickUploadCard()
+
+        viewModel.effect.test {
+            assertThat(awaitItem()).isEqualTo(UploadReelScreenEffect.LaunchFilePicker)
+        }
+    }
+
+    @Test
     fun `onClickNext should send NavigateToAddDescription effect if upload thumbnail success`() = runTest(testDispatcher) {
         viewModel.onRetrieveVideo(validFile)
         advanceUntilIdle()


### PR DESCRIPTION
### This PR fixes the multiple launching of fire picker when clicking on upload video card in upload screen

- I replaced the immediate call of the launcher in the ui with a call to the interaction listener
- The implementation of the interaction listener function in the view model calls and effect, which is throttled by default in base view model
- Increased the throttle window duration for more strict behavior and to avoid multiple launchs