### PR TITLE
fix:empty state appears at first launch

### DIFF
--- a/admin_panel/src/commonMain/kotlin/net/thechance/mena/admin_panel/presentation/base/BaseViewModel.kt
+++ b/admin_panel/src/commonMain/kotlin/net/thechance/mena/admin_panel/presentation/base/BaseViewModel.kt
@@ -49,9 +49,11 @@ abstract class BaseViewModel<STATE, EFFECT>(initialState: STATE) : ViewModel() {
                 onFinish?.invoke()
             }
         }
+        inScope.launch {
+            onStart?.invoke()
+        }
 
         return inScope.launch(dispatcher + exceptionHandler) {
-            onStart?.invoke()
             onSuccess(callee())
             onFinish?.invoke()
         }

--- a/admin_panel/src/commonMain/kotlin/net/thechance/mena/admin_panel/presentation/screen/users_management/UsersManagementScreenState.kt
+++ b/admin_panel/src/commonMain/kotlin/net/thechance/mena/admin_panel/presentation/screen/users_management/UsersManagementScreenState.kt
@@ -13,7 +13,7 @@ data class UsersManagementScreenState(
     val query: String = "",
     val pageInfo : UserPageInfo = UserPageInfo(),
     val sort: SortState = SortState(),
-    val isLoading: Boolean = true,
+    val isLoading: Boolean =false,
     val errorState: ErrorState? = null,
     val snackBar: SnackBarState = SnackBarState(),
     val isBlockDialogShown: Boolean = false,


### PR DESCRIPTION
issueempty state appears at first launch cuz is loading not assign to true at onStart()

solution
handle base view model to ensure the loading state is set to true immediately when getUsers() is called, rather than waiting for the coroutine to be scheduled on the IO dispatcher.

another solution 
we can just make on start() not suspendable at base view model
