### PR TITLE
fix/CHT-78-correct-balance-amount-when-no-internet

### DIFF
--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeScreenState.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeScreenState.kt
@@ -9,7 +9,7 @@ data class HomeScreenState(
     val isBalanceLoading: Boolean = false,
     val isSynced: Boolean = false,
     val isError: Boolean = false,
-    val balanceAmount: Int = 0,
+    val balanceAmount: String = "0",
     val chats: List<ChatUiState> = emptyList()
 ) {
     data class ChatUiState @OptIn(ExperimentalUuidApi::class) constructor(

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeViewModel.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeViewModel.kt
@@ -188,7 +188,7 @@ class HomeViewModel(
     }
 
     private fun onGetBalanceAmountSuccess(balanceAmount: Double) {
-        updateState { it.copy(balanceAmount = balanceAmount.toString(), isBalanceLoading = false) }
+        updateState { it.copy(balanceAmount = balanceAmount.toInt().toString(), isBalanceLoading = false) }
     }
 
     private fun onGetBalanceAmountError() {

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeViewModel.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeViewModel.kt
@@ -188,12 +188,11 @@ class HomeViewModel(
     }
 
     private fun onGetBalanceAmountSuccess(balanceAmount: Double) {
-        val balance = balanceAmount.toInt()
-        updateState { it.copy(balanceAmount = balance, isBalanceLoading = false) }
+        updateState { it.copy(balanceAmount = balanceAmount.toString(), isBalanceLoading = false) }
     }
 
     private fun onGetBalanceAmountError() {
-        updateState { it.copy(isBalanceLoading = false) }
+        updateState { it.copy(isBalanceLoading = false, balanceAmount = "--") }
         showSnackBar(
             titleStringResource = Res.string.error,
             messageStringResource = Res.string.could_not_get_balance,

--- a/core_chat_presentation/src/commonTest/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeViewModelTest.kt
+++ b/core_chat_presentation/src/commonTest/kotlin/net/thechance/mena/core_chat/presentation/screen/home/HomeViewModelTest.kt
@@ -73,7 +73,7 @@ class HomeViewModelTest {
 
         viewModel.state.test {
             val state = awaitItem()
-            assertThat(state.balanceAmount).isEqualTo(expectedBalance.toInt())
+            assertThat(state.balanceAmount).isEqualTo(expectedBalance.toInt().toString())
         }
     }
 
@@ -123,7 +123,7 @@ class HomeViewModelTest {
 
         viewModel.state.test {
             val state = awaitItem()
-            assertThat(state.balanceAmount).isEqualTo(0)
+            assertThat(state.balanceAmount).isEqualTo("--")
         }
     }
 


### PR DESCRIPTION
## what has been done
- fix the amount of balance in case of no internet connection to show 2 dashes (--) instead of zero value and hopefully preventing another HEART ATTACK from silly mistake 

fix/CHT-78-correct-balance-amount-when-no-internet

<img width="352" height="751" alt="image" src="https://github.com/user-attachments/assets/88aca79f-85c6-45d8-9c65-907d3b638f18" />
