### PR TITLE
Fix/IDN-173 Prevent AppBar title from shifting when trailing content expands

### DIFF
--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/appBar/AppBar.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/appBar/AppBar.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
@@ -50,9 +51,9 @@ fun AppBar(
         Text(
             text = title,
             color = titleColor,
-            style = Theme.typography.title.medium,
-            modifier = Modifier.weight(1f)
+            style = Theme.typography.title.medium
         )
+        Spacer(modifier = Modifier.weight(1f))
         trailingContent?.let {
             Row(
                 modifier = Modifier.padding(start = 8.dp),


### PR DESCRIPTION
## Fix AppBar title alignment issue

This PR fixes a layout bug where the AppBar title shifted when trailing content expanded.

### Changes
- Replaced `Modifier.weight(1f)` on the title with a `Spacer(weight = 1f)` after the title.
- Ensured consistent title alignment regardless of trailing content size.
