### PR TITLE
fix: Add TRENDS_STORAGE_ACCESS_SECRET to Info.plist

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -27,11 +27,13 @@
 	<string>We need access to your camera.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>We need access to your photo library.</string>
-    <key>NSMicrophoneUsageDescription</key>
-    <string>We need access to your microphone to record audio messages.</string>
-    <key>UIFileSharingEnabled</key>
-    <true/>
-    <key>LSSupportsOpeningDocumentsInPlace</key>
-    <true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>We need access to your microphone to record audio messages.</string>
+	<key>UIFileSharingEnabled</key>
+	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
+	<key>TRENDS_STORAGE_ACCESS_SECRET</key>
+	<string>$(TRENDS_STORAGE_ACCESS_SECRET)</string>
 </dict>
 </plist>


### PR DESCRIPTION
Added TRENDS_STORAGE_ACCESS_SECRET to the Info.plist, which is required for displaying trends on the iOS platform.

Since this value is a secret, it should not be stored directly in the Info.plist.
Instead, add it to a secure configuration file such as config.xcconfig, and reference it in the Info.plist using:

<img width="1512" height="982" alt="Screenshot 2025-11-09 at 2 07 23 PM" src="https://github.com/user-attachments/assets/4c05eca0-46e8-4774-a8bd-e0cc2b156e6f" />

