### PR TITLE
Fix/cht 104 voice message

### DIFF
--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/di/networkModule.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/di/networkModule.kt
@@ -9,6 +9,7 @@ import net.thechance.mena.core_chat.data.source.remote.network.ImageDownloaderIm
 import net.thechance.mena.core_chat.data.source.remote.network.WebSocketManager
 import net.thechance.mena.core_chat.data.source.remote.network.WebSocketManagerImpl
 import net.thechance.mena.core_chat.data.source.remote.network.createHttpClient
+import net.thechance.mena.core_chat.data.source.remote.network.createMediaHttpClient
 import net.thechance.mena.core_chat.data.source.remote.network.httpClientEngineFactory
 import net.thechance.mena.core_chat.domain.service.ImageDownloaderService
 import org.koin.core.qualifier.named
@@ -28,6 +29,11 @@ internal val networkModule = module {
             get(),
             httpClientEngineFactory,
             get(named(CHAT_JSON))
+        )
+    }
+    single(named(MEDIA_CLIENT)) {
+        createMediaHttpClient(
+            httpClientEngineFactory
         )
     }
     single<WebSocketManager> {
@@ -54,6 +60,7 @@ internal val networkModule = module {
 
 private const val BASE_URL = "baseUrl"
 const val CHAT_CLIENT = "chatClient"
+const val MEDIA_CLIENT = "mediaClient"
 const val CHAT_JSON = "chatJson"
 const val IMAGE_MESSAGE_SENDER = "image_message_sender"
 const val TEXT_MESSAGE_SENDER = "text_message_sender"

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/di/repositoryModule.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/di/repositoryModule.kt
@@ -56,7 +56,7 @@ internal val repositoryModule = module {
 
     single<AudioRecordRepository> {
         AudioRecordRepositoryImpl(
-            client = get(named(CHAT_CLIENT)),
+            client = get(named(MEDIA_CLIENT)),
             fileManager = get(),
             audioRecorder = get(),
         )

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/repository/AudioRecordRepositoryImpl.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/repository/AudioRecordRepositoryImpl.kt
@@ -6,8 +6,8 @@ import io.ktor.util.reflect.typeInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
-import net.thechance.mena.core_chat.data.utils.audio.AudioRecorder
 import net.thechance.mena.core_chat.data.utils.FileManager
+import net.thechance.mena.core_chat.data.utils.audio.AudioRecorder
 import net.thechance.mena.core_chat.data.utils.tryNetworkCall
 import net.thechance.mena.core_chat.domain.exception.AudioFileNotFound
 import net.thechance.mena.core_chat.domain.exception.InvalidAudioFile
@@ -54,6 +54,7 @@ class AudioRecordRepositoryImpl(
 
         val audioBytes = tryNetworkCall<ByteArray>(
             bodyType = typeInfo<ByteArray>(),
+            maxAttempts = 3
         ) {
             client.get(audioUrl)
         } ?: throw NotFoundException("Audio file not found on server")

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/remote/network/httpClient.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/remote/network/httpClient.kt
@@ -71,3 +71,23 @@ fun createHttpClient(
         }
     }
 }
+
+fun createMediaHttpClient(
+    httpClientEngineFactory: HttpClientEngineFactory<HttpClientEngineConfig>
+): HttpClient {
+    val timeOutIntervalMilliSeconds = 30_000L
+
+    return HttpClient(httpClientEngineFactory) {
+
+        install(Logging) {
+            logger = Logger.SIMPLE
+            level = LogLevel.ALL
+        }
+
+        install(HttpTimeout) {
+            requestTimeoutMillis = timeOutIntervalMilliSeconds
+            connectTimeoutMillis = timeOutIntervalMilliSeconds
+            socketTimeoutMillis = timeOutIntervalMilliSeconds
+        }
+    }
+}


### PR DESCRIPTION
### **Root Cause**
- Our main HTTP client configuration was applying Bearer token authentication to ALL requests:

```
fun createHttpClient(...): HttpClient {
    return HttpClient(httpClientEngineFactory) {
        defaultRequest {
            contentType(ContentType.Application.Json)
            accept(ContentType.Application.Json)  //  Forces JSON response
        }
        
        install(Auth) {
            bearer {
                loadTokens { 
                    BearerTokens(
                        accessToken = authorizationService.getAccessToken(),
                        refreshToken = authorizationService.getRefreshToken()
                    )
                }
            }
        }
    }
}
```
**The Problem:**

- DigitalOcean Spaces is S3-compatible storage that uses AWS Signature authentication​
- Bearer tokens are NOT supported by S3/Spaces API​
- When our client sent Authorization: Bearer <token> header to Spaces CDN, the S3 service rejected it with InvalidArgument error
- Our audio files are stored as public CDN URLs - they don't need authentication at all

**Evidence from Logs:**
```
REQUEST to DigitalOcean Spaces:
Authorization: Bearer eyJhbGM4NCJ9...  ← S3 doesn't understand JWT tokens

RESPONSE:
400 Bad Request
<Error><Code>InvalidArgument</Code></Error>  ← S3 rejects Bearer auth
```
--------------------

### **Solution**

**Create Separate Media HTTP Client**
We created a dedicated HTTP client for downloading media files (audio, images) from CDN:

```
/**
 * Media HTTP Client for downloading binary content from CDN
 * 
 * Why separate?
 * - DigitalOcean Spaces (S3-compatible) doesn't support Bearer token auth
 * - Our media files are public CDN URLs - no authentication needed
 * - Prevents auth token leakage to third-party services
 * - Allows different configuration for binary vs JSON downloads
 */
fun createMediaHttpClient(
    httpClientEngineFactory: HttpClientEngineFactory<HttpClientEngineConfig>
): HttpClient {
    val timeOutIntervalMilliSeconds = 30_000L

    return HttpClient(httpClientEngineFactory) {
        // NO Auth plugin - public CDN doesn't need authentication
        // NO ContentNegotiation - downloading binary data, not JSON
        // NO default Accept/Content-Type headers
        
        install(Logging) {
            logger = Logger.SIMPLE
            level = LogLevel.ALL
        }

        install(HttpTimeout) {
            requestTimeoutMillis = timeOutIntervalMilliSeconds
            connectTimeoutMillis = timeOutIntervalMilliSeconds
            socketTimeoutMillis = timeOutIntervalMilliSeconds
        }
    }
}
```





