### PR TITLE
feat: Center align mobile number text field content

### DIFF
--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/textField/MobileNumberTextField.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/textField/MobileNumberTextField.kt
@@ -3,6 +3,7 @@ package net.thechance.mena.designsystem.presentation.component.textField
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -11,6 +12,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
@@ -92,7 +94,8 @@ fun MobileNumberLeadingContent(
             .padding(
                 vertical = 13.dp,
                 horizontal = 8.dp
-            )
+            ),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Image(
             painter = countryPainter,


### PR DESCRIPTION
Before:
<img width="160" height="160" alt="image" src="https://github.com/user-attachments/assets/ca78addb-a12e-47cd-94d7-7c138b24fcfe" />

After:
<img width="179" height="206" alt="image" src="https://github.com/user-attachments/assets/37549c91-b934-4abf-92d4-1ec31cc544e5" />
