### PR TITLE
Fix/WLT-158 transaction history screen

### DIFF
--- a/wallet_presentation/src/commonMain/composeResources/values-ar/strings.xml
+++ b/wallet_presentation/src/commonMain/composeResources/values-ar/strings.xml
@@ -76,7 +76,7 @@
     <string name="transactions_history">سجل المعاملات</string>
     <string name="filter">الفلاتر</string>
     <string name="transaction_pay">تسوق عبر الإنترنت</string>
-    <string name="transaction_send">إرسال إلى </string>
+    <string name="transaction_send">إرسال إلى</string>
     <string name="transaction_receive"> استلام من</string>
     <string name="money_icon">أيقونة المال</string>
     <string name="transaction_type_icon">أيقونة نوع المعاملة</string>

--- a/wallet_presentation/src/commonMain/composeResources/values/strings.xml
+++ b/wallet_presentation/src/commonMain/composeResources/values/strings.xml
@@ -61,8 +61,8 @@
     <string name="transactions_history">Transactions History</string>
     <string name="filter">Filters</string>
     <string name="transaction_pay">Online shopping</string>
-    <string name="transaction_send">Send to </string>
-    <string name="transaction_receive">Receive from </string>
+    <string name="transaction_send">Send to</string>
+    <string name="transaction_receive">Receive from</string>
     <string name="money_icon">money icon</string>
     <string name="transaction_type_icon">Transactions Type Icon</string>
     <string name="online_shopping">Online Shopping</string>

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/component/ErrorView.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/component/ErrorView.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,7 +37,8 @@ internal fun ErrorView(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 24.dp),
+            .verticalScroll(rememberScrollState())
+            .padding( 24.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/component/FilterContent.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/component/FilterContent.kt
@@ -8,7 +8,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/component/StatePlaceholder.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/component/StatePlaceholder.kt
@@ -27,7 +27,7 @@ fun StatePlaceholder(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier.padding(horizontal = 16.dp),
+        modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_history/TransactionFilterState.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_history/TransactionFilterState.kt
@@ -15,7 +15,7 @@ data class TransactionFilterState(
     val activeFilterCount: Int = 0,
     val isDateBottomSheetVisible: Boolean = false,
     val datePickerMode: DatePickerMode = DatePickerMode.START_DATE,
-    val isLoading: Boolean = false,
+    val isApplyButtonLoading: Boolean = false,
     val errorState: ErrorState? = null
 ) {
     val hasActiveFilters: Boolean

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_history/TransactionHistoryScreen.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_history/TransactionHistoryScreen.kt
@@ -81,7 +81,7 @@ fun TransactionHistoryContent(
                 },
                 onLeadingClick = interactionListener::onBackClicked,
                 trailingContent = {
-                    if (state.history.isNotEmpty()) {
+                    if (state.history.isNotEmpty() || state.filterState.activeFilterCount > 0) {
                         Icon(
                             modifier = Modifier
                                 .clip(RoundedCornerShape(16.dp))

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_history/TransactionHistoryViewModel.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_history/TransactionHistoryViewModel.kt
@@ -224,7 +224,7 @@ class TransactionHistoryViewModel(
     }
 
     private fun resetPaginator() {
-        updateState { it.copy(history = emptyList(),) }
+        updateState { it.copy(history = emptyList()) }
 
         paginator.reset()
         loadNextTransactions()

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_history/TransactionHistoryViewModel.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_history/TransactionHistoryViewModel.kt
@@ -47,7 +47,7 @@ class TransactionHistoryViewModel(
         loadNextTransactions()
     }
 
-    private fun initializePaginator(){
+    private fun initializePaginator() {
         paginator = Paginator(
             initialKey = INITIAL_PAGE,
             onLoadUpdated = ::onPaginationLoading,
@@ -85,6 +85,7 @@ class TransactionHistoryViewModel(
             showInvalidDatesSnackBar()
             return
         }
+        updateState { it.copy(filterState = it.filterState.copy(isApplyButtonLoading = true)) }
         resetPaginator()
     }
 
@@ -223,7 +224,7 @@ class TransactionHistoryViewModel(
     }
 
     private fun resetPaginator() {
-        updateState { it.copy(history = emptyList()) }
+        updateState { it.copy(history = emptyList(),) }
 
         paginator.reset()
         loadNextTransactions()
@@ -249,7 +250,9 @@ class TransactionHistoryViewModel(
             )
         }
 
-        if (isLoading) { updateState { it.copy(errorState = null) } }
+        if (isLoading) {
+            updateState { it.copy(errorState = null) }
+        }
     }
 
     private suspend fun getPagedTransactions(page: Int): List<Transaction> =
@@ -273,7 +276,7 @@ class TransactionHistoryViewModel(
                 it.copy(
                     isFilterVisible = false,
                     filterState = it.filterState.copy(
-                        isLoading = false,
+                        isApplyButtonLoading = false,
                         activeFilterCount = getActiveFilterCount()
                     )
                 )
@@ -289,7 +292,7 @@ class TransactionHistoryViewModel(
                     else -> ErrorState.UnknownError
                 },
                 isLoading = false,
-                filterState = it.filterState.copy(isLoading = false)
+                filterState = it.filterState.copy(isApplyButtonLoading = false)
             )
         }
     }

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_history/component/TransactionFilterBottomSheet.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_history/component/TransactionFilterBottomSheet.kt
@@ -3,6 +3,7 @@ package net.thechance.mena.wallet.presentation.screen.transaction_history.compon
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -11,6 +12,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,6 +51,7 @@ fun ScaffoldScope.TransactionFilterBottomSheet(
     onStatusSelected: (FilterStatus) -> Unit,
     modifier: Modifier = Modifier
 ) {
+
     BottomSheet(
         isVisible = isVisible,
         onDismissRequest = onDismiss,
@@ -56,23 +60,39 @@ fun ScaffoldScope.TransactionFilterBottomSheet(
         stickyFooterContent = {
             StickyFooterContent(
                 hasActiveFilters = uiState.hasActiveFilters,
-                isLoading = uiState.isLoading,
+                isLoading = uiState.isApplyButtonLoading,
                 onClickAddFilter = onClickAddFilter
             )
         },
         sheetContent = {
-            HeaderFilterContent(onResetClicked = onResetClicked)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+            ) {
+                HeaderFilterContent(onResetClicked = onResetClicked)
 
-            FilterContent(
-                selectedTypes = uiState.selectedTypes,
-                selectedStatus = uiState.selectedStatus,
-                startDate = uiState.startDate?.let { formatLocalDate(date = it, outputFormat = "yyyy/MM/dd") } ?: "",
-                endDate = uiState.endDate?.let { formatLocalDate(date = it, outputFormat = "yyyy/MM/dd") } ?: "",
-                onTypeSelected = onTypeToggled,
-                onStatusSelected = onStatusSelected,
-                onStartDateClicked = onStartDateClicked,
-                onEndDateClicked = onEndDateClicked
-            )
+                FilterContent(
+                    selectedTypes = uiState.selectedTypes,
+                    selectedStatus = uiState.selectedStatus,
+                    startDate = uiState.startDate?.let {
+                        formatLocalDate(
+                            date = it,
+                            outputFormat = "yyyy/MM/dd"
+                        )
+                    } ?: "",
+                    endDate = uiState.endDate?.let {
+                        formatLocalDate(
+                            date = it,
+                            outputFormat = "yyyy/MM/dd"
+                        )
+                    } ?: "",
+                    onTypeSelected = onTypeToggled,
+                    onStatusSelected = onStatusSelected,
+                    onStartDateClicked = onStartDateClicked,
+                    onEndDateClicked = onEndDateClicked
+                )
+            }
         }
     )
 }

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_history/component/TransactiontitleAndAmount.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/transaction_history/component/TransactiontitleAndAmount.kt
@@ -35,7 +35,7 @@ fun TransactionTitleAndAmount(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = transactionTitle,
+                text = "$transactionTitle ",
                 style = Theme.typography.body.small,
                 color = Theme.colorScheme.shadePrimary,
                 maxLines = 1,


### PR DESCRIPTION
Fixed the apply filter button not loading when clicking on it
Fixed error view not being scrollable
Added the missing space in transaction history screen item
Removed extra horizontal padding in state place holder component
Fixed export icon not showing when filter result is empty