### PR TITLE
feat: Add out of stock status to product editing

### DIFF
--- a/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/dto/product/ProductDto.kt
+++ b/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/dto/product/ProductDto.kt
@@ -33,5 +33,8 @@ data class ProductDto(
     val quantityInCart : Int,
 
     @SerialName("isFavorite")
-    val isFavorite: Boolean = false
+    val isFavorite: Boolean = false,
+
+    @SerialName("isOutOfStock")
+    val isOutOfStock: Boolean = false
 )

--- a/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/dto/product/UpdateProductRequest.kt
+++ b/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/dto/product/UpdateProductRequest.kt
@@ -14,5 +14,7 @@ data class UpdateProductRequest(
     @SerialName("shelfId")
     val shelfId: String?,
     @SerialName("imageUrls")
-    val imageUrls: List<String>?
+    val imageUrls: List<String>?,
+    @SerialName("isOutOfStock")
+    val isOutOfStock: Boolean = false
 )

--- a/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/mapper/ProductMapper.kt
+++ b/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/mapper/ProductMapper.kt
@@ -24,7 +24,8 @@ fun UpdateProductParams.toUpdateProductRequest(): UpdateProductRequest {
         description = description?.takeIf { it.isNotBlank() },
         price = price,
         shelfId = shelfId?.takeIf { it.isNotBlank() },
-        imageUrls = imageUrls?.takeIf { it.isNotEmpty() }
+        imageUrls = imageUrls?.takeIf { it.isNotEmpty() },
+        isOutOfStock = isOutOfStock
     )
 }
 

--- a/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/mapper/ProductMapper.kt
+++ b/dukan_data/src/commonMain/kotlin/net/thechance/mena/dukan/data/mapper/ProductMapper.kt
@@ -39,7 +39,8 @@ fun ProductDto.toDomain(): Product = Product(
     createdAt = createdAt,
     quantityInCart = quantityInCart,
     shelfId = shelfId,
-    isFavorite = isFavorite
+    isFavorite = isFavorite,
+    isOutOfStock = isOutOfStock
 )
 
 @OptIn(ExperimentalUuidApi::class)
@@ -52,5 +53,6 @@ fun ProductCartDto.toDomain(): Product = Product(
     quantityInCart = quantityInCart,
     createdAt = "",
     shelfId = null,
-    isFavorite = false
+    isFavorite = false,
+    isOutOfStock = false
 )

--- a/dukan_domain/src/commonMain/kotlin/net/thechance/mena/dukan/domain/entity/Product.kt
+++ b/dukan_domain/src/commonMain/kotlin/net/thechance/mena/dukan/domain/entity/Product.kt
@@ -13,5 +13,6 @@ data class Product(
     val createdAt: String,
     val quantityInCart: Int,
     val shelfId: Uuid?,
-    val isFavorite: Boolean
+    val isFavorite: Boolean,
+    val isOutOfStock: Boolean = false
 )

--- a/dukan_domain/src/commonMain/kotlin/net/thechance/mena/dukan/domain/model/UpdateProductParams.kt
+++ b/dukan_domain/src/commonMain/kotlin/net/thechance/mena/dukan/domain/model/UpdateProductParams.kt
@@ -6,6 +6,7 @@ data class UpdateProductParams(
     val price: Double?,
     val shelfId: String?,
     val imageUrls: List<String>?,
+    val isOutOfStock: Boolean = false,
 )
 
 

--- a/dukan_presentation/src/commonMain/composeResources/values-ar/strings.xml
+++ b/dukan_presentation/src/commonMain/composeResources/values-ar/strings.xml
@@ -178,5 +178,5 @@
     <string name="checkout_dialog_title">ميزة الدفع</string>
     <string name="checkout_dialog_description">هذه الميزة لم يتم تنفيذها بعد.</string>
     <string name="back_to_dukan_screen_icon">أيقونة العودة للشاشة الدكان</string>
-
+    <string name="product_is_out_of_stock">المنتج غير متوفر</string>
 </resources>

--- a/dukan_presentation/src/commonMain/composeResources/values/strings.xml
+++ b/dukan_presentation/src/commonMain/composeResources/values/strings.xml
@@ -177,4 +177,5 @@
     <string name="checkout_dialog_title">Checkout Feature</string>
     <string name="checkout_dialog_description">This feature is not implemented yet.</string>
     <string name="back_to_dukan_screen_icon">Back to dukan screen icon</string>
+    <string name="product_is_out_of_stock">Product is out of stock</string>
 </resources>

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/editProduct/EditProductScreen.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/editProduct/EditProductScreen.kt
@@ -30,6 +30,7 @@ import net.thechance.mena.dukan.presentation.screen.createProduct.component.Prod
 import net.thechance.mena.dukan.presentation.screen.createProduct.component.ProductNameSection
 import net.thechance.mena.dukan.presentation.screen.createProduct.component.ShelfSection
 import net.thechance.mena.dukan.presentation.screen.editProduct.component.editProductDialog
+import net.thechance.mena.dukan.presentation.screen.editProduct.component.StockStatusSection
 import net.thechance.mena.dukan.presentation.util.ObserveAsEffect
 import net.thechance.mena.dukan.presentation.viewModel.editProduct.EditProductEffect
 import net.thechance.mena.dukan.presentation.viewModel.editProduct.EditProductInteractionListener
@@ -142,6 +143,14 @@ private fun EditProductContent(
                     description = state.description,
                     isTextFieldEnabled = state.isTextFieldEnabled,
                     onDescriptionChange = interactionListener::onDescriptionChange
+                )
+            }
+
+            item {
+                StockStatusSection(
+                    isOutOfStock = state.isOutOfStock,
+                    isEnabled = state.isTextFieldEnabled,
+                    onOutOfStockChange = interactionListener::onOutOfStockChange
                 )
             }
 

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/editProduct/component/StockStatusSection.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/editProduct/component/StockStatusSection.kt
@@ -1,0 +1,57 @@
+package net.thechance.mena.dukan.presentation.screen.editProduct.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import mena.dukan_presentation.generated.resources.Res
+import mena.dukan_presentation.generated.resources.product_is_out_of_stock
+import net.thechance.mena.designsystem.presentation.component.switches.Switch
+import net.thechance.mena.designsystem.presentation.component.text.Text
+import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
+import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun StockStatusSection(
+    isOutOfStock: Boolean,
+    isEnabled: Boolean,
+    onOutOfStockChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = Theme.spacing._16, vertical = Theme.spacing._12),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Theme.spacing._8)
+    ) {
+        Switch(
+            isChecked = isOutOfStock,
+            onCheckedChange = onOutOfStockChange,
+            isEnabled = isEnabled
+        )
+
+        Text(
+            text = stringResource(Res.string.product_is_out_of_stock),
+            style = Theme.typography.label.medium,
+            color = Theme.colorScheme.shadePrimary,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun StockStatusSectionPreview() {
+    MenaTheme {
+        StockStatusSection(
+            isOutOfStock = false,
+            isEnabled = true,
+            onOutOfStockChange = {}
+        )
+    }
+}

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/editProduct/EditProductInteractionListener.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/editProduct/EditProductInteractionListener.kt
@@ -19,6 +19,7 @@ interface EditProductInteractionListener {
     fun onSaveProductClicked()
     fun onDismissSnackBar()
     fun onCropImageBackClicked()
+    fun onOutOfStockChange(isOutOfStock: Boolean)
 }
 
 

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/editProduct/EditProductUiState.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/editProduct/EditProductUiState.kt
@@ -29,6 +29,7 @@ data class EditProductUiState(
     val isTextFieldEnabled: Boolean = true,
     val isCancelImageEnabled: Boolean = true,
     val deleteDialog: DeleteDialogState? = null,
+    val isOutOfStock: Boolean = false,
 ) {
     data class DeleteDialogState(
         val title: StringResource,

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/editProduct/EditProductViewModel.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/editProduct/EditProductViewModel.kt
@@ -237,6 +237,12 @@ class EditProductViewModel(
         }
     }
 
+    override fun onOutOfStockChange(isOutOfStock: Boolean) {
+        updateState {
+            copy(isOutOfStock = isOutOfStock).updateButtonState()
+        }
+    }
+
     override fun onUploadImageClicked(image: ImageFile) {
         tryToExecute(
             block = { onUploadImageBlock(image) },
@@ -485,7 +491,8 @@ class EditProductViewModel(
             description = trimmedDescription,
             price = state.value.price.toDoubleOrNull(),
             shelfId = state.value.selectedShelf?.id,
-            imageUrls = finalImageUrls
+            imageUrls = finalImageUrls,
+            isOutOfStock = state.value.isOutOfStock
         )
     }
 

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/editProduct/EditProductViewModel.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/editProduct/EditProductViewModel.kt
@@ -104,7 +104,8 @@ class EditProductViewModel(
                 price = product.price.toString(),
                 description = product.description,
                 existingImageUrls = filteredImages,
-                isTextFieldEnabled = true
+                isTextFieldEnabled = true,
+                isOutOfStock = product.isOutOfStock
             ).updateButtonState()
         }
     }

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/editProduct/EditProductViewModelTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/editProduct/EditProductViewModelTest.kt
@@ -226,6 +226,32 @@ class EditProductViewModelTest {
     }
 
     @Test
+    fun `onOutOfStockChange SHOULD update isOutOfStock to true`() = scope.runTest {
+        viewModel.onOutOfStockChange(true)
+        assertTrue(viewModel.state.value.isOutOfStock)
+    }
+
+    @Test
+    fun `onOutOfStockChange SHOULD update isOutOfStock to false`() = scope.runTest {
+        viewModel.updateState { copy(isOutOfStock = true) }
+        assertTrue(viewModel.state.value.isOutOfStock)
+
+        viewModel.onOutOfStockChange(false)
+        assertFalse(viewModel.state.value.isOutOfStock)
+    }
+
+    @Test
+    fun `onOutOfStockChange SHOULD call updateButtonState`() = scope.runTest {
+        viewModel.updateStateWithValidProduct()
+
+        viewModel.onOutOfStockChange(true)
+        val updatedState = viewModel.state.value
+
+        assertTrue(updatedState.isOutOfStock)
+        assertNotNull(updatedState.isSaveButtonEnabled)
+    }
+
+    @Test
     fun `onShelfSelect SHOULD update selected shelf`() = scope.runTest {
         val shelf = CreateProductUiState.ShelfUiState(
             id = fakeShelves()[0].id.toString(),


### PR DESCRIPTION
## Add Out of Stock Toggle

Adds a switch to mark products as out of stock in the edit product screen. Uses the design system Switch component with proper spacing and state management.