### PR TITLE
Fix Ios deep link integration

### DIFF
--- a/composeApp/src/androidMain/kotlin/net/thechance/mena/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/net/thechance/mena/MainActivity.kt
@@ -1,5 +1,6 @@
 package net.thechance.mena
 
+import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -14,10 +15,9 @@ import net.thechance.mena.appEntryPoint.MainEntryViewModel
 import net.thechance.mena.identity.presentation.util.AppLocalizer
 import net.thechance.mena.identity.presentation.util.PermissionManager
 import org.koin.android.ext.android.inject
-import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class MainActivity : ComponentActivity() {
-    private val activityViewModel: MainEntryViewModel by viewModel<MainEntryViewModel>()
+    private val mainEntryViewModel: MainEntryViewModel by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         PermissionManager.init(this)
@@ -34,14 +34,14 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    override fun onResume() {
-        super.onResume()
-        activityViewModel.onDeepLinkChange(
-            deepLink = parseDeepLinkFromIntent()
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        mainEntryViewModel.onDeepLinkChange(
+            deepLink = parseDeepLinkFromIntent(intent)
         )
     }
 
-    private fun parseDeepLinkFromIntent(): DeepLink {
+    private fun parseDeepLinkFromIntent(intent: Intent): DeepLink {
         val appLinkData: Uri? = intent.data
         return DeepLink(
             userId = appLinkData?.getQueryParameter("userId"),

--- a/composeApp/src/commonMain/kotlin/net/thechance/mena/di/appModule.kt
+++ b/composeApp/src/commonMain/kotlin/net/thechance/mena/di/appModule.kt
@@ -2,12 +2,12 @@ package net.thechance.mena.di
 
 import net.thechance.mena.AppEnvironment
 import net.thechance.mena.appEntryPoint.MainEntryViewModel
-import org.koin.core.module.dsl.viewModelOf
+import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 const val APP_VERSION = "appVersion"
 val appModule = module {
     single(named(APP_VERSION)) { AppEnvironment.versionName }
-    viewModelOf(::MainEntryViewModel)
+    singleOf(::MainEntryViewModel)
 }

--- a/composeApp/src/commonMain/kotlin/net/thechance/mena/di/utils/DIHelper.kt
+++ b/composeApp/src/commonMain/kotlin/net/thechance/mena/di/utils/DIHelper.kt
@@ -1,0 +1,9 @@
+package net.thechance.mena.di.utils
+
+import net.thechance.mena.appEntryPoint.MainEntryViewModel
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+
+class DIHelper: KoinComponent {
+    fun getMainEntryViewModel(): MainEntryViewModel = this.get()
+}

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -17,6 +17,7 @@ struct ContentView: View {
             .ignoresSafeArea()
             .onOpenURL { url in
                 let deepLink = parseDeepLink(from: url)
+                DIHelper().getMainEntryViewModel().onDeepLinkChange(deepLink: deepLink)
             }
     }
 }


### PR DESCRIPTION
This PR brings deep link handling to the IOS side by providing single instance of the `MainEntryViewModel` using `DIHelper` class.


https://github.com/user-attachments/assets/794c3b68-d8ec-42ce-82b1-88c1ca5f90ad
