### PR TITLE
feat: Add delete confirmation dialog for bookmarks

### DIFF
--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkInteractionListener.kt
@@ -4,4 +4,7 @@ interface BookmarkInteractionListener {
     fun onBackClick()
     fun onDeleteBookmarkClick(bookmarkId: Int)
     fun onStartTilawahClick()
+    fun onConfirmDeleteDownloadedSurahClick()
+    fun onDismissDeleteConfirmationDialog()
+
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkScreen.kt
@@ -36,6 +36,7 @@ import net.thechance.mena.faith.presentation.designSystem.theme.QuranTheme
 import net.thechance.mena.faith.presentation.feature.quran.bookmark.component.BookmarkAppBar
 import net.thechance.mena.faith.presentation.feature.quran.bookmark.component.BookmarkItems
 import net.thechance.mena.faith.presentation.feature.quran.bookmark.component.EmptyBookmarkState
+import net.thechance.mena.faith.presentation.feature.quran.downloadedSur.components.DeleteConfirmationDialog
 import net.thechance.mena.faith.presentation.navigation.LocalNavController
 import net.thechance.mena.faith.presentation.navigation.Route
 import net.thechance.mena.faith.presentation.utils.extentions.isEmpty
@@ -81,7 +82,19 @@ private fun Content(
                 isVisible = snackBarState.isVisible,
                 status = snackBarState.status,
             )
-        },
+        }, overlays = {
+            dialog(
+                isVisible = uiState.showDeleteConfirmationDialog,
+            ) {
+                DeleteConfirmationDialog(
+                    showDialog = uiState.showDeleteConfirmationDialog,
+                    onDeleteClick = { listener::onConfirmDeleteDownloadedSurahClick },
+                    onDismiss = listener::onDismissDeleteConfirmationDialog,
+                    title = "Remove Aya",
+                    message = "Are you sure you want to remove this aya from bookmarks?"
+                )
+            }
+        }
     ) {
         Column(
             modifier = Modifier
@@ -186,6 +199,8 @@ private fun BookmarkScreenPreview() {
                 override fun onBackClick() {}
                 override fun onDeleteBookmarkClick(bookmarkId: Int) {}
                 override fun onStartTilawahClick() {}
+                override fun onConfirmDeleteDownloadedSurahClick() {}
+                override fun onDismissDeleteConfirmationDialog() {}
             },
             snackBarState = SnackBarState()
         )

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkUiState.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkUiState.kt
@@ -11,7 +11,8 @@ data class BookMarkUiState(
     val bookmarks: Flow<PagingData<BookmarkCardUiState>> = emptyFlow(),
     val isLoading: Boolean = false,
     val error: String? = null,
-) {
+    val showDeleteConfirmationDialog: Boolean = false,
+    ) {
     data class BookmarkCardUiState(
         val bookmarkId: Int = 0,
         val surahName: String = "",

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkViewModel.kt
@@ -27,9 +27,9 @@ class BookmarkViewModel(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
     snackBarHandler: SnackbarHandler,
 ) : BaseViewModel<BookMarkUiState, BookmarkEffect>(
-        BookMarkUiState(),
-        snackBarHandler,
-    ),
+    BookMarkUiState(),
+    snackBarHandler,
+),
     BookmarkInteractionListener {
     private val cachedBookmarksFlow =
         createBookmarksPagingSource()
@@ -57,13 +57,25 @@ class BookmarkViewModel(
 
     override fun onDeleteBookmarkClick(bookmarkId: Int) {
         tryToExecute(
-            dispatcher = dispatcher,
-            execute = { bookmarkRepository.deleteAyahBookmark(bookmarkId) },
+            execute = {
+                onConfirmDeleteDownloadedSurahClick()
+                bookmarkRepository.deleteAyahBookmark(bookmarkId)
+            },
             onStart = { insertDeletedBookmarkId(bookmarkId) },
-            onSuccess = { onDeleteBookmarkSuccess() },
+            onSuccess = {
+                onDeleteBookmarkSuccess()
+                onDismissDeleteConfirmationDialog()
+            },
             onError = { removeDeletedBookmarkId(bookmarkId) },
+            dispatcher = dispatcher
         )
     }
+
+    override fun onDismissDeleteConfirmationDialog() =
+        updateState { it.copy(showDeleteConfirmationDialog = false) }
+
+    override fun onConfirmDeleteDownloadedSurahClick() =
+        updateState { it.copy(showDeleteConfirmationDialog = true) }
 
     private fun insertDeletedBookmarkId(id: Int) =
         deletedBookmarkIdsFlow.update { currentSet -> currentSet + id }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/downloadedSur/components/DeleteConfirmationDialog.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/downloadedSur/components/DeleteConfirmationDialog.kt
@@ -24,12 +24,14 @@ fun ScaffoldScope.DeleteConfirmationDialog(
     showDialog: Boolean,
     onDeleteClick: () -> Unit,
     onDismiss: () -> Unit,
+    title: String = stringResource(Res.string.delete_surah),
+    message: String = stringResource(Res.string.delete_surah_dialog_message),
 ) {
     Dialog(
         isVisible = showDialog,
         onDismiss = onDismiss,
-        title = stringResource(Res.string.delete_surah),
-        message = stringResource(Res.string.delete_surah_dialog_message),
+        title = title,
+        message = message,
         dismissOnClickOutside = true,
         dismissOnBackPress = true,
         onCancelClick = onDismiss,


### PR DESCRIPTION
- Implement a confirmation dialog before deleting an aya from bookmarks.
- Generalize the `DeleteConfirmationDialog` to accept custom title and message strings.
- Update the bookmark screen and viewmodel to handle the dialog's visibility and actions.