### PR TITLE
refactor: center DatePickerScreen content vertically

### DIFF
--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/AuthScreenContainer.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/components/AuthScreenContainer.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.unit.dp
 import mena.identity_presentation.generated.resources.Res
 import mena.identity_presentation.generated.resources.login_background
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
@@ -54,7 +53,5 @@ internal fun AuthScreenContainer(
                 .padding(vertical = Theme.spacing._24, horizontal = Theme.spacing._16),
             content = content
         )
-
-
     }
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/register/datePicker/DatePickerScreen.kt
@@ -1,13 +1,9 @@
 package net.thechance.mena.identity.presentation.screen.register.datePicker
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.Navigator
@@ -41,37 +37,25 @@ class DatePickerScreen(
         listener: DatePickerScreenInteractionListener
     ) {
         Scaffold {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .systemBarsPadding()
-                    .padding(top = 24.dp)
-            ) {
-                AuthScreenContainer {
-                    PageDescription(
-                        title = stringResource(Res.string.date_picker_screen_prompt_title),
-                        subtitle = stringResource(Res.string.date_picker_screen_prompt),
-                    )
-
-                    Box(
-                        modifier = Modifier.weight(1f),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        GregorianDatePicker(
-                            selectedDate = state.selectedDate,
-                            onDateChange = listener::onChangeDate
-                        )
-                    }
-
-                    PrimaryButton(
-                        text = stringResource(Res.string.next),
-                        onClick = listener::onClickNext,
-                        isEnabled = state.isNextEnabled,
-                        isLoading = state.isNextLoading,
-                        contentPadding = PaddingValues(vertical = 13.dp),
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
+            AuthScreenContainer {
+                PageDescription(
+                    title = stringResource(Res.string.date_picker_screen_prompt_title),
+                    subtitle = stringResource(Res.string.date_picker_screen_prompt),
+                )
+                Spacer(Modifier.weight(1f))
+                GregorianDatePicker(
+                    selectedDate = state.selectedDate,
+                    onDateChange = listener::onChangeDate
+                )
+                Spacer(Modifier.weight(1f))
+                PrimaryButton(
+                    text = stringResource(Res.string.next),
+                    onClick = listener::onClickNext,
+                    isEnabled = state.isNextEnabled,
+                    isLoading = state.isNextLoading,
+                    contentPadding = PaddingValues(vertical = 13.dp),
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
         }
     }


### PR DESCRIPTION
This PR refactor the `DatePickerScreen` to properly center its content vertically.

- Use `Spacer` with `weight(1f)` on both sides of the `GregorianDatePicker` to push it to the center within the `AuthScreenContainer`.
- Remove the nested `Box` with `weight(1f)` and `contentAlignment = Alignment.Center` as it is now redundant.
- Clean up unused imports in `AuthScreenContainer`.


https://github.com/user-attachments/assets/f5517e47-029c-4619-a5b6-044a7799a8c6
