### PR TITLE
Feature/IDN 193 change passowrd and empty addresses screens not scrollable

### DIFF
--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/EnableLocationLayout.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/EnableLocationLayout.kt
@@ -6,15 +6,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.resources.painterResource
 import mena.identity_presentation.generated.resources.Res
-import mena.identity_presentation.generated.resources.ic_location
-import mena.identity_presentation.generated.resources.enable_location_title
 import mena.identity_presentation.generated.resources.enable_location_message
 import mena.identity_presentation.generated.resources.enable_location_permission_button
+import mena.identity_presentation.generated.resources.enable_location_title
+import mena.identity_presentation.generated.resources.ic_location
 import mena.identity_presentation.generated.resources.location_icon_desc
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -23,7 +23,7 @@ fun EnableLocationLayout(
     modifier: Modifier = Modifier,
     isLoading: Boolean = false
 ) {
-    LocationEmptyState(
+    LocationEmptySection(
         iconPainter = painterResource(Res.drawable.ic_location),
         iconContentDescriptionResource = Res.string.location_icon_desc,
         titleResource = Res.string.enable_location_title,

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/LabeledInputPassword.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/LabeledInputPassword.kt
@@ -40,8 +40,8 @@ internal fun LabeledInputPassword(
             onValueChanged = onChangePassword::invoke,
             hint = "",
             trailingIcon = painterResource(
-                if (isPasswordVisible) Res.drawable.ic_open_eye
-                else Res.drawable.ic_close_eye
+                if (isPasswordVisible) Res.drawable.ic_close_eye
+                else Res.drawable.ic_open_eye
             ),
             leadingIcon = painterResource(Res.drawable.ic_lock),
             showTrailingDivider = false,

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/LocationEmptySection.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/LocationEmptySection.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -21,7 +23,7 @@ import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
-fun LocationEmptyState(
+fun LocationEmptySection(
     iconPainter: Painter,
     iconContentDescriptionResource: StringResource,
     titleResource: StringResource,
@@ -31,8 +33,10 @@ fun LocationEmptyState(
     modifier: Modifier = Modifier,
     isLoading: Boolean = false
 ) {
+    val scrollState = rememberScrollState()
+
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize().verticalScroll(scrollState),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/LocationEmptySection.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/LocationEmptySection.kt
@@ -65,7 +65,7 @@ fun LocationEmptySection(
         )
 
         PrimaryButton(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().padding(bottom = Theme.spacing._12),
             text = stringResource(buttonTextResource),
             contentPadding = PaddingValues(horizontal = Theme.spacing._24),
             onClick = onButtonClicked,

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/NoSavedLocationsLayout.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/NoSavedLocationsLayout.kt
@@ -6,15 +6,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.resources.painterResource
 import mena.identity_presentation.generated.resources.Res
-import mena.identity_presentation.generated.resources.ic_location_saved_empty
-import mena.identity_presentation.generated.resources.no_saved_locations_title
-import mena.identity_presentation.generated.resources.no_saved_locations_message
 import mena.identity_presentation.generated.resources.add_location_button
+import mena.identity_presentation.generated.resources.ic_location_saved_empty
 import mena.identity_presentation.generated.resources.location_saved_empty_desc
+import mena.identity_presentation.generated.resources.no_saved_locations_message
+import mena.identity_presentation.generated.resources.no_saved_locations_title
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -23,7 +23,7 @@ fun NoSavedLocationsLayout(
     modifier: Modifier = Modifier,
     isLoading: Boolean = false
 ) {
-    LocationEmptyState(
+    LocationEmptySection(
         iconPainter = painterResource(Res.drawable.ic_location_saved_empty),
         iconContentDescriptionResource = Res.string.location_saved_empty_desc,
         titleResource = Res.string.no_saved_locations_title,

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/changePassword/ChangePasswordScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/changePassword/ChangePasswordScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.BackHandler
@@ -70,6 +71,7 @@ class ChangePasswordScreen(
                 HorizontalPager(
                     state = pagerState,
                     userScrollEnabled = false,
+                    verticalAlignment = Alignment.Top,
                     modifier = Modifier.weight(1f)
                 ) { page ->
                     when (page) {

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/changePassword/components/CurrentPasswordContent.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/changePassword/components/CurrentPasswordContent.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -32,9 +34,10 @@ fun CurrentPasswordContent(
     onChangeCurrentPassword: (String) -> Unit,
     onToggleCurrentPasswordVisibility: () -> Unit,
     modifier: Modifier = Modifier
-){
+) {
+    val scrollState = rememberScrollState()
 
-    Column(modifier = modifier.fillMaxSize()) {
+    Column(modifier.fillMaxSize().verticalScroll(scrollState)) {
         Text(
             text = stringResource(Res.string.verify_current_password),
             style = Theme.typography.title.medium,
@@ -72,7 +75,7 @@ fun CurrentPasswordContent(
             contentPadding = PaddingValues(vertical = 13.dp),
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = Theme.spacing._12)
+                .padding(bottom = Theme.spacing._12, top = Theme.spacing._24)
                 .imePadding()
         )
     }
@@ -80,7 +83,7 @@ fun CurrentPasswordContent(
 
 @Preview(showBackground = true)
 @Composable
-private fun CurrentPasswordContentPreview(){
+private fun CurrentPasswordContentPreview() {
     MenaTheme {
         CurrentPasswordContent(
             state = CurrentPasswordContentUIState(),

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/changePassword/components/NewPasswordContent.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/changePassword/components/NewPasswordContent.kt
@@ -3,6 +3,7 @@ package net.thechance.mena.identity.presentation.screen.changePassword.component
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -34,7 +35,7 @@ fun NewPasswordContent(
 ) {
     val scrollState = rememberScrollState()
 
-    Column(modifier.fillMaxWidth().verticalScroll(scrollState)) {
+    Column(modifier.fillMaxSize().verticalScroll(scrollState)) {
 
         Text(
             text = stringResource(Res.string.enter_your_new_password),

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/changePassword/components/NewPasswordContent.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/changePassword/components/NewPasswordContent.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -30,8 +32,9 @@ fun NewPasswordContent(
     listener: ChangePasswordScreenInteractionListener,
     modifier: Modifier = Modifier
 ) {
+    val scrollState = rememberScrollState()
 
-    Column(modifier = modifier.fillMaxWidth()) {
+    Column(modifier.fillMaxWidth().verticalScroll(scrollState)) {
 
         Text(
             text = stringResource(Res.string.enter_your_new_password),
@@ -74,7 +77,7 @@ fun NewPasswordContent(
             isLoading = isLoading,
             contentPadding = PaddingValues(vertical = 13.dp),
             modifier = Modifier.fillMaxWidth()
-                .padding(bottom = Theme.spacing._12)
+                .padding(bottom = Theme.spacing._12, top = Theme.spacing._24)
         )
     }
 }


### PR DESCRIPTION
## Changes
- fix vertical scroll in change passowrd and empty addresses screens 
- swap show and hide password icons


https://github.com/user-attachments/assets/70620025-53a4-44c5-9fdc-48497d5d5a7d


<img width="372" height="804" alt="image" src="https://github.com/user-attachments/assets/ef1b24d8-4e87-4220-8b55-e97603341746" />



