### PR TITLE
fix:empty screen appear before loading data

### DIFF
--- a/admin_panel/src/commonMain/kotlin/net/thechance/mena/admin_panel/presentation/screen/users_management/UsersManagementScreen.kt
+++ b/admin_panel/src/commonMain/kotlin/net/thechance/mena/admin_panel/presentation/screen/users_management/UsersManagementScreen.kt
@@ -68,9 +68,8 @@ private fun UsersManagementScreenContent(
             )
 
             when {
-                state.isLoading && state.users.isEmpty()-> UsersLoadingIndicator()
-
-                state.users.isEmpty() ->{
+                state.users.isEmpty()-> UsersLoadingIndicator()
+                false ->{
                     if (state.query.isNotEmpty()) {
                         UsersSearchEmptyState()
                     } else{

--- a/admin_panel/src/commonMain/kotlin/net/thechance/mena/admin_panel/presentation/screen/users_management/UsersManagementScreen.kt
+++ b/admin_panel/src/commonMain/kotlin/net/thechance/mena/admin_panel/presentation/screen/users_management/UsersManagementScreen.kt
@@ -68,8 +68,9 @@ private fun UsersManagementScreenContent(
             )
 
             when {
-                state.users.isEmpty()-> UsersLoadingIndicator()
-                false ->{
+                state.isLoading -> UsersLoadingIndicator()
+
+                state.users.isEmpty() ->{
                     if (state.query.isNotEmpty()) {
                         UsersSearchEmptyState()
                     } else{

--- a/admin_panel/src/commonMain/kotlin/net/thechance/mena/admin_panel/presentation/screen/users_management/UsersManagementScreenState.kt
+++ b/admin_panel/src/commonMain/kotlin/net/thechance/mena/admin_panel/presentation/screen/users_management/UsersManagementScreenState.kt
@@ -13,7 +13,7 @@ data class UsersManagementScreenState(
     val query: String = "",
     val pageInfo : UserPageInfo = UserPageInfo(),
     val sort: SortState = SortState(),
-    val isLoading: Boolean = false,
+    val isLoading: Boolean = true,
     val errorState: ErrorState? = null,
     val snackBar: SnackBarState = SnackBarState(),
     val isBlockDialogShown: Boolean = false,

--- a/admin_panel/src/commonMain/kotlin/net/thechance/mena/admin_panel/presentation/screen/users_management/UsersManagementScreenState.kt
+++ b/admin_panel/src/commonMain/kotlin/net/thechance/mena/admin_panel/presentation/screen/users_management/UsersManagementScreenState.kt
@@ -13,7 +13,7 @@ data class UsersManagementScreenState(
     val query: String = "",
     val pageInfo : UserPageInfo = UserPageInfo(),
     val sort: SortState = SortState(),
-    val isLoading: Boolean = true,
+    val isLoading: Boolean = false,
     val errorState: ErrorState? = null,
     val snackBar: SnackBarState = SnackBarState(),
     val isBlockDialogShown: Boolean = false,


### PR DESCRIPTION
fix:empty screen appear before loading data
before:

https://github.com/user-attachments/assets/0007433f-07e5-48fc-9775-b9a4cae3d211

after:

https://github.com/user-attachments/assets/18a367fd-8648-4a4f-b236-16941ea915b6



