### PR TITLE
Feature/ provide a custom ImageLoader for Coil

### DIFF
--- a/trends_presentation/build.gradle.kts
+++ b/trends_presentation/build.gradle.kts
@@ -72,6 +72,7 @@ kotlin {
 
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)
+            implementation(libs.bundles.coil)
         }
 
         commonTest.dependencies {

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/TrendsNavGraph.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/TrendsNavGraph.kt
@@ -29,6 +29,8 @@ import net.thechance.mena.trends.presentation.screen.upload_reel.UploadReelScree
 import net.thechance.mena.trends.presentation.screen.user_reel.UserReelScreen
 import net.thechance.mena.trends.presentation.screen.video_description.VideoDescriptionScreen
 import net.thechance.mena.trends.presentation.shared.component.snackbar.TrendsSnackBar
+import net.thechance.mena.trends.presentation.shared.util.LocalImageLoader
+import net.thechance.mena.trends.presentation.shared.util.provideImageLoader
 import net.thechance.mena.trends.presentation.snackbar.LocalSnackbarController
 import net.thechance.mena.trends.presentation.snackbar.SnackBarControllerImpl
 import net.thechance.mena.trends.presentation.snackbar.defaultSnackBarAnimationConfig
@@ -40,10 +42,12 @@ fun TrendsNavHost() {
     val coroutineScope = rememberCoroutineScope()
     val snackBarController = remember(coroutineScope) { SnackBarControllerImpl(coroutineScope) }
     val currentSnackbarData by snackBarController.state.collectAsStateWithLifecycle()
+    val coilLoader = provideImageLoader()
 
     CompositionLocalProvider(
         LocalNavController provides navController,
-        LocalSnackbarController provides snackBarController
+        LocalSnackbarController provides snackBarController,
+        LocalImageLoader provides coilLoader
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
 

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/component/BaseAsyncImage.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/component/BaseAsyncImage.kt
@@ -13,6 +13,7 @@ import coil3.network.NetworkHeaders
 import coil3.network.httpHeaders
 import coil3.request.ImageRequest
 import net.thechance.mena.trends.presentation.di.trendStorageAccessSecret
+import net.thechance.mena.trends.presentation.shared.util.LocalImageLoader
 
 private const val HTTP_UNAUTHORIZED_STATUS_EXCEPTION = 403
 
@@ -27,6 +28,7 @@ fun BaseAsyncImage(
     onRequestRefresh: () -> Unit
 ){
     val context = LocalPlatformContext.current
+    val coil = LocalImageLoader.current
 
     val networkHeaders = NetworkHeaders.Builder()
         .set("X-ACCESS-KEY", trendStorageAccessSecret)
@@ -53,6 +55,7 @@ fun BaseAsyncImage(
                     }
                 }
             },
+            imageLoader = coil,
             alignment = alignment,
             contentDescription = contentDescription,
             contentScale = contentScale,

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/component/BaseAsyncImage.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/component/BaseAsyncImage.kt
@@ -28,7 +28,7 @@ fun BaseAsyncImage(
     onRequestRefresh: () -> Unit
 ){
     val context = LocalPlatformContext.current
-    val coil = LocalImageLoader.current
+    val coilImageLoader = LocalImageLoader.current
 
     val networkHeaders = NetworkHeaders.Builder()
         .set("X-ACCESS-KEY", trendStorageAccessSecret)
@@ -55,7 +55,7 @@ fun BaseAsyncImage(
                     }
                 }
             },
-            imageLoader = coil,
+            imageLoader = coilImageLoader,
             alignment = alignment,
             contentDescription = contentDescription,
             contentScale = contentScale,

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/util/ImageLoaderProvider.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/util/ImageLoaderProvider.kt
@@ -23,7 +23,7 @@ fun provideImageLoader(
 }
 
 val LocalImageLoader = staticCompositionLocalOf<ImageLoader> {
-    throw IllegalStateException("ImageLoader not initialized")
+    error("ImageLoader not initialized")
 }
 
 const val DEFAULT_CLIENT_NAME = "defaultClient"

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/util/ImageLoaderProvider.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/util/ImageLoaderProvider.kt
@@ -1,0 +1,30 @@
+package net.thechance.mena.trends.presentation.shared.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import coil3.ImageLoader
+import coil3.compose.LocalPlatformContext
+import coil3.network.ktor3.KtorNetworkFetcherFactory
+import io.ktor.client.HttpClient
+import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
+
+@Composable
+fun provideImageLoader(
+    networkClient: HttpClient = koinInject<HttpClient>(named(DEFAULT_CLIENT_NAME))
+): ImageLoader {
+    val context = LocalPlatformContext.current
+    return remember {
+        ImageLoader.Builder(context)
+            .components { add(KtorNetworkFetcherFactory(networkClient)) }
+            .build()
+    }
+}
+
+val LocalImageLoader = staticCompositionLocalOf<ImageLoader> {
+    throw IllegalStateException("ImageLoader not initialized")
+}
+
+const val DEFAULT_CLIENT_NAME = "defaultClient"
+


### PR DESCRIPTION
Created a custom `ImageLoader` provider for Coil to use a specific Ktor HTTP client. This loader is now provided through a `CompositionLocal` and used in `BaseAsyncImage` to handle image loading.