### PR TITLE
fix/DKN-153-enable-adding-products-to-cart-from-details-screen-opened-from-search-results

### DIFF
--- a/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/dto/product/ProductSearchDto.kt
+++ b/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/dto/product/ProductSearchDto.kt
@@ -18,6 +18,9 @@ data class ProductSearchDto(
     @SerialName("dukanName")
     val dukanName: String,
 
+    @SerialName("dukanId")
+    val dukanId: Uuid,
+
     @SerialName("price")
     val price: Double,
 

--- a/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/mapper/ProductSearchMapper.kt
+++ b/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/mapper/ProductSearchMapper.kt
@@ -11,6 +11,7 @@ fun ProductSearchDto.toDomain(): ProductSearch = ProductSearch(
     id = id,
     name = name,
     dukanName = dukanName,
+    dukanId = dukanId,
     price = price,
     imageUrl = mainImageUrl,
 )

--- a/dukan_domain/src/commonMain/kotlin/net/thechance/mena/dukan/domain/entity/ProductSearch.kt
+++ b/dukan_domain/src/commonMain/kotlin/net/thechance/mena/dukan/domain/entity/ProductSearch.kt
@@ -9,6 +9,7 @@ data class ProductSearch(
     val id: Uuid,
     val name: String,
     val dukanName: String,
+    val dukanId: Uuid,
     val imageUrl: String,
     val price: Double,
 )

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/search/SearchScreen.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/search/SearchScreen.kt
@@ -48,11 +48,10 @@ fun SearchScreen(viewModel: SearchViewModel = koinViewModel()) {
             }
 
             is SearchEffect.NavigateToProductDetails -> {
-                // Todo (ProductDetails (dukanId) need to refactor after productDetailsResponse updated )
                 navController.navigate(
                     route = DukanRoute.ProductDetails(
                         productId = effect.productId,
-                        dukanId = ""
+                        dukanId = effect.dukanId
                     )
                 )
             }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/search/component/SearchCompleteContent.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/search/component/SearchCompleteContent.kt
@@ -191,7 +191,7 @@ private fun DukansList(
 @Composable
 private fun ProductsList(
     productPagingItems: LazyPagingItems<SearchUiState.ProductUiState>,
-    onProductClicked: (productId: Uuid) -> Unit
+    onProductClicked: (productId: Uuid,dukanId:Uuid) -> Unit
 ) {
     AnimatedContent(
         targetState = productPagingItems.loadState.refresh,
@@ -243,7 +243,7 @@ private fun ProductsList(
                                 productPrice = product.price,
                                 productCardBackground = Theme.colorScheme.background.surfaceLow,
                                 productImageBackground = Theme.colorScheme.background.surfaceHigh,
-                                onProductClick = { onProductClicked(product.id) },
+                                onProductClick = { onProductClicked(product.id,product.dukanId) },
                             )
                         }
                     }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/util/stubPreviews/PreviewSearchInteractionListener.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/util/stubPreviews/PreviewSearchInteractionListener.kt
@@ -14,6 +14,6 @@ object PreviewSearchInteractionListener: SearchInteractionListener {
     override fun onProductsSelected() {}
     override fun onDukanClicked(dukanId: Uuid) {}
     override fun onDukanFavoriteToggled(dukanId: Uuid, isFavorite: Boolean) {}
-    override fun onProductClicked(productId: Uuid) {}
+    override fun onProductClicked(productId: Uuid,dukanId: Uuid) {}
     override fun onSnackBarDismissed() {}
 }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/util/stubPreviews/SearchDataPreviewList.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/util/stubPreviews/SearchDataPreviewList.kt
@@ -37,6 +37,7 @@ val previewProductsFlow = flowOf(
                 imageUrl = "https://example.com/product1.jpg",
                 name = "sport - shoes",
                 dukanName = "Puma",
+                dukanId = Uuid.random(),
                 price = 99.99,
             ),
             SearchUiState.ProductUiState(
@@ -44,6 +45,7 @@ val previewProductsFlow = flowOf(
                 imageUrl = "https://example.com/product2.jpg",
                 name = "Sports T-Shirt",
                 dukanName = "Defacto",
+                dukanId = Uuid.random(),
                 price = 29.99,
             ),
         )

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/Mapper.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/Mapper.kt
@@ -22,6 +22,7 @@ fun ProductSearch.toSearchUiState(): SearchUiState.ProductUiState{
         name = name,
         imageUrl = imageUrl,
         dukanName = dukanName,
+        dukanId = dukanId,
         price = price
     )
 }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchEffect.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchEffect.kt
@@ -3,5 +3,5 @@ package net.thechance.mena.dukan.presentation.viewModel.search
 sealed interface SearchEffect {
     object NavigateBack : SearchEffect
     data class NavigateToDukanDetails(val dukanId: String) : SearchEffect
-    data class NavigateToProductDetails(val productId: String) : SearchEffect
+    data class NavigateToProductDetails(val productId: String,val dukanId: String) : SearchEffect
 }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchInteractionListener.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchInteractionListener.kt
@@ -12,6 +12,6 @@ interface SearchInteractionListener {
     fun onProductsSelected()
     fun onDukanClicked(dukanId: Uuid)
     fun onDukanFavoriteToggled(dukanId: Uuid, isFavorite:Boolean)
-    fun onProductClicked(productId: Uuid)
+    fun onProductClicked(productId: Uuid,dukanId: Uuid)
     fun onSnackBarDismissed()
 }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchUiState.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchUiState.kt
@@ -37,6 +37,7 @@ data class SearchUiState(
         val name: String,
         val imageUrl: String,
         val dukanName: String,
+        val dukanId:Uuid,
         val price: Double,
     )
 }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchViewModel.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchViewModel.kt
@@ -90,8 +90,8 @@ class SearchViewModel(
         )
     }
 
-    override fun onProductClicked(productId: Uuid) {
-        emitEffect(effect = SearchEffect.NavigateToProductDetails(productId = productId.toString()))
+    override fun onProductClicked(productId: Uuid, dukanId: Uuid) {
+        emitEffect(effect = SearchEffect.NavigateToProductDetails(productId = productId.toString(),dukanId = dukanId.toString()))
     }
 
     override fun onSnackBarDismissed() {

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchFakeData.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchFakeData.kt
@@ -34,6 +34,7 @@ val fakePumaShoesProductPaged = PagedResult(
             name = "puma-shoes",
             imageUrl = "https://example.com/dukan1.jpg",
             dukanName = "Puma",
+            dukanId = Uuid.random(),
             price = 20.0,
         ),
     )

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchViewModelTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchViewModelTest.kt
@@ -221,8 +221,9 @@ class SearchViewModelTest {
     @Test
     fun `onProductClicked should emit NavigateToProductDetails effect`() = runTest(testDispatcher) {
         val productId = Uuid.random()
-        searchViewModel.onProductClicked(productId)
-        val expectedEffect = SearchEffect.NavigateToProductDetails(productId = productId.toString())
+        val dukanId = Uuid.random()
+        searchViewModel.onProductClicked(productId,dukanId)
+        val expectedEffect = SearchEffect.NavigateToProductDetails(productId = productId.toString(),dukanId = dukanId.toString())
         val actualEffect = searchViewModel.effect.first()
         assertEquals(expectedEffect, actualEffect)
 


### PR DESCRIPTION
refactor product search response dto with dukan id 
so we can pass to the details viewmodel and add it latter to cart 