### PR TITLE
Refactor: update URL scheme from app to mena

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -7,7 +7,7 @@
 		<dict>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>app</string>
+				<string>mena</string>
 			</array>
 			<key>CFBundleURLName</key>
 			<string>net.the-chance.mena-dev</string>


### PR DESCRIPTION
The PR changes the `CFBundleURLSchemes` for the iOS application. It replaces the previous generic URL scheme `app` with the more specific scheme `mena`.

This change was made in order to avoid conflicting the link with other apps that use the same scheme in the iOS.

https://github.com/user-attachments/assets/9baf05ba-4fc3-4d12-bdcb-5ef44d1d087e