### PR TITLE
fix add to cart button old price padding

### DIFF
--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/AddToCartSection.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/AddToCartSection.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -26,6 +27,7 @@ import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.dukan.presentation.component.product.ProductQuantityButton
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import kotlin.math.min
 
 @Composable
 fun AddToCartSection(
@@ -58,7 +60,8 @@ fun AddToCartSection(
             iconPadding = PaddingValues(Theme.spacing._8 + Theme.spacing._2)
         )
         Button(
-            modifier = Modifier.height(48.dp)
+            modifier = Modifier
+                .heightIn(min=48.dp)
                 .fillMaxWidth(),
             onClick = onAddToCartClick,
             isEnabled = true,
@@ -70,7 +73,7 @@ fun AddToCartSection(
             ),
             shape = RoundedCornerShape(Theme.radius.md),
             containerColor = Theme.colorScheme.primary.primary,
-            contentPadding = PaddingValues(vertical = Theme.spacing._4)
+//            contentPadding = PaddingValues(vertical = Theme.spacing._4)
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -90,16 +93,15 @@ fun AddToCartSection(
                         .background(Theme.colorScheme.primary.onPrimaryBody)
                 )
                 Column(
-                    verticalArrangement = Arrangement.spacedBy(Theme.spacing._2)
                 ) {
                     Text(
                         text = "$$productPrice",
-                        style = Theme.typography.label.medium,
+                        style = Theme.typography.label.small,
                         color = Theme.colorScheme.primary.onPrimary,
                     )
                     Text(
                         text = "$$productPrice",
-                        style = Theme.typography.label.medium.copy(
+                        style = Theme.typography.label.small.copy(
                             textDecoration = TextDecoration.LineThrough
                         ),
                         color = Theme.colorScheme.primary.onPrimaryBody,


### PR DESCRIPTION
emulator :
<img width="350" height="765" alt="emulator" src="https://github.com/user-attachments/assets/136f8e3c-f44b-4ce8-9880-309ed0b7f508" />

android device api 13:
![device api 13](https://github.com/user-attachments/assets/2f7be6a5-1cca-4601-a79b-c14d579282b7)




iOS:
<img width="1242" height="2688" alt="ios" src="https://github.com/user-attachments/assets/15eab237-47ba-4682-963d-da715de2bc28" />
