### PR TITLE
Fix/dkn 127 fix image loading ios

### DIFF
--- a/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/di/DukanRepositoryModule.kt
+++ b/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/di/DukanRepositoryModule.kt
@@ -8,7 +8,8 @@ import net.thechance.mena.dukan.data.repository.DukanProductRepositoryImpl
 import net.thechance.mena.dukan.data.repository.LocationRepositoryImpl
 import net.thechance.mena.dukan.data.repository.SearchRepositoryImpl
 import net.thechance.mena.dukan.data.repository.ShelfRepositoryImpl
-import net.thechance.mena.dukan.data.util.network.buildApiClient
+import net.thechance.mena.dukan.data.util.network.buildDukanApiClient
+import net.thechance.mena.dukan.data.util.network.buildDukanCoilClient
 import net.thechance.mena.dukan.data.util.wrapper.GeocoderWrapper
 import net.thechance.mena.dukan.data.util.wrapper.MobileGeocoderWrapper
 import net.thechance.mena.dukan.domain.repository.CartRepository
@@ -25,11 +26,18 @@ import org.koin.dsl.module
 
 internal val dukanRepositoryModule = module {
     single<HttpClient>(named("dukanClient")) {
-        buildApiClient(
+        buildDukanApiClient(
             authorizationService = get(),
             baseUrl = get<String>(named("baseUrl"))
         )
     }
+
+    single<HttpClient>(named("dukanCoilClient")) {
+        buildDukanCoilClient()
+    }
+
+
+
     single<DukanDiscoveryRepository> {
         DukanDiscoveryRepositoryImpl(
             client = get(named("dukanClient")),

--- a/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/util/network/buildApiClient.kt
+++ b/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/util/network/buildApiClient.kt
@@ -20,7 +20,7 @@ import net.thechance.mena.identity.domain.service.AuthorizationService
 expect val platformHttpClientEngineFactory: HttpClientEngineFactory<HttpClientEngineConfig>
 
 
-fun buildApiClient(
+fun buildDukanApiClient(
     authorizationService: AuthorizationService,
     baseUrl: String
 ): HttpClient {
@@ -67,6 +67,17 @@ fun buildApiClient(
             }
         }
 
+        install(HttpTimeout) {
+            requestTimeoutMillis = 15_000
+            connectTimeoutMillis = 15_000
+            socketTimeoutMillis = 15_000
+        }
+    }
+}
+
+
+fun buildDukanCoilClient(): HttpClient {
+    return HttpClient(platformHttpClientEngineFactory) {
         install(HttpTimeout) {
             requestTimeoutMillis = 15_000
             connectTimeoutMillis = 15_000

--- a/dukan_presentation/build.gradle.kts
+++ b/dukan_presentation/build.gradle.kts
@@ -71,9 +71,11 @@ kotlin {
 
             // maps
             implementation(libs.maplibre.compose)
+            implementation(libs.bundles.coil)
         }
         iosMain.dependencies {
-
+            implementation(libs.bundles.coil)
+            implementation(libs.ktor.client.darwin)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/navigation/DukanNavHost.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/navigation/DukanNavHost.kt
@@ -6,6 +6,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
+import coil3.compose.setSingletonImageLoaderFactory
 import net.thechance.mena.dukan.presentation.screen.categoryDukans.CategoryDukansScreen
 import net.thechance.mena.dukan.presentation.screen.checkout.CheckoutScreen
 import net.thechance.mena.dukan.presentation.screen.createDukan.CreateDukanScreen
@@ -22,6 +23,8 @@ import net.thechance.mena.dukan.presentation.screen.pendingDukan.PendingDukanScr
 import net.thechance.mena.dukan.presentation.screen.productDetails.ProductDetailsScreen
 import net.thechance.mena.dukan.presentation.screen.search.SearchScreen
 import net.thechance.mena.dukan.presentation.screen.shelfDetails.ShelfDetailsScreen
+import net.thechance.mena.dukan.presentation.util.LocalImageLoader
+import net.thechance.mena.dukan.presentation.util.provideImageLoader
 import net.thechance.mena.wallet.api.WalletApi
 import org.koin.compose.koinInject
 import net.thechance.mena.identity.api.IdentityFeatureApi as IdentityApi
@@ -32,8 +35,10 @@ fun DukanNavHost(
     identityApi: IdentityApi = koinInject()
 ) {
     val navController = rememberNavController()
+    val coilImageLoader = provideImageLoader()
+    setSingletonImageLoaderFactory { coilImageLoader }
     CompositionLocalProvider(
-        LocalNavController provides navController
+        LocalNavController provides navController, LocalImageLoader provides coilImageLoader
     ) {
         NavHost(
             navController = navController,

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/util/ImageLoaderProvider.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/util/ImageLoaderProvider.kt
@@ -1,0 +1,30 @@
+package net.thechance.mena.dukan.presentation.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import coil3.ImageLoader
+import coil3.compose.LocalPlatformContext
+import coil3.network.ktor3.KtorNetworkFetcherFactory
+import io.ktor.client.HttpClient
+import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
+
+
+@Composable
+fun provideImageLoader(
+    networkClient: HttpClient = koinInject<HttpClient>(named("dukanCoilClient"))
+): ImageLoader{
+    val context = LocalPlatformContext.current
+    return remember {
+        ImageLoader.Builder(context)
+            .components { add(KtorNetworkFetcherFactory(networkClient)) }
+            .build()
+    }
+}
+
+
+val LocalImageLoader = staticCompositionLocalOf<ImageLoader> {
+    throw IllegalStateException("ImageLoader not initialized")
+}
+


### PR DESCRIPTION
Summary
iOS images were failing to load because Coil didn’t have a valid image loader configured for the Darwin engine.
This PR introduces a proper multiplatform setup for Coil using a shared ImageLoader with Ktor-based network support and global registration.

Changes
• Added a provideImageLoader() function using KtorNetworkFetcherFactory + platform-specific HTTP engine.
• Set up Coil’s global loader via setSingletonImageLoaderFactory { coilImageLoader } inside DukanNavHost.
• Added dukanCoilClient for image requests (separate from API client).
• Updated Gradle dependencies to include coil-network-ktor3 and ktor-client-darwin in iosMain.
• Confirmed working image loading on both Android and iOS.

Notes
• No need to manually pass imageLoader to AsyncImage anymore — Coil is globally configured.