### PR TITLE
Fix/wlt 160 export transactions screen

### DIFF
--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsScreen.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsScreen.kt
@@ -16,8 +16,6 @@ import mena.wallet_presentation.generated.resources.Res
 import mena.wallet_presentation.generated.resources.back_button
 import mena.wallet_presentation.generated.resources.export_transactions
 import mena.wallet_presentation.generated.resources.ic_arrow_left
-import mena.wallet_presentation.generated.resources.pick_end_date
-import mena.wallet_presentation.generated.resources.pick_start_date
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
@@ -30,7 +28,6 @@ import net.thechance.mena.wallet.presentation.navigation.StatementDetailsScreenR
 import net.thechance.mena.wallet.presentation.screen.export.component.DownloadingToast
 import net.thechance.mena.wallet.presentation.screen.export.component.ExportTransactionContentBody
 import net.thechance.mena.wallet.presentation.utils.ObserveAsEffect
-import net.thechance.mena.wallet.presentation.utils.orToday
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -81,20 +78,8 @@ private fun ExportTransactionScreenContent(
             bottomSheet(isVisible = state.dateState.isDateBottomSheetVisible) { isVisible ->
                 DatePickerBottomSheet(
                     isVisible = isVisible,
-                    defaultSelectedDate = when (state.dateState.datePickerMode) {
-                        ExportTransactionsState.DatePickerMode.START_DATE ->
-                            state.dateState.defaultStartDate.orToday()
-
-                        ExportTransactionsState.DatePickerMode.END_DATE ->
-                            state.dateState.defaultEndDate.orToday()
-                    },
-                    title = when (state.dateState.datePickerMode) {
-                        ExportTransactionsState.DatePickerMode.START_DATE ->
-                            stringResource(Res.string.pick_start_date)
-
-                        ExportTransactionsState.DatePickerMode.END_DATE ->
-                            stringResource(Res.string.pick_end_date)
-                    },
+                    defaultSelectedDate = state.defaultSelectedDate,
+                    title = stringResource(state.dateState.datePickerMode.titleRes),
                     onPickClick = { day, month, year ->
                         val pickedDate = LocalDate(year, month, day)
                         interactionListener.onPickDateClicked(pickedDate)

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsState.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsState.kt
@@ -1,9 +1,13 @@
 package net.thechance.mena.wallet.presentation.screen.export
 
 import kotlinx.datetime.LocalDate
+import mena.wallet_presentation.generated.resources.Res
+import mena.wallet_presentation.generated.resources.pick_end_date
+import mena.wallet_presentation.generated.resources.pick_start_date
 
 import net.thechance.mena.wallet.presentation.model.FilterType
 import net.thechance.mena.wallet.presentation.model.SnackBarState
+import net.thechance.mena.wallet.presentation.utils.orToday
 import org.jetbrains.compose.resources.StringResource
 
 data class ExportTransactionsState(
@@ -40,9 +44,18 @@ data class ExportTransactionsState(
         val messageRes: StringResource? = null,
     )
 
-    enum class DatePickerMode {
-        START_DATE,
-        END_DATE
+    enum class DatePickerMode(val titleRes: StringResource) {
+        START_DATE(Res.string.pick_start_date),
+        END_DATE(Res.string.pick_end_date)
     }
+
+    val defaultSelectedDate: LocalDate
+        get() = when (dateState.datePickerMode) {
+            DatePickerMode.START_DATE ->
+                dateState.defaultStartDate.orToday()
+
+            DatePickerMode.END_DATE ->
+                dateState.defaultEndDate.orToday()
+        }
 }
 

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsViewModel.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/ExportTransactionsViewModel.kt
@@ -66,7 +66,8 @@ class ExportTransactionsViewModel(
             oldState.copy(
                 isCustomFilterCardSelected = false,
                 isDownloadButtonEnabled = true,
-                isViewAndShareButtonEnabled = true
+                isViewAndShareButtonEnabled = true,
+                filterState = ExportTransactionsState.FilterState()
             )
         }
     }

--- a/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/component/ExportTransactionContentBody.kt
+++ b/wallet_presentation/src/commonMain/kotlin/net/thechance/mena/wallet/presentation/screen/export/component/ExportTransactionContentBody.kt
@@ -1,13 +1,18 @@
 package net.thechance.mena.wallet.presentation.screen.export.component
 
-import androidx.compose.animation.Crossfade
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -38,36 +43,23 @@ fun ExportTransactionContentBody(
     Column(
         modifier = Modifier
             .fillMaxHeight()
-            .padding(16.dp)
+            .padding(horizontal = 16.dp)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.SpaceBetween
     ) {
         ExportTransactionFilterSection(
-            modifier = Modifier.weight(1f),
             state = state,
-            interactionListener = interactionListener
+            interactionListener = interactionListener,
+            modifier = Modifier.padding(top = 16.dp)
         )
 
-        OutlinedButton(
-            text = stringResource(Res.string.view_and_share),
-            onClick = interactionListener::onViewAndShareClicked,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 6.dp, bottom = 12.dp),
-            trailingIcon = painterResource(Res.drawable.share),
-            isLoading = state.isViewAndShareLoading,
-            isEnabled = state.isViewAndShareButtonEnabled,
-            contentPadding = PaddingValues(vertical = 13.dp),
-        )
-
-        PrimaryButton(
-            text = stringResource(Res.string.download),
-            onClick = interactionListener::onDownloadClicked,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 8.dp),
-            trailingIcon = painterResource(Res.drawable.download),
-            isLoading = state.isDownloadLoading,
-            isEnabled = state.isDownloadButtonEnabled,
-            contentPadding = PaddingValues(vertical = 13.dp)
+        ExportTransactionActionButtons(
+            isViewAndShareLoading = state.isViewAndShareLoading,
+            isViewAndShareEnabled = state.isViewAndShareButtonEnabled,
+            isDownloadLoading = state.isDownloadLoading,
+            isDownloadEnabled = state.isDownloadButtonEnabled,
+            interactionListener = interactionListener,
+            modifier = Modifier.padding(top = 32.dp, bottom = 16.dp)
         )
     }
 }
@@ -79,42 +71,73 @@ private fun ExportTransactionFilterSection(
     state: ExportTransactionsState,
     interactionListener: ExportTransactionsListener
 ) {
-    LazyColumn(
+    Column(
         modifier = modifier
     ) {
+        ExportTypeCard(
+            cardTitle = stringResource(Res.string.all_transactions),
+            onCardSelected = interactionListener::onAllTransactionsClicked,
+            isSelected = (!state.isCustomFilterCardSelected),
+            isEnabled = (!state.canSelectExportType),
+            modifier = Modifier.padding(bottom = 12.dp)
+        )
 
-        item {
-            ExportTypeCard(
-                cardTitle = stringResource(Res.string.all_transactions),
-                onCardSelected = interactionListener::onAllTransactionsClicked,
-                isSelected = (!state.isCustomFilterCardSelected),
-                isEnabled = (!state.canSelectExportType),
-                modifier = Modifier.padding(bottom = 12.dp)
+        ExportTypeCard(
+            cardTitle = stringResource(Res.string.custom_filtering),
+            isSelected = state.isCustomFilterCardSelected,
+            isEnabled = (!state.canSelectExportType),
+            onCardSelected = interactionListener::onCustomFilteringClicked,
+        )
+
+        AnimatedVisibility(
+            visible = state.isCustomFilterCardSelected,
+            enter = fadeIn(animationSpec = tween(durationMillis = 300)),
+            exit = fadeOut(animationSpec = tween(durationMillis = 300)),
+            label = stringResource(Res.string.filter_crossfade),
+        ) {
+            FilterSection(
+                state = state.filterState,
+                interactionListener = interactionListener
             )
         }
+    }
+}
 
-        item {
-            ExportTypeCard(
-                cardTitle = stringResource(Res.string.custom_filtering),
-                isSelected = state.isCustomFilterCardSelected,
-                isEnabled = (!state.canSelectExportType),
-                onCardSelected = interactionListener::onCustomFilteringClicked,
-            )
-        }
+@Composable
+private fun ExportTransactionActionButtons(
+    isViewAndShareLoading: Boolean,
+    isViewAndShareEnabled: Boolean,
+    isDownloadLoading: Boolean,
+    isDownloadEnabled: Boolean,
+    interactionListener: ExportTransactionsListener,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+    ) {
+        OutlinedButton(
+            text = stringResource(Res.string.view_and_share),
+            onClick = interactionListener::onViewAndShareClicked,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 6.dp, bottom = 12.dp),
+            trailingIcon = painterResource(Res.drawable.share),
+            isLoading = isViewAndShareLoading,
+            isEnabled = isViewAndShareEnabled,
+            contentPadding = PaddingValues(vertical = 13.dp),
+        )
 
-        item {
-            Crossfade(
-                targetState = state.isCustomFilterCardSelected,
-                label = stringResource(Res.string.filter_crossfade),
-            ) { visible ->
-                if (visible) {
-                    FilterSection(
-                        state = state.filterState,
-                        interactionListener = interactionListener
-                    )
-                }
-            }
-        }
+        PrimaryButton(
+            text = stringResource(Res.string.download),
+            onClick = interactionListener::onDownloadClicked,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 8.dp),
+            trailingIcon = painterResource(Res.drawable.download),
+            isLoading = isDownloadLoading,
+            isEnabled = isDownloadEnabled,
+            contentPadding = PaddingValues(vertical = 13.dp)
+        )
     }
 }
 


### PR DESCRIPTION
### PR Content:
1- Fixed a bug where view and share & download button were not scrollable and blocked the rest of the content
| Before | After |
|---------|--------|
| https://github.com/user-attachments/assets/6b90382b-26bb-4153-9e4e-b7cab70693fc | https://github.com/user-attachments/assets/ba7a0ac6-f5c4-4152-a065-6f335f704fa8 |


2- Fixed a bug where filter state didn't reset after deselecting custom filter.
| Before | After |
|---------|--------|
| https://github.com/user-attachments/assets/191f058c-cef2-4dc1-be74-7306f35caba2 | https://github.com/user-attachments/assets/93feae47-1e9a-45f6-8e26-ae8b83f9458d |