### PR TITLE
refactor: Remove toUrl() extension function

### DIFF
--- a/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/mapper/ReelMapper.kt
+++ b/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/mapper/ReelMapper.kt
@@ -5,7 +5,6 @@ import net.thechance.mena.trends.data.dto.ReelPathUrlsDto
 import net.thechance.mena.trends.data.util.orFalse
 import net.thechance.mena.trends.data.util.orZero
 import net.thechance.mena.trends.data.util.parseDateStringOrNull
-import net.thechance.mena.trends.data.util.toUrl
 import net.thechance.mena.trends.domain.entity.Reel
 import net.thechance.mena.trends.domain.model.ReelUrls
 
@@ -13,8 +12,8 @@ import net.thechance.mena.trends.domain.model.ReelUrls
 internal fun ReelDto.toEntity(): Reel {
     return Reel(
         id = id.orEmpty(),
-        thumbnailUrl = reelImageUrl?.toUrl().orEmpty(),
-        videoUrl = videoUrl?.toUrl().orEmpty(),
+        thumbnailUrl = reelImageUrl.orEmpty(),
+        videoUrl = videoUrl.orEmpty(),
         description = description.orEmpty(),
         likesCount = likesCount.orZero(),
         viewsCount = viewsCount.orZero(),
@@ -28,7 +27,7 @@ internal fun ReelDto.toEntity(): Reel {
 
 internal fun ReelPathUrlsDto.toReelUrls(): ReelUrls{
     return ReelUrls(
-        videoUrl = videoPath?.toUrl().orEmpty(),
-        thumbnailUrl = thumbnailPath?.toUrl().orEmpty()
+        videoUrl = videoPath.orEmpty(),
+        thumbnailUrl = thumbnailPath.orEmpty()
     )
 }

--- a/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/util/mapperExtensions.kt
+++ b/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/util/mapperExtensions.kt
@@ -21,7 +21,3 @@ fun String?.parseDateStringOrNull(
             .toLocalDateTime(TimeZone.currentSystemDefault())
     }.getOrNull()
 }
-
-internal fun String.toUrl(): String{
-    return "https://mena-trends.fra1.cdn.digitaloceanspaces.com/$this"
-}

--- a/trends_data/src/commonTest/kotlin/net/thechance/mena/trends/data/mapper/ReelMapperTest.kt
+++ b/trends_data/src/commonTest/kotlin/net/thechance/mena/trends/data/mapper/ReelMapperTest.kt
@@ -6,7 +6,6 @@ import assertk.assertions.isNull
 import kotlinx.datetime.LocalDateTime
 import net.thechance.mena.trends.data.dto.CategoryDto
 import net.thechance.mena.trends.data.dto.ReelDto
-import net.thechance.mena.trends.data.util.toUrl
 import kotlin.test.Test
 
 internal class ReelMapperTest {

--- a/trends_data/src/commonTest/kotlin/net/thechance/mena/trends/data/mapper/ReelMapperTest.kt
+++ b/trends_data/src/commonTest/kotlin/net/thechance/mena/trends/data/mapper/ReelMapperTest.kt
@@ -15,8 +15,8 @@ internal class ReelMapperTest {
         val entity = reelDto.toEntity()
 
         assertThat(entity.id).isEqualTo(reelDto.id)
-        assertThat(entity.thumbnailUrl).isEqualTo(reelDto.reelImageUrl?.toUrl())
-        assertThat(entity.videoUrl).isEqualTo(reelDto.videoUrl?.toUrl())
+        assertThat(entity.thumbnailUrl).isEqualTo(reelDto.reelImageUrl)
+        assertThat(entity.videoUrl).isEqualTo(reelDto.videoUrl)
         assertThat(entity.description).isEqualTo(reelDto.description)
         assertThat(entity.likesCount).isEqualTo(reelDto.likesCount)
         assertThat(entity.viewsCount).isEqualTo(reelDto.viewsCount)

--- a/trends_data/src/commonTest/kotlin/net/thechance/mena/trends/data/repository/ReelRepositoryImplTest.kt
+++ b/trends_data/src/commonTest/kotlin/net/thechance/mena/trends/data/repository/ReelRepositoryImplTest.kt
@@ -21,7 +21,6 @@ import net.thechance.mena.trends.data.repository.util.toggleLikeReelResponse
 import net.thechance.mena.trends.data.repository.util.updateReelResponse
 import net.thechance.mena.trends.data.repository.util.uploadReelResponse
 import net.thechance.mena.trends.data.repository.util.uploadReelThumbnailResponse
-import net.thechance.mena.trends.data.util.toUrl
 import net.thechance.mena.trends.domain.model.UploadReelProgress
 import kotlin.test.Test
 import kotlin.test.assertFails
@@ -234,8 +233,8 @@ internal class ReelRepositoryImplTest {
         val result = repository.getReelUrls(REEL_ID)
 
 
-        assertThat(result.videoUrl).isEqualTo(fakeReelUrls.videoPath?.toUrl())
-        assertThat(result.thumbnailUrl).isEqualTo(fakeReelUrls.thumbnailPath?.toUrl())
+        assertThat(result.videoUrl).isEqualTo(fakeReelUrls.videoPath)
+        assertThat(result.thumbnailUrl).isEqualTo(fakeReelUrls.thumbnailPath)
     }
 
     private companion object {


### PR DESCRIPTION
The `toUrl()` extension function, which prepended a base URL to a string, has been removed.
