### PR TITLE
fixing padding above the keyboard on search screen 

### DIFF
--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/search/SearchScreen.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/search/SearchScreen.kt
@@ -71,7 +71,7 @@ private fun SearchContent(
     listener: SearchInteractionListener
 ) {
     Scaffold(
-        modifier = Modifier.imePadding(),
+        modifier = Modifier,
         topBar = {
             SearchHeader(
                 query = state.searchQuery,


### PR DESCRIPTION
before :
android 
![2025-11-11 00 31 11](https://github.com/user-attachments/assets/6bed946a-c363-461a-aea2-6984c918ad87)

iOS 
<img width="1242" height="2688" alt="IMG_1403" src="https://github.com/user-attachments/assets/4cb64e41-5933-4fc0-b025-910985c7d10b" />





after :
android 
![2025-11-11 00 32 25](https://github.com/user-attachments/assets/2df772c1-9111-44df-83af-a36e778f283f)

iOS
<img width="1242" height="2688" alt="IMG_1404" src="https://github.com/user-attachments/assets/7a7363ea-edd0-4ed0-ba75-a43df14dfdd6" />
