### PR TITLE
fix retrieve refresh token

### DIFF
--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/remote/network/httpClient.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/remote/network/httpClient.kt
@@ -47,13 +47,13 @@ fun createHttpClient(
                 loadTokens {
                     BearerTokens(
                         accessToken = authorizationService.getAccessToken(),
-                        refreshToken = ""
+                        refreshToken = authorizationService.getRefreshToken()
                     )
                 }
                 refreshTokens {
                     BearerTokens(
-                        accessToken = authorizationService.refreshToken(),
-                        refreshToken = ""
+                        accessToken = authorizationService.getNewAccessToken(),
+                        refreshToken = authorizationService.getRefreshToken()
                     )
                 }
             }

--- a/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/util/network/buildApiClient.kt
+++ b/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/util/network/buildApiClient.kt
@@ -55,15 +55,13 @@ fun buildApiClient(
                 loadTokens {
                     BearerTokens(
                         accessToken = authorizationService.getAccessToken(),
-                        refreshToken = authorizationService.refreshToken()
+                        refreshToken = authorizationService.getRefreshToken()
                     )
                 }
-
                 refreshTokens {
-                    val newAccessToken = authorizationService.refreshToken()
                     BearerTokens(
-                        accessToken = newAccessToken,
-                        refreshToken = authorizationService.refreshToken()
+                        accessToken = authorizationService.getNewAccessToken(),
+                        refreshToken = authorizationService.getRefreshToken()
                     )
                 }
             }

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/client/NetworkClient.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/client/NetworkClient.kt
@@ -51,13 +51,13 @@ class NetworkClient(
                     loadTokens {
                         BearerTokens(
                             accessToken = authorizationService.getAccessToken(),
-                            refreshToken = authorizationService.refreshToken()
+                            refreshToken = authorizationService.getRefreshToken()
                         )
                     }
                     refreshTokens {
                         BearerTokens(
-                            accessToken = authorizationService.refreshToken(),
-                            refreshToken = authorizationService.refreshToken()
+                            accessToken = authorizationService.getNewAccessToken(),
+                            refreshToken = authorizationService.getRefreshToken()
                         )
                     }
                 }

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/identityDataModule.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/identityDataModule.kt
@@ -11,13 +11,13 @@ import net.thechance.mena.identity.data.dataSource.local.database.dao.UserDao
 import net.thechance.mena.identity.data.repository.AuthenticationRepositoryImpl
 import net.thechance.mena.identity.data.repository.ImagesRepositoryImpl
 import net.thechance.mena.identity.data.repository.RegisterRepositoryImpl
+import net.thechance.mena.identity.data.repository.RegistrationDraftRepositoryImpl
 import net.thechance.mena.identity.data.repository.ResetPasswordRepositoryImpl
 import net.thechance.mena.identity.data.repository.SettingsRepositoryImpl
 import net.thechance.mena.identity.data.repository.UserRepositoryImpl
 import net.thechance.mena.identity.data.repository.location.AddressesRepositoryImpl
 import net.thechance.mena.identity.data.repository.location.GeocoderWrapper
 import net.thechance.mena.identity.data.repository.location.MobileGeocoderWrapper
-import net.thechance.mena.identity.data.repository.RegistrationDraftRepositoryImpl
 import net.thechance.mena.identity.domain.repository.AddressesRepository
 import net.thechance.mena.identity.domain.repository.AuthenticationRepository
 import net.thechance.mena.identity.domain.repository.ImagesRepository
@@ -70,11 +70,10 @@ val identityDataModule = module {
     singleOf(::ImagesRepositoryImpl) bind ImagesRepository::class
     singleOf(::AuthorizationService)
     single(named(IDENTITY_CLIENT)) {
-        provideCoilClient(
+        provideHttpClient(
             engine = get(),
             baseUrl = get<String>(named(BASE_URL)),
-            settings = get(),
-            refreshToken = { get<AuthorizationService>().refreshToken() }
+            authorizationService = { get<AuthorizationService>() },
         )
     }
 

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/provideHttpClient.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/provideHttpClient.kt
@@ -1,6 +1,5 @@
 package net.thechance.mena.identity.data.di
 
-import com.russhwolf.settings.Settings
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.HttpTimeout
@@ -15,19 +14,17 @@ import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.encodedPath
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
-import net.thechance.mena.identity.data.dataSource.local.setting.accessToken
-import net.thechance.mena.identity.data.dataSource.local.setting.refreshToken
 import net.thechance.mena.identity.data.repository.AuthenticationRepositoryImpl.Companion.LOGIN_ENDPOINT
 import net.thechance.mena.identity.data.repository.AuthenticationRepositoryImpl.Companion.REFRESH_ENDPOINT
 import net.thechance.mena.identity.data.repository.ResetPasswordRepositoryImpl.Companion.REQUEST_OTP
 import net.thechance.mena.identity.data.repository.ResetPasswordRepositoryImpl.Companion.RESET_PASSWORD
 import net.thechance.mena.identity.data.repository.ResetPasswordRepositoryImpl.Companion.VERIFY_OTP
+import net.thechance.mena.identity.domain.service.AuthorizationService
 
-internal fun provideCoilClient(
+internal fun provideHttpClient(
     engine: HttpClientEngine,
-    settings: Settings,
     baseUrl: String,
-    refreshToken: suspend () -> Unit
+    authorizationService: suspend () -> AuthorizationService,
 ): HttpClient {
     return HttpClient(engine) {
         defaultRequest { url(baseUrl) }
@@ -45,11 +42,16 @@ internal fun provideCoilClient(
         install(Auth) {
             bearer {
                 loadTokens {
-                    BearerTokens(settings.accessToken, settings.refreshToken)
+                    BearerTokens(
+                        accessToken = authorizationService().getAccessToken(),
+                        refreshToken = authorizationService().getRefreshToken(),
+                    )
                 }
                 refreshTokens {
-                    refreshToken()
-                    BearerTokens(settings.accessToken, settings.refreshToken)
+                    BearerTokens(
+                        accessToken = authorizationService().getNewAccessToken(),
+                        refreshToken = authorizationService().getRefreshToken(),
+                    )
                 }
                 sendWithoutRequest { request ->
                     val path = request.url.encodedPath.removePrefix("/")

--- a/identity_domain/src/commonMain/kotlin/net/thechance/mena/identity/domain/service/AuthorizationService.kt
+++ b/identity_domain/src/commonMain/kotlin/net/thechance/mena/identity/domain/service/AuthorizationService.kt
@@ -3,14 +3,18 @@ package net.thechance.mena.identity.domain.service
 import kotlinx.coroutines.flow.StateFlow
 import net.thechance.mena.identity.domain.repository.AuthenticationRepository
 
-class AuthorizationService (private val authenticationRepository: AuthenticationRepository){
+class AuthorizationService(private val authenticationRepository: AuthenticationRepository) {
 
     suspend fun getAccessToken(): String {
         return authenticationRepository.getAccessToken()
     }
 
-    suspend fun refreshToken(): String {
+    suspend fun getNewAccessToken(): String {
         return authenticationRepository.refreshAccessToken()
+    }
+
+    suspend fun getRefreshToken(): String {
+        return authenticationRepository.getAuthTokens()?.refreshToken ?: ""
     }
 
     fun observeAccessToken(): StateFlow<String> = authenticationRepository.observeTokenChange()

--- a/identity_domain/src/jvmTest/kotlin/net/thechance/mena/identity/domain/service/AuthenticationServiceTest.kt
+++ b/identity_domain/src/jvmTest/kotlin/net/thechance/mena/identity/domain/service/AuthenticationServiceTest.kt
@@ -31,7 +31,7 @@ class AuthenticationServiceTest {
     fun `getRefreshToken() should return refresh token`() = runTest{
         coEvery { authenticationRepository.refreshAccessToken() } returns refreshToken
 
-        val result = authorizationService.refreshToken()
+        val result = authorizationService.getNewAccessToken()
 
         assertEquals(refreshToken ,result)
 

--- a/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/client/NetworkClient.kt
+++ b/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/client/NetworkClient.kt
@@ -78,15 +78,14 @@ class NetworkClient : KoinComponent {
                 loadTokens {
                     BearerTokens(
                         accessToken = authorizationService.getAccessToken(),
-                        refreshToken = authorizationService.refreshToken()
+                        refreshToken = authorizationService.getRefreshToken()
                     )
                 }
 
                 refreshTokens {
-                    val newAccessToken = authorizationService.refreshToken()
                     BearerTokens(
-                        accessToken = newAccessToken,
-                        refreshToken = authorizationService.refreshToken()
+                        accessToken = authorizationService.getNewAccessToken(),
+                        refreshToken = authorizationService.getRefreshToken()
                     )
                 }
             }

--- a/wallet_data/src/commonMain/kotlin/net/thechance/mena/wallet/data/network_client/NetworkClientImpl.kt
+++ b/wallet_data/src/commonMain/kotlin/net/thechance/mena/wallet/data/network_client/NetworkClientImpl.kt
@@ -96,13 +96,13 @@ class NetworkClientImpl(
                     loadTokens {
                         BearerTokens(
                             accessToken = authorizationService.getAccessToken(),
-                            refreshToken = ""
+                            refreshToken = authorizationService.getRefreshToken()
                         )
                     }
                     refreshTokens {
                         BearerTokens(
-                            accessToken = authorizationService.refreshToken(),
-                            refreshToken = ""
+                            accessToken = authorizationService.getNewAccessToken(),
+                            refreshToken = authorizationService.getRefreshToken()
                         )
                     }
                 }


### PR DESCRIPTION
There is a problem retrieving the refresh token when creating the HttpClient; it should get the refresh token from the local storage and just refresh it when needed.