### PR TITLE
feat: Pass current address details to map screen

### DIFF
--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/addEditLocation/AddEditLocationScreenViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/addEditLocation/AddEditLocationScreenViewModel.kt
@@ -103,7 +103,7 @@ class AddEditLocationScreenViewModel(
     override fun onClickMap() {
         sendNewEffect(
             createNavigateToMapEffect(
-                addressModel = null,
+                addressModel = createAddressModelFromCurrentState(state.value.addressUIState),
                 onSuccess = ::onAddressFromPickLocation
             )
         )


### PR DESCRIPTION
When a user selects a location and proceeds to "Add New Address," the address type is automatically set to Home instead of remaining unselected or using the correct previous value.

https://github.com/user-attachments/assets/1ea0aa7e-8e62-4e59-82de-ae0df1d98fbc
