### PR TITLE
Refactor/ use UIView for video player instead of AVPlayerViewController

### DIFF
--- a/trends_presentation/src/iosMain/kotlin/net/thechance/mena/trends/presentation/video_player/PlayerLayerView.kt
+++ b/trends_presentation/src/iosMain/kotlin/net/thechance/mena/trends/presentation/video_player/PlayerLayerView.kt
@@ -1,0 +1,25 @@
+package net.thechance.mena.trends.presentation.video_player
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.readValue
+import platform.AVFoundation.AVLayerVideoGravityResizeAspectFill
+import platform.AVFoundation.AVPlayer
+import platform.AVFoundation.AVPlayerLayer
+import platform.UIKit.UIView
+
+@OptIn(ExperimentalForeignApi::class)
+class PlayerLayerView(player: AVPlayer) :
+    UIView(frame = platform.CoreGraphics.CGRectZero.readValue()) {
+    private val playerLayer = AVPlayerLayer()
+
+    init {
+        layer.addSublayer(playerLayer)
+        playerLayer.player = player
+        playerLayer.videoGravity = AVLayerVideoGravityResizeAspectFill
+    }
+
+    override fun layoutSubviews() {
+        super.layoutSubviews()
+        playerLayer.frame = layer.bounds
+    }
+}

--- a/trends_presentation/src/iosMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.ios.kt
+++ b/trends_presentation/src/iosMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.ios.kt
@@ -270,8 +270,7 @@ actual fun VideoPlayer(
                                 if (duration > 0.0 && barWidth > 0f) {
                                     val newProgress = (offset.x / barWidth).coerceIn(0f, 1f)
                                     val seekSeconds = newProgress * duration
-                                    val seekTime =
-                                        CMTimeMakeWithSeconds(seekSeconds, PREFERRED_TIME_SCALE)
+                                    val seekTime = CMTimeMakeWithSeconds(seekSeconds, PREFERRED_TIME_SCALE)
                                     player.seekToTime(seekTime)
                                 }
                             }

--- a/trends_presentation/src/iosMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.ios.kt
+++ b/trends_presentation/src/iosMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.ios.kt
@@ -1,6 +1,5 @@
 package net.thechance.mena.trends.presentation.video_player
 
-
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
@@ -39,7 +38,6 @@ import net.thechance.mena.trends.presentation.di.trendStorageAccessSecret
 import net.thechance.mena.trends.presentation.video_player.composable.LoadingItem
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
-import platform.AVFoundation.AVLayerVideoGravityResizeAspectFill
 import platform.AVFoundation.AVPlayer
 import platform.AVFoundation.AVPlayerItem
 import platform.AVFoundation.AVPlayerItemDidPlayToEndTimeNotification
@@ -58,13 +56,11 @@ import platform.AVFoundation.rate
 import platform.AVFoundation.replaceCurrentItemWithPlayerItem
 import platform.AVFoundation.seekToTime
 import platform.AVFoundation.timeControlStatus
-import platform.AVKit.AVPlayerViewController
 import platform.CoreMedia.CMTimeGetSeconds
 import platform.CoreMedia.CMTimeMakeWithSeconds
 import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSURL
 import platform.Foundation.NSURLErrorBadServerResponse
-
 
 private const val PREFERRED_TIME_SCALE = 600
 
@@ -114,12 +110,7 @@ actual fun VideoPlayer(
 
     player.actionAtItemEnd = 1
 
-    val playerViewController = remember {
-        AVPlayerViewController().apply {
-            showsPlaybackControls = false
-            videoGravity = AVLayerVideoGravityResizeAspectFill
-        }
-    }
+    val playerView = remember(url) { PlayerLayerView(player) }
 
     LaunchedEffect(url) {
 
@@ -161,8 +152,6 @@ actual fun VideoPlayer(
     }
 
     LaunchedEffect(url, isReelVisible) {
-        playerViewController.player = player
-
         replayReelWhenFinishedAutomatic(player)
 
         if (isReelVisible) {
@@ -191,7 +180,7 @@ actual fun VideoPlayer(
                 }
 
                 AVPlayerItemStatusFailed -> true
-                AVPlayerItemStatusFailed, AVPlayerItemStatusUnknown, null -> false
+                AVPlayerItemStatusUnknown, null -> false
                 else -> false
             }
 
@@ -230,9 +219,10 @@ actual fun VideoPlayer(
         contentAlignment = Alignment.Center
     ) {
         UIKitView(
-            factory = { playerViewController.view },
-            update = {
-                it.setNeedsLayout()
+            factory = { playerView },
+            update = { view ->
+                view.setNeedsLayout()
+                view.layoutIfNeeded()
                 if (isPaused) player.pause() else player.play()
             },
             modifier = Modifier.matchParentSize()
@@ -280,7 +270,8 @@ actual fun VideoPlayer(
                                 if (duration > 0.0 && barWidth > 0f) {
                                     val newProgress = (offset.x / barWidth).coerceIn(0f, 1f)
                                     val seekSeconds = newProgress * duration
-                                    val seekTime = CMTimeMakeWithSeconds(seekSeconds, PREFERRED_TIME_SCALE)
+                                    val seekTime =
+                                        CMTimeMakeWithSeconds(seekSeconds, PREFERRED_TIME_SCALE)
                                     player.seekToTime(seekTime)
                                 }
                             }


### PR DESCRIPTION
Replaced `AVPlayerViewController` with a custom `UIView` (`PlayerLayerView`) to have more control over the video player's view hierarchy. This change also includes layout updates to ensure the new view is properly sized and rendered.


https://github.com/user-attachments/assets/ab1f088f-49d9-4ad7-be71-996da7667710

