### PR TITLE
Refactor/CHT 107 create message id from client side

### DIFF
--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/messagesender/AudioMessageSender.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/messagesender/AudioMessageSender.kt
@@ -33,6 +33,7 @@ class AudioMessageSender(
         val audioFile = ("audio_${LocalDateTime.now()}" to bytes)
         val multipartAudio = audioFile.buildAudioMultiPartFormData(
             fieldName = AUDIO_FILE_PARAM,
+            messageId = message.id.toString(),
             chatId = message.chatId.toString(),
             audioDurationMs = content.audioDurationMs
         )

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/messagesender/ImageMessageSender.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/messagesender/ImageMessageSender.kt
@@ -38,6 +38,7 @@ class ImageMessageSender(
         val imageFile = ("image_${LocalDateTime.now()}" to bytes)
         val multipartImage = imageFile.buildImageMultiPartFormData(
             fieldName = IMAGES_FILES_PARAM,
+            messageId = message.id.toString(),
             chatId = message.chatId.toString()
         )
 

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/messagesender/TextMessageSender.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/messagesender/TextMessageSender.kt
@@ -25,7 +25,7 @@ class TextMessageSender(
             throw SendMessageFailedException("Message content is not text")
         }
 
-        val dto = SendMessageDto(chatId = message.chatId.toString(), text = content.text)
+        val dto = SendMessageDto(messageId = message.id.toString(), chatId = message.chatId.toString(), text = content.text)
         val messageJson = json.encodeToString(SendMessageDto.serializer(), dto)
         webSocketManager.sendTextFrame(SEND_MESSAGE_DESTINATION, messageJson)
     }

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/repository/MessageRepositoryImpl.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/repository/MessageRepositoryImpl.kt
@@ -115,9 +115,16 @@ class MessageRepositoryImpl(
 
         val page = response.toPagedListOfMessages()
 
-        cachedMessageDao.insertAllMessages(page.data.toCachedMessageLocalDto())
+        updateLocalMessages(page.data)
 
         return page
+    }
+
+    private suspend fun updateLocalMessages(messages: List<Message>){
+        cachedMessageDao.insertAllMessages(messages.toCachedMessageLocalDto())
+
+        val messagesIds = messages.map{ it.id.toString() }
+        pendingMessageDao.deleteMessagesByIds(messagesIds)
     }
 
     suspend fun syncAfterLastUpdate(chatId: Uuid) {
@@ -143,9 +150,7 @@ class MessageRepositoryImpl(
                 if (response != null && !response.data.isNullOrEmpty()) {
                     chatSyncTimeDao.upsert(ChatSyncTime(chatId.toString(), now.toString()))
 
-                    cachedMessageDao.insertAllMessages(
-                        response.data.toListOfMessages().toCachedMessageLocalDto()
-                    )
+                    updateLocalMessages(response.data.toListOfMessages())
 
                     messagesFlow.emitAll(response.data.mapNotNull(MessageDto::toDomain).asFlow())
                 }
@@ -159,11 +164,11 @@ class MessageRepositoryImpl(
     }
 
     override suspend fun deleteMessage(message: Message) {
-        pendingMessageDao.deleteMessage(message.id.toString())
+        pendingMessageDao.deleteMessageById(message.id.toString())
     }
 
     override fun observePendingMessagesByChatId(chatId: Uuid): Flow<List<Message>> {
-        val messages = pendingMessageDao.getMessagesByChat(chatId.toString())
+        val messages = pendingMessageDao.getMessagesByChatId(chatId.toString())
         return messages.map { it.toDomain() }
     }
 
@@ -179,7 +184,7 @@ class MessageRepositoryImpl(
         try {
             val messageSender = messageSenderFactory.create(message.content)
             messageSender.send(message)
-            pendingMessageDao.deleteMessage(pendingMessage.id)
+            pendingMessageDao.deleteMessageById(pendingMessage.id)
         } catch (e: Exception) {
             pendingMessageDao.updateMessageStatus(pendingMessage.id, MessageStatus.FAILED)
             throw SendMessageFailedException("Failed to send message: ${e.message}")
@@ -255,7 +260,7 @@ class MessageRepositoryImpl(
             PRIVATE_MESSAGES -> {
                 val message = json.decodeFromString<MessageDto>(body).toDomain()
                 message?.let {
-                    cachedMessageDao.insertMessage(it.toCachedMessageLocalDto())
+                    updateLocalMessages(listOf(message))
                     messagesFlow.emit(it)
                 }
             }

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/local/database/cachedMessage/CachedMessageDao.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/local/database/cachedMessage/CachedMessageDao.kt
@@ -10,9 +10,6 @@ import net.thechance.mena.core_chat.domain.entity.MessageStatus
 @Dao
 interface CachedMessageDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertMessage(message: CachedMessageLocalDto)
-
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAllMessages(message: List<CachedMessageLocalDto>)
 
     @Query("SELECT * FROM cached_messages WHERE chat_id = :chatId ORDER BY timestamp DESC LIMIT :limit OFFSET :offset")
@@ -21,12 +18,6 @@ interface CachedMessageDao {
         limit: Int,
         offset: Int
     ): List<CachedMessageLocalDto>
-
-    @Query("UPDATE cached_messages SET status = :status WHERE id = :id")
-    suspend fun updateMessageStatus(id: String, status: MessageStatus)
-
-    @Query("DELETE FROM cached_messages WHERE id = :id")
-    suspend fun deleteMessage(id: String)
 
     @Query("SELECT COUNT(*) FROM cached_messages WHERE chat_id = :chatId")
     suspend fun getTotalMessagesCount(chatId: String): Int

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/local/database/pendingMessage/PendingMessageDao.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/local/database/pendingMessage/PendingMessageDao.kt
@@ -13,11 +13,14 @@ interface PendingMessageDao {
     suspend fun insertMessage(message: PendingMessageLocalDto)
 
     @Query("SELECT * FROM pending_messages WHERE chat_id = :chatId ORDER BY timestamp ASC")
-    fun getMessagesByChat(chatId: String): Flow<List<PendingMessageLocalDto>>
+    fun getMessagesByChatId(chatId: String): Flow<List<PendingMessageLocalDto>>
 
     @Query("UPDATE pending_messages SET status = :status WHERE id = :id")
     suspend fun updateMessageStatus(id: String, status: MessageStatus)
 
     @Query("DELETE FROM pending_messages WHERE id = :id")
-    suspend fun deleteMessage(id: String)
+    suspend fun deleteMessageById(id: String)
+
+    @Query("DELETE FROM pending_messages WHERE id IN (:ids)")
+    suspend fun deleteMessagesByIds(ids: List<String>)
 }

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/remote/dto/ChatDto.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/remote/dto/ChatDto.kt
@@ -1,8 +1,6 @@
 package net.thechance.mena.core_chat.data.source.remote.dto
 
 import kotlinx.serialization.Serializable
-import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 
 @Serializable
 data class ChatDto(
@@ -10,10 +8,4 @@ data class ChatDto(
     val name: String,
     val imageUrl: String?,
     val requesterId: String,
-)
-
-@OptIn(ExperimentalUuidApi::class)
-@Serializable
-data class DeleteChatResponse(
-    val deletedChatId: Uuid,
 )

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/remote/dto/MessageDto.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/remote/dto/MessageDto.kt
@@ -19,6 +19,7 @@ data class MessageDto(
 
 @Serializable
 data class SendMessageDto(
+    val messageId: String,
     val chatId: String,
     val text: String? = null
 )

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/utils/buildAudioMultiPartFormData.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/utils/buildAudioMultiPartFormData.kt
@@ -7,6 +7,7 @@ import io.ktor.http.HttpHeaders
 
 fun Pair<String, ByteArray>.buildAudioMultiPartFormData(
     fieldName: String,
+    messageId: String,
     chatId: String,
     audioDurationMs: Long? = null
 ): MultiPartFormDataContent {
@@ -16,6 +17,7 @@ fun Pair<String, ByteArray>.buildAudioMultiPartFormData(
 
     return MultiPartFormDataContent(
         formData {
+            append("messageId", messageId)
             append("chatId", chatId)
             audioDurationMs?.let { append("audioDurationMs", it.toString()) }
             append(

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/utils/buildImageMultiPartFormData.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/utils/buildImageMultiPartFormData.kt
@@ -9,7 +9,8 @@ import io.ktor.http.HttpHeaders
 
 fun Pair<String, ByteArray>.buildImageMultiPartFormData(
     fieldName: String,
-    chatId: String
+    messageId: String,
+    chatId: String,
 ): MultiPartFormDataContent {
     val (name, byteArray) = this
     val extension = byteArray.getExtension()
@@ -17,6 +18,7 @@ fun Pair<String, ByteArray>.buildImageMultiPartFormData(
 
     return MultiPartFormDataContent(
         formData {
+            append("messageId", messageId)
             append("chatId", chatId)
             append(
                 fieldName,

--- a/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/chat/MessageRepositoryImplTest.kt
+++ b/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/chat/MessageRepositoryImplTest.kt
@@ -136,11 +136,11 @@ class MessageRepositoryImplTest {
             senderId = userId,
             chatId = chatId,
         )
-        everySuspend { pendingMessageDao.deleteMessage(any()) } returns Unit
+        everySuspend { pendingMessageDao.deleteMessageById(any()) } returns Unit
 
         repository.deleteMessage(message)
 
-        verifySuspend { pendingMessageDao.deleteMessage(message.id.toString()) }
+        verifySuspend { pendingMessageDao.deleteMessageById(message.id.toString()) }
     }
 
 
@@ -176,7 +176,7 @@ class MessageRepositoryImplTest {
         every { webSocketManager.isConnected() } returns true
         everySuspend { webSocketManager.sendTextFrame(any(), any()) } returns Unit
         everySuspend { pendingMessageDao.insertMessage(any()) } returns Unit
-        everySuspend { pendingMessageDao.deleteMessage(any()) } returns Unit
+        everySuspend { pendingMessageDao.deleteMessageById(any()) } returns Unit
 
         val message = createMessage(
             senderId = userId,
@@ -243,7 +243,7 @@ class MessageRepositoryImplTest {
                 message2.toPendingMessageLocalDto()
             )
 
-            everySuspend { pendingMessageDao.getMessagesByChat(chatId.toString()) } returns flowOf(
+            everySuspend { pendingMessageDao.getMessagesByChatId(chatId.toString()) } returns flowOf(
                 messageEntities
             )
 
@@ -252,19 +252,19 @@ class MessageRepositoryImplTest {
 
             assertThat(result).isNotEmpty()
             assertThat(result.size).isEqualTo(2)
-            verifySuspend { pendingMessageDao.getMessagesByChat(chatId.toString()) }
+            verifySuspend { pendingMessageDao.getMessagesByChatId(chatId.toString()) }
         }
 
     @Test
     fun `should return empty list when no local messages exist for chat`() = runTest {
-        everySuspend { pendingMessageDao.getMessagesByChat(chatId.toString()) } returns flowOf(
+        everySuspend { pendingMessageDao.getMessagesByChatId(chatId.toString()) } returns flowOf(
             emptyList()
         )
 
         val result = repository.observePendingMessagesByChatId(chatId).first()
 
         assertThat(result.isEmpty()).isTrue()
-        verifySuspend { pendingMessageDao.getMessagesByChat(chatId.toString()) }
+        verifySuspend { pendingMessageDao.getMessagesByChatId(chatId.toString()) }
     }
 
     @Test
@@ -290,7 +290,7 @@ class MessageRepositoryImplTest {
         runTest {
             every { webSocketManager.isConnected() } returns true
             everySuspend { pendingMessageDao.insertMessage(any()) } returns Unit
-            everySuspend { pendingMessageDao.deleteMessage(any()) } returns Unit
+            everySuspend { pendingMessageDao.deleteMessageById(any()) } returns Unit
 
             httpClient = createHttpClient(
                 imagesResponse = { defaultUploadImagesResponse() }
@@ -315,7 +315,7 @@ class MessageRepositoryImplTest {
             repository.sendMessage(message)
 
             verifySuspend { pendingMessageDao.insertMessage(any()) }
-            verifySuspend { pendingMessageDao.deleteMessage(any()) }
+            verifySuspend { pendingMessageDao.deleteMessageById(any()) }
         }
 
     @Test
@@ -361,7 +361,7 @@ class MessageRepositoryImplTest {
         runTest {
             every { webSocketManager.isConnected() } returns true
             everySuspend { pendingMessageDao.insertMessage(any()) } returns Unit
-            everySuspend { pendingMessageDao.deleteMessage(any()) } returns Unit
+            everySuspend { pendingMessageDao.deleteMessageById(any()) } returns Unit
 
             httpClient = createHttpClient(
                 audioResponse = { defaultAudioResponse() }
@@ -386,7 +386,7 @@ class MessageRepositoryImplTest {
             repository.sendMessage(message)
 
             verifySuspend { pendingMessageDao.insertMessage(any()) }
-            verifySuspend { pendingMessageDao.deleteMessage(any()) }
+            verifySuspend { pendingMessageDao.deleteMessageById(any()) }
         }
 
     @Test
@@ -523,6 +523,7 @@ class MessageRepositoryImplTest {
         } returns emptyList()
         everySuspend { cachedMessageDao.getTotalMessagesCount(any()) } returns 0
         everySuspend { cachedMessageDao.insertAllMessages(any()) } returns Unit
+        everySuspend { pendingMessageDao.deleteMessagesByIds(any()) } returns Unit
         everySuspend { chatSyncTimeDao.getLastSyncTime(any()) } returns null
         everySuspend { chatSyncTimeDao.upsert(any()) } returns Unit
         httpClient = createHttpClient(
@@ -537,6 +538,7 @@ class MessageRepositoryImplTest {
             chatSyncTimeDao = chatSyncTimeDao,
         )
         val result = repository.loadMessages(chatId, 0, 20)
+
         assertThat(result.data).isNotEmpty()
         assertThat(result.totalItems).isGreaterThan(0)
         verifySuspend { cachedMessageDao.insertAllMessages(any()) }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModel.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModel.kt
@@ -239,10 +239,7 @@ class ChatViewModel(
             content = content
         )
 
-        tryToExecute(
-            execute = { messageRepository.sendMessage(message.toEntity()) },
-            onSuccess = { onSendMessageSuccess(message) }
-        )
+        sendMessage(message)
     }
 
     override fun onInputMessageChanged(value: String) {
@@ -270,12 +267,7 @@ class ChatViewModel(
 
         tryToExecute(
             execute = { messageRepository.sendMessage(message.toEntity()) },
-            onSuccess = { onSendMessageSuccess(message) }
         )
-    }
-
-    private suspend fun onSendMessageSuccess(message: MessageUiState) {
-        safeUpdateMessages { messages -> messages.filter { it.id != message.id && it.sendAt != message.sendTime } }
     }
 
     override fun onMessageClicked(messageId: Uuid) {


### PR DESCRIPTION
# What have been done
This PR introduce new strategy for fixing issue with **syncing pending messages with succeeded messages** between mobile and backend when losing connection before getting success confirmation from backend, by generating the new message id from client side to compare the new message with user pending message and delete the already succeeded messages

Also fixed bug where newly sent Image/Audio messages not appear in chat until close and re-open chat