### PR TITLE
Fix/IDN-110 Immediate navigation to home screen after auth

### DIFF
--- a/composeApp/src/commonMain/kotlin/net/thechance/mena/appEntryPoint/EntryPoint.kt
+++ b/composeApp/src/commonMain/kotlin/net/thechance/mena/appEntryPoint/EntryPoint.kt
@@ -5,17 +5,20 @@ import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.thechance.mena.core_chat.api.CoreChatApi
 import net.thechance.mena.identity.api.IdentityFeatureApi
+import net.thechance.mena.identity.domain.service.AuthorizationService
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun EntryPoint(
     identityApi: IdentityFeatureApi = koinInject(),
-    viewModel: MainEntryViewModel = koinViewModel()
+    viewModel: MainEntryViewModel = koinViewModel(),
+    authorizationService: AuthorizationService = koinInject()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val accessToken by authorizationService.observeAccessToken().collectAsStateWithLifecycle()
 
-    if (state.userAccessToken.isNullOrBlank()) {
+    if (accessToken.isBlank()) {
         identityApi.LoginFlow()
         return
     }

--- a/composeApp/src/commonMain/kotlin/net/thechance/mena/appEntryPoint/MainEntryState.kt
+++ b/composeApp/src/commonMain/kotlin/net/thechance/mena/appEntryPoint/MainEntryState.kt
@@ -2,8 +2,7 @@ package net.thechance.mena.appEntryPoint
 
 data class MainEntryState(
     val activeFeature: Feature = Feature.CHAT,
-    val deepLink: DeepLink? = null,
-    val userAccessToken: String? = null
+    val deepLink: DeepLink? = null
 )
 
 enum class Feature {

--- a/composeApp/src/commonMain/kotlin/net/thechance/mena/appEntryPoint/MainEntryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/net/thechance/mena/appEntryPoint/MainEntryViewModel.kt
@@ -1,22 +1,13 @@
 package net.thechance.mena.appEntryPoint
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
-import net.thechance.mena.identity.domain.service.AuthorizationService
 
-class MainEntryViewModel(
-    private val authorizationService: AuthorizationService,
-) : ViewModel(), MainEntryInteractionListener {
+class MainEntryViewModel : ViewModel(), MainEntryInteractionListener {
     private val _state = MutableStateFlow(MainEntryState())
     val state = _state.asStateFlow()
-
-    init {
-        getUserAccessToken()
-    }
 
     override fun onDeepLinkChange(deepLink: DeepLink) {
         _state.update { it.copy(deepLink = deepLink) }
@@ -28,11 +19,5 @@ class MainEntryViewModel(
 
     override fun setActiveFeature(feature: Feature) {
         _state.update { it.copy(activeFeature = feature) }
-    }
-
-    private fun getUserAccessToken() {
-        viewModelScope.launch {
-            _state.update { it.copy(userAccessToken = authorizationService.getAccessToken()) }
-        }
     }
 }


### PR DESCRIPTION
**Made EntryPoint reactive to token changes**
   - EntryPoint now observes `AuthorizationService.observeAccessToken()` StateFlow directly
   - Automatically navigates when token changes from empty to non-empty

**Removed accessToken from UI state**
   - Removed `userAccessToken` from `MainEntryState` (authentication is not UI state)
   
   
[Screen_recording_20251108_101025.webm](https://github.com/user-attachments/assets/7fc42664-06ad-4417-b7f7-574bac619167)
