### PR TITLE
Fix/dkn 177 product details affected by dukan color

### DIFF
--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/product/ProductQuantityButton.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/component/product/ProductQuantityButton.kt
@@ -32,6 +32,7 @@ fun ProductQuantityButton(
     onPlusClick: () -> Unit,
     onMinusClick: () -> Unit,
     inCartQuantity: Int,
+    dukanColor: Color = Theme.colorScheme.primary.primary,
     backgroundColor: Color = Theme.colorScheme.background.surface,
     iconPadding: PaddingValues = PaddingValues(Theme.spacing._4 + Theme.spacing._2)
 ) {
@@ -46,7 +47,7 @@ fun ProductQuantityButton(
         Icon(
             painter = painterResource(Res.drawable.remove_01),
             contentDescription = stringResource(Res.string.remove_product),
-            tint = Theme.colorScheme.primary.primary,
+            tint = dukanColor,
             modifier = Modifier
                 .clip(CircleShape)
                 .background(color = Theme.colorScheme.background.surfaceLow)
@@ -66,7 +67,7 @@ fun ProductQuantityButton(
         Icon(
             painter = painterResource(Res.drawable.add_icon),
             contentDescription = stringResource(Res.string.add_product),
-            tint = Theme.colorScheme.primary.primary,
+            tint = dukanColor,
             modifier = Modifier
                 .clip(CircleShape)
                 .background(color = Theme.colorScheme.background.surfaceLow)

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/ProductDetailsContent.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/ProductDetailsContent.kt
@@ -39,6 +39,14 @@ fun ProductDetailsContent(
                 listener = listener
             )
         },
+        bottomBar = {
+            AddToCartSection(
+                onAddToCartClick = {listener.onAddToCartClicked(productId = state.product.id)},
+                onPlusClick = {listener.onPlusClicked(state.product.id)},
+                onMinusClick = {listener.onMinusClicked(productId = state.product.id)},
+                state = state
+            )
+        },
         snakeBar = {
             state.snackBarState?.let {snackBarUiState ->
                 SnackBar(
@@ -75,13 +83,6 @@ fun ProductDetailsContent(
                         isLoading = state.isLoading
                     )
                 }
-                AddToCartSection(
-                    modifier = Modifier.align(Alignment.BottomCenter),
-                    onAddToCartClick = {listener.onAddToCartClicked(productId = state.product.id)},
-                    onPlusClick = {listener.onPlusClicked(state.product.id)},
-                    onMinusClick = {listener.onMinusClicked(productId = state.product.id)},
-                    state = state
-                )
             }
         }
     }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/ProductDetailsContent.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/ProductDetailsContent.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/AddToCartSection.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/AddToCartSection.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/AddToCartSection.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/AddToCartSection.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import mena.dukan_presentation.generated.resources.Res
@@ -40,7 +41,6 @@ fun AddToCartSection(
 ) {
     Column(
         modifier = modifier.fillMaxWidth()
-            .height(120.dp)
             .background(Theme.colorScheme.background.surface)
             .padding(
                 top = Theme.spacing._8,
@@ -54,6 +54,7 @@ fun AddToCartSection(
         ProductQuantityButton(
             onPlusClick = onPlusClick,
             onMinusClick = onMinusClick,
+            dukanColor = Color(state.dukanColor),
             inCartQuantity = state.product.inCartQuantity,
             backgroundColor = Theme.colorScheme.background.surfaceHigh,
             iconPadding = PaddingValues(Theme.spacing._8 + Theme.spacing._2)
@@ -71,7 +72,7 @@ fun AddToCartSection(
                 Theme.colorScheme.primary.primary
             ),
             shape = SquircleShape(Theme.radius.md),
-            containerColor = Theme.colorScheme.primary.primary,
+            containerColor = Color(state.dukanColor),
             disabledContainerColor = Theme.colorScheme.disabled,
             disabledContentColor = Theme.colorScheme.textDisabled ,
         ) {
@@ -95,12 +96,12 @@ fun AddToCartSection(
                 )
                 Column {
                     Text(
-                        text = "$${state.product.price}",
+                        text = "${state.product.price}$",
                         style = Theme.typography.label.small,
                         color = Theme.colorScheme.primary.onPrimary,
                     )
                     Text(
-                        text = "$${state.product.price}",
+                        text = "${state.product.price}$",
                         style = Theme.typography.label.small.copy(
                             textDecoration = TextDecoration.LineThrough
                         ),

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/ProductDetailsInfoSection.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/ProductDetailsInfoSection.kt
@@ -75,7 +75,8 @@ private fun ProductDetailsInfoContent(
         text = state.name,
         style = Theme.typography.title.medium,
         color = Theme.colorScheme.shadePrimary,
-        textAlign = TextAlign.Center,
+        textAlign = TextAlign.Start,
+        maxLines = 2,
         modifier = Modifier
     )
     ProductDetailsPriceRow(

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/ProductDetailsTopAppBar.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/productDetails/components/ProductDetailsTopAppBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.dp
 import mena.dukan_presentation.generated.resources.Res
@@ -60,6 +61,7 @@ fun ProductDetailsAppBar(
                     }
                 ),
                 contentDescription = stringResource(Res.string.favorite_icon),
+                tint = Color(state.dukanColor),
                 onClick = listener::onToggleProductToFavoriteClicked
             )
             AppBarOptionContainer(
@@ -80,6 +82,7 @@ private fun AppBarIcon(
     painter: Painter,
     contentDescription: String,
     onClick: () -> Unit,
+    tint: Color = Theme.colorScheme.primary.primary,
     modifier: Modifier = Modifier
 ) {
     AppBarOptionContainer(
@@ -87,7 +90,7 @@ private fun AppBarIcon(
     ) {
         Icon(
             painter = painter,
-            tint = Theme.colorScheme.primary.primary,
+            tint = tint,
             contentDescription = contentDescription,
             modifier = modifier.size(40.dp)
         )

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsMapper.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsMapper.kt
@@ -23,4 +23,4 @@ fun ProductDetailsUiState.ProductInfo.toDomainParams(dukanId: String): UpdatePro
         dukanId = dukanId
     )
 }
-fun toColor(color: String): Long = color.removePrefix("#").toLong(16) or 0xFF000000
+fun parseHexColor(color: String): Long = color.removePrefix("#").toLong(16) or 0xFF000000

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsMapper.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsMapper.kt
@@ -24,4 +24,4 @@ fun ProductDetailsUiState.ProductInfo.toDomainParams(dukanId: String): UpdatePro
     )
 }
 
-fun String.toColor(): Long = (removePrefix("#").toLong(16) or 0xFF000000)
+fun String.toColor(): Long = removePrefix("#").toLong(16) or 0xFF000000

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsMapper.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsMapper.kt
@@ -23,5 +23,4 @@ fun ProductDetailsUiState.ProductInfo.toDomainParams(dukanId: String): UpdatePro
         dukanId = dukanId
     )
 }
-
-fun String.toColor(): Long = removePrefix("#").toLong(16) or 0xFF000000
+fun toColor(color: String): Long = color.removePrefix("#").toLong(16) or 0xFF000000

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsMapper.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsMapper.kt
@@ -23,3 +23,5 @@ fun ProductDetailsUiState.ProductInfo.toDomainParams(dukanId: String): UpdatePro
         dukanId = dukanId
     )
 }
+
+fun String.toColor(): Long = (removePrefix("#").toLong(16) or 0xFF000000)

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsUiState.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsUiState.kt
@@ -12,7 +12,7 @@ data class ProductDetailsUiState(
     val isFirstQuantityOne: Boolean = false,
     val snackBarState: SnackBarUiState? = null,
     val hasProductInCart: Boolean = false,
-    val isButtonEnable : Boolean = false
+    val isButtonEnable : Boolean = false,
     val dukanColor : Long = 0,
 ) {
     data class ProductInfo(

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsUiState.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsUiState.kt
@@ -11,7 +11,8 @@ data class ProductDetailsUiState(
     val selectedImageUrl: String = "",
     val isFirstQuantityOne: Boolean = false,
     val snackBarState: SnackBarUiState? = null,
-    val hasProductInCart: Boolean = false
+    val hasProductInCart: Boolean = false,
+    val dukanColor : Long = 0,
 ) {
     data class ProductInfo(
         val id: String = "",

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModel.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModel.kt
@@ -47,19 +47,19 @@ class ProductDetailsViewModel(
         loadDukanInfo()
     }
 
-    private fun loadDukanInfo(){
+    private fun loadDukanInfo() {
         tryToExecute(
-            block = { dukanManagementRepository.getDukanDetailsByDukanId(args.dukanId)},
+            block = { dukanManagementRepository.getDukanDetailsByDukanId(args.dukanId) },
             onSuccess = ::onLoadDukanSuccess,
             onError = ::onLoadDukanError
         )
     }
 
-    private fun onLoadDukanSuccess(dukan: Dukan){
-        updateState { copy(dukanColor = dukan.color.hexCode.toColor()) }
+    private fun onLoadDukanSuccess(dukan: Dukan) {
+        updateState { copy(dukanColor = toColor(color = dukan.color.hexCode)) }
     }
 
-    private fun onLoadDukanError(throwable: Throwable){
+    private fun onLoadDukanError(throwable: Throwable) {
         updateState { copy(dukanColor = 0xFF000000) }
     }
 

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModel.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModel.kt
@@ -13,10 +13,12 @@ import mena.dukan_presentation.generated.resources.no_internet_connection
 import mena.dukan_presentation.generated.resources.remove_product_successfully
 import mena.dukan_presentation.generated.resources.something_went_wrong
 import net.thechance.mena.dukan.domain.entity.Cart
+import net.thechance.mena.dukan.domain.entity.Dukan
 import net.thechance.mena.dukan.domain.entity.Product
 import net.thechance.mena.dukan.domain.exceptions.NoInternetException
 import net.thechance.mena.dukan.domain.model.UpdateProductCartQuantityParams
 import net.thechance.mena.dukan.domain.repository.CartRepository
+import net.thechance.mena.dukan.domain.repository.DukanManagementRepository
 import net.thechance.mena.dukan.domain.repository.ProductRepository
 import net.thechance.mena.dukan.presentation.component.shared.SnackBarType
 import net.thechance.mena.dukan.presentation.component.shared.SnackBarUiState
@@ -27,6 +29,7 @@ import org.jetbrains.compose.resources.StringResource
 class ProductDetailsViewModel(
     private val productRepository: ProductRepository,
     private val dukanCartRepository: CartRepository,
+    private val dukanManagementRepository: DukanManagementRepository,
     savedStateHandle: SavedStateHandle,
     defaultDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : BaseViewModel<ProductDetailsUiState, ProductDetailsEffects>(
@@ -38,6 +41,23 @@ class ProductDetailsViewModel(
     init {
         loadProductDetails()
         loadCartInfo()
+        loadDukanInfo()
+    }
+
+    private fun loadDukanInfo(){
+        tryToExecute(
+            block = { dukanManagementRepository.getDukanDetailsByDukanId(args.dukanId)},
+            onSuccess = ::onLoadDukanSuccess,
+            onError = ::onLoadDukanError
+        )
+    }
+
+    private fun onLoadDukanSuccess(dukan: Dukan){
+        updateState { copy(dukanColor = dukan.color.hexCode.toColor()) }
+    }
+
+    private fun onLoadDukanError(throwable: Throwable){
+        updateState { copy(dukanColor = 0xFF000000) }
     }
 
     private fun loadCartInfo() {

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModel.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModel.kt
@@ -56,7 +56,7 @@ class ProductDetailsViewModel(
     }
 
     private fun onLoadDukanSuccess(dukan: Dukan) {
-        updateState { copy(dukanColor = toColor(color = dukan.color.hexCode)) }
+        updateState { copy(dukanColor = parseHexColor(color = dukan.color.hexCode)) }
     }
 
     private fun onLoadDukanError(throwable: Throwable) {

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/Mapper.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/Mapper.kt
@@ -50,4 +50,11 @@ class ProductDetailsMapperTest {
         assertEquals(4, params.quantity)
         assertEquals("dukanId_1", params.dukanId)
     }
+
+    @Test
+    fun `toColor should map String color to Long`(){
+        val color = "#432CCD"
+        val colorLong = color.toColor()
+        assertEquals(0xFF432CCD, colorLong)
+    }
 }

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/Mapper.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/Mapper.kt
@@ -54,7 +54,7 @@ class ProductDetailsMapperTest {
     @Test
     fun `toColor should map String color to Long`(){
         val color = "#432CCD"
-        val colorLong = color.toColor()
+        val colorLong = toColor(color = color)
         assertEquals(0xFF432CCD, colorLong)
     }
 }

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/Mapper.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/Mapper.kt
@@ -54,7 +54,7 @@ class ProductDetailsMapperTest {
     @Test
     fun `toColor should map String color to Long`(){
         val color = "#432CCD"
-        val colorLong = toColor(color = color)
+        val colorLong = parseHexColor(color = color)
         assertEquals(0xFF432CCD, colorLong)
     }
 }

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModelTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModelTest.kt
@@ -80,7 +80,7 @@ class ProductDetailsViewModelTest {
         advanceUntilIdle()
         viewModel.state.test {
             val state = awaitItem()
-            assertEquals(toColor(dummyDukanDetails().color.hexCode), state.dukanColor)
+            assertEquals(parseHexColor(dummyDukanDetails().color.hexCode), state.dukanColor)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModelTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModelTest.kt
@@ -80,7 +80,7 @@ class ProductDetailsViewModelTest {
         advanceUntilIdle()
         viewModel.state.test {
             val state = awaitItem()
-            assertEquals(dummyDukanDetails().color.hexCode.toColor(), state.dukanColor)
+            assertEquals(toColor(dummyDukanDetails().color.hexCode), state.dukanColor)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModelTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/productDetails/ProductDetailsViewModelTest.kt
@@ -19,9 +19,12 @@ import kotlinx.coroutines.test.setMain
 import mena.dukan_presentation.generated.resources.Res
 import mena.dukan_presentation.generated.resources.no_internet_connection
 import net.thechance.mena.dukan.domain.entity.Cart
+import net.thechance.mena.dukan.domain.entity.Color
+import net.thechance.mena.dukan.domain.entity.Dukan
 import net.thechance.mena.dukan.domain.entity.Product
 import net.thechance.mena.dukan.domain.exceptions.NoInternetException
 import net.thechance.mena.dukan.domain.repository.CartRepository
+import net.thechance.mena.dukan.domain.repository.DukanManagementRepository
 import net.thechance.mena.dukan.domain.repository.ProductRepository
 import net.thechance.mena.dukan.presentation.component.shared.SnackBarType
 import kotlin.test.AfterTest
@@ -40,6 +43,8 @@ class ProductDetailsViewModelTest {
 
     private val productRepository = mock<ProductRepository>(mode = MockMode.autofill)
     private val dukanCartRepository = mock<CartRepository>(mode = MockMode.autofill)
+    private val dukanManagementRepository =
+        mock<DukanManagementRepository>(mode = MockMode.autofill)
 
     private val testDispatcher = StandardTestDispatcher()
 
@@ -64,6 +69,20 @@ class ProductDetailsViewModelTest {
     @AfterTest
     fun cleanup() {
         Dispatchers.resetMain()
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    @Test
+    fun `init SHOULD load dukan details successfully`() = runTest {
+        everySuspend { dukanManagementRepository.getDukanDetailsByDukanId(any()) } returns dummyDukanDetails()
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.state.test {
+            val state = awaitItem()
+            assertEquals(dummyDukanDetails().color.hexCode.toColor(), state.dukanColor)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @OptIn(ExperimentalUuidApi::class)
@@ -389,8 +408,8 @@ class ProductDetailsViewModelTest {
         productRepository = productRepository,
         defaultDispatcher = testDispatcher,
         savedStateHandle = savedStateHandle,
-        dukanCartRepository = dukanCartRepository
-
+        dukanCartRepository = dukanCartRepository,
+        dukanManagementRepository = dukanManagementRepository
     )
 }
 
@@ -414,4 +433,18 @@ private fun dummyProductDetails(): Product = Product(
     quantityInCart = 10,
     shelfId = Uuid.parse("123e4567-e89b-12d3-a456-000000000124"),
     isFavorite = false
+)
+
+@OptIn(ExperimentalUuidApi::class)
+private fun dummyDukanDetails() = Dukan(
+    id = Uuid.parse("123e4567-e89b-12d3-a456-426614174003"),
+    name = "Test Dukan",
+    isFavorite = true,
+    address = "123 Test Street",
+    imageUrl = "https://example.com/image.png",
+    coordinates = Dukan.Coordinates(latitude = 30.0, longitude = 31.0),
+    color = Color(id = Uuid.random(), hexCode = "#FF0000"),
+    style = Dukan.Style.WIDE_IMAGE,
+    categories = emptySet(),
+    status = Dukan.Status.APPROVED,
 )


### PR DESCRIPTION
Fix bugs to make product details screen color should affected by the dukan’s color, product details are hidden in landscape and check product name should not be centered when it's more than one line