### PR TITLE
feat: Add delete confirmation dialog for bookmarks

### DIFF
--- a/faith_presentation/src/commonMain/composeResources/values-ar/strings.xml
+++ b/faith_presentation/src/commonMain/composeResources/values-ar/strings.xml
@@ -138,5 +138,6 @@
     <string name="add_mosque_message">تمت إضافة المسجد بنجاح.</string>
     <string name="mosque_image">صورة المسجد</string>
     <string name="read_all_surah">تلاوة السورة</string>
-
+    <string name="remove_aya">حذف الآية</string>
+    <string name="remove_aya_message">هل أنت متأكد من حذف هذة الاية من الإشارات المرجعية</string>
 </resources>

--- a/faith_presentation/src/commonMain/composeResources/values/strings.xml
+++ b/faith_presentation/src/commonMain/composeResources/values/strings.xml
@@ -201,6 +201,7 @@
     <string name="add_mosque_message">Added mosque successfully.</string>
     <string name="read_all_surah">Tilawah All Surah</string>
     <string name="mosque_image">Mosque image</string>
-
+    <string name="remove_aya">Remove Aya</string>
+    <string name="remove_aya_message">"Are you sure you want to remove this aya from bookmarks?"</string>
 
 </resources>

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkInteractionListener.kt
@@ -4,4 +4,7 @@ interface BookmarkInteractionListener {
     fun onBackClick()
     fun onDeleteBookmarkClick(bookmarkId: Int)
     fun onStartTilawahClick()
+    fun onConfirmDeleteDownloadedSurahClick()
+    fun onDismissDeleteConfirmationDialog()
+
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkInteractionListener.kt
@@ -4,7 +4,7 @@ interface BookmarkInteractionListener {
     fun onBackClick()
     fun onDeleteBookmarkClick(bookmarkId: Int)
     fun onStartTilawahClick()
-    fun onConfirmDeleteDownloadedSurahClick()
+    fun onConfirmDeleteBookmarkClick()
     fun onDismissDeleteConfirmationDialog()
 
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkScreen.kt
@@ -86,10 +86,10 @@ private fun Content(
             )
         }, overlays = {
             dialog(
-                isVisible = uiState.showDeleteConfirmationDialog,
+                isVisible = uiState.isDeleteConfirmationDialogVisible,
             ) {
                 DeleteConfirmationDialog(
-                    showDialog = uiState.showDeleteConfirmationDialog,
+                    showDialog = uiState.isDeleteConfirmationDialogVisible,
                     onDeleteClick = listener::onConfirmDeleteBookmarkClick,
                     onDismiss = listener::onDismissDeleteConfirmationDialog,
                     title = stringResource(Res.string.remove_aya),

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkScreen.kt
@@ -26,6 +26,8 @@ import mena.faith_presentation.generated.resources.empty_state_bookmark_descript
 import mena.faith_presentation.generated.resources.empty_state_bookmark_image
 import mena.faith_presentation.generated.resources.empty_state_bookmark_title
 import mena.faith_presentation.generated.resources.ic_not_saved_book_mark
+import mena.faith_presentation.generated.resources.remove_aya
+import mena.faith_presentation.generated.resources.remove_aya_message
 import net.thechance.mena.designsystem.presentation.component.indicator.DotsProgressIndicator
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
@@ -88,10 +90,10 @@ private fun Content(
             ) {
                 DeleteConfirmationDialog(
                     showDialog = uiState.showDeleteConfirmationDialog,
-                    onDeleteClick = { listener::onConfirmDeleteDownloadedSurahClick },
+                    onDeleteClick = listener::onConfirmDeleteBookmarkClick,
                     onDismiss = listener::onDismissDeleteConfirmationDialog,
-                    title = "Remove Aya",
-                    message = "Are you sure you want to remove this aya from bookmarks?"
+                    title = stringResource(Res.string.remove_aya),
+                    message = stringResource(Res.string.remove_aya_message)
                 )
             }
         }
@@ -199,7 +201,7 @@ private fun BookmarkScreenPreview() {
                 override fun onBackClick() {}
                 override fun onDeleteBookmarkClick(bookmarkId: Int) {}
                 override fun onStartTilawahClick() {}
-                override fun onConfirmDeleteDownloadedSurahClick() {}
+                override fun onConfirmDeleteBookmarkClick() {}
                 override fun onDismissDeleteConfirmationDialog() {}
             },
             snackBarState = SnackBarState()

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkScreen.kt
@@ -36,6 +36,7 @@ import net.thechance.mena.faith.presentation.designSystem.theme.QuranTheme
 import net.thechance.mena.faith.presentation.feature.quran.bookmark.component.BookmarkAppBar
 import net.thechance.mena.faith.presentation.feature.quran.bookmark.component.BookmarkItems
 import net.thechance.mena.faith.presentation.feature.quran.bookmark.component.EmptyBookmarkState
+import net.thechance.mena.faith.presentation.feature.quran.downloadedSur.components.DeleteConfirmationDialog
 import net.thechance.mena.faith.presentation.navigation.LocalNavController
 import net.thechance.mena.faith.presentation.navigation.Route
 import net.thechance.mena.faith.presentation.utils.extentions.isEmpty
@@ -81,7 +82,19 @@ private fun Content(
                 isVisible = snackBarState.isVisible,
                 status = snackBarState.status,
             )
-        },
+        }, overlays = {
+            dialog(
+                isVisible = uiState.showDeleteConfirmationDialog,
+            ) {
+                DeleteConfirmationDialog(
+                    showDialog = uiState.showDeleteConfirmationDialog,
+                    onDeleteClick = { listener::onConfirmDeleteDownloadedSurahClick },
+                    onDismiss = listener::onDismissDeleteConfirmationDialog,
+                    title = "Remove Aya",
+                    message = "Are you sure you want to remove this aya from bookmarks?"
+                )
+            }
+        }
     ) {
         Column(
             modifier = Modifier
@@ -186,6 +199,8 @@ private fun BookmarkScreenPreview() {
                 override fun onBackClick() {}
                 override fun onDeleteBookmarkClick(bookmarkId: Int) {}
                 override fun onStartTilawahClick() {}
+                override fun onConfirmDeleteDownloadedSurahClick() {}
+                override fun onDismissDeleteConfirmationDialog() {}
             },
             snackBarState = SnackBarState()
         )

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkUiState.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkUiState.kt
@@ -11,7 +11,8 @@ data class BookMarkUiState(
     val bookmarks: Flow<PagingData<BookmarkCardUiState>> = emptyFlow(),
     val isLoading: Boolean = false,
     val error: String? = null,
-) {
+    val showDeleteConfirmationDialog: Boolean = false,
+    ) {
     data class BookmarkCardUiState(
         val bookmarkId: Int = 0,
         val surahName: String = "",

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkUiState.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkUiState.kt
@@ -11,7 +11,7 @@ data class BookMarkUiState(
     val bookmarks: Flow<PagingData<BookmarkCardUiState>> = emptyFlow(),
     val isLoading: Boolean = false,
     val error: String? = null,
-    val showDeleteConfirmationDialog: Boolean = false,
+    val isDeleteConfirmationDialogVisible: Boolean = false,
     ) {
     data class BookmarkCardUiState(
         val bookmarkId: Int = 0,

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkViewModel.kt
@@ -59,7 +59,7 @@ class BookmarkViewModel(
 
     override fun onDeleteBookmarkClick(bookmarkId: Int) {
         pendingDeleteBookmarkId = bookmarkId
-        updateState { it.copy(showDeleteConfirmationDialog = true) }
+        updateState { it.copy(isDeleteConfirmationDialogVisible = true) }
     }
 
     override fun onConfirmDeleteBookmarkClick() {
@@ -68,11 +68,7 @@ class BookmarkViewModel(
         tryToExecute(
             execute = { bookmarkRepository.deleteAyahBookmark(bookmarkId) },
             onStart = { insertDeletedBookmarkId(bookmarkId) },
-            onSuccess = {
-                onDeleteBookmarkSuccess()
-                onDismissDeleteConfirmationDialog()
-                pendingDeleteBookmarkId = null
-            },
+            onSuccess = { onDeleteBookmarkSuccess() },
             onError = {
                 removeDeletedBookmarkId(bookmarkId)
                 onDismissDeleteConfirmationDialog()
@@ -83,7 +79,7 @@ class BookmarkViewModel(
     }
 
     override fun onDismissDeleteConfirmationDialog() {
-        updateState { it.copy(showDeleteConfirmationDialog = false) }
+        updateState { it.copy(isDeleteConfirmationDialogVisible = false) }
         pendingDeleteBookmarkId = null
     }
 
@@ -102,7 +98,13 @@ class BookmarkViewModel(
         }
     }
 
-    private fun onDeleteBookmarkSuccess() =
+    private fun onDeleteBookmarkSuccess() {
+        onDeleteBookmarkSuccessSnackbar()
+        onDismissDeleteConfirmationDialog()
+        pendingDeleteBookmarkId = null
+    }
+
+    private fun onDeleteBookmarkSuccessSnackbar() =
         snackbarHandler.showSnackBar(
             message = Res.string.bookmark_removed_successfully,
             status = SnackBarState.Status.Success,

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkViewModel.kt
@@ -27,9 +27,9 @@ class BookmarkViewModel(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
     snackBarHandler: SnackbarHandler,
 ) : BaseViewModel<BookMarkUiState, BookmarkEffect>(
-        BookMarkUiState(),
-        snackBarHandler,
-    ),
+    BookMarkUiState(),
+    snackBarHandler,
+),
     BookmarkInteractionListener {
     private val cachedBookmarksFlow =
         createBookmarksPagingSource()
@@ -57,13 +57,25 @@ class BookmarkViewModel(
 
     override fun onDeleteBookmarkClick(bookmarkId: Int) {
         tryToExecute(
-            dispatcher = dispatcher,
-            execute = { bookmarkRepository.deleteAyahBookmark(bookmarkId) },
+            execute = {
+                onConfirmDeleteDownloadedSurahClick()
+                bookmarkRepository.deleteAyahBookmark(bookmarkId)
+            },
             onStart = { insertDeletedBookmarkId(bookmarkId) },
-            onSuccess = { onDeleteBookmarkSuccess() },
+            onSuccess = {
+                onDeleteBookmarkSuccess()
+                onDismissDeleteConfirmationDialog()
+            },
             onError = { removeDeletedBookmarkId(bookmarkId) },
+            dispatcher = dispatcher
         )
     }
+
+    override fun onDismissDeleteConfirmationDialog() =
+        updateState { it.copy(showDeleteConfirmationDialog = false) }
+
+    override fun onConfirmDeleteDownloadedSurahClick() =
+        updateState { it.copy(showDeleteConfirmationDialog = true) }
 
     private fun insertDeletedBookmarkId(id: Int) =
         deletedBookmarkIdsFlow.update { currentSet -> currentSet + id }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkViewModel.kt
@@ -31,6 +31,7 @@ class BookmarkViewModel(
     snackBarHandler,
 ),
     BookmarkInteractionListener {
+
     private val cachedBookmarksFlow =
         createBookmarksPagingSource()
             .map { pagingData ->
@@ -38,6 +39,7 @@ class BookmarkViewModel(
             }.cachedIn(viewModelScope)
 
     private val deletedBookmarkIdsFlow = MutableStateFlow(setOf<Int>())
+    private var pendingDeleteBookmarkId: Int? = null
 
     private val filteredBookmarksFlow =
         combine(
@@ -56,26 +58,34 @@ class BookmarkViewModel(
     override fun onStartTilawahClick() = sendEffect(BookmarkEffect.NavigateToSur)
 
     override fun onDeleteBookmarkClick(bookmarkId: Int) {
+        pendingDeleteBookmarkId = bookmarkId
+        updateState { it.copy(showDeleteConfirmationDialog = true) }
+    }
+
+    override fun onConfirmDeleteBookmarkClick() {
+        val bookmarkId = pendingDeleteBookmarkId ?: return
+
         tryToExecute(
-            execute = {
-                onConfirmDeleteDownloadedSurahClick()
-                bookmarkRepository.deleteAyahBookmark(bookmarkId)
-            },
+            execute = { bookmarkRepository.deleteAyahBookmark(bookmarkId) },
             onStart = { insertDeletedBookmarkId(bookmarkId) },
             onSuccess = {
                 onDeleteBookmarkSuccess()
                 onDismissDeleteConfirmationDialog()
+                pendingDeleteBookmarkId = null
             },
-            onError = { removeDeletedBookmarkId(bookmarkId) },
+            onError = {
+                removeDeletedBookmarkId(bookmarkId)
+                onDismissDeleteConfirmationDialog()
+                pendingDeleteBookmarkId = null
+            },
             dispatcher = dispatcher
         )
     }
 
-    override fun onDismissDeleteConfirmationDialog() =
+    override fun onDismissDeleteConfirmationDialog() {
         updateState { it.copy(showDeleteConfirmationDialog = false) }
-
-    override fun onConfirmDeleteDownloadedSurahClick() =
-        updateState { it.copy(showDeleteConfirmationDialog = true) }
+        pendingDeleteBookmarkId = null
+    }
 
     private fun insertDeletedBookmarkId(id: Int) =
         deletedBookmarkIdsFlow.update { currentSet -> currentSet + id }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/downloadedSur/DownloadedSurScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/downloadedSur/DownloadedSurScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mena.faith_presentation.generated.resources.Res
+import mena.faith_presentation.generated.resources.delete_surah
+import mena.faith_presentation.generated.resources.delete_surah_dialog_message
 import mena.faith_presentation.generated.resources.ic_ad_duha
 import mena.faith_presentation.generated.resources.ic_al_kahf
 import mena.faith_presentation.generated.resources.ic_an_nas
@@ -25,6 +27,7 @@ import net.thechance.mena.faith.presentation.feature.quran.downloadedSur.compone
 import net.thechance.mena.faith.presentation.feature.quran.downloadedSur.components.DownloadedSurahCard
 import net.thechance.mena.faith.presentation.navigation.LocalNavController
 import net.thechance.mena.faith.presentation.navigation.Route
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -80,6 +83,8 @@ private fun Content(
                     showDialog = uiState.showDeleteConfirmationDialog,
                     onDeleteClick = listener::onConfirmDeleteDownloadedSurahClick,
                     onDismiss = listener::onDismissDeleteConfirmationDialog,
+                    title = stringResource(Res.string.delete_surah),
+                    message = stringResource(Res.string.delete_surah_dialog_message)
                 )
             }
         }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/downloadedSur/components/DeleteConfirmationDialog.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/downloadedSur/components/DeleteConfirmationDialog.kt
@@ -11,8 +11,6 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import mena.faith_presentation.generated.resources.Res
 import mena.faith_presentation.generated.resources.delete
-import mena.faith_presentation.generated.resources.delete_surah
-import mena.faith_presentation.generated.resources.delete_surah_dialog_message
 import net.thechance.mena.designsystem.presentation.component.dialog.Dialog
 import net.thechance.mena.designsystem.presentation.component.scaffold.ScaffoldScope
 import net.thechance.mena.designsystem.presentation.component.text.Text
@@ -24,8 +22,8 @@ fun ScaffoldScope.DeleteConfirmationDialog(
     showDialog: Boolean,
     onDeleteClick: () -> Unit,
     onDismiss: () -> Unit,
-    title: String = stringResource(Res.string.delete_surah),
-    message: String = stringResource(Res.string.delete_surah_dialog_message),
+    title: String ,
+    message: String,
 ) {
     Dialog(
         isVisible = showDialog,

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/downloadedSur/components/DeleteConfirmationDialog.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/downloadedSur/components/DeleteConfirmationDialog.kt
@@ -24,12 +24,14 @@ fun ScaffoldScope.DeleteConfirmationDialog(
     showDialog: Boolean,
     onDeleteClick: () -> Unit,
     onDismiss: () -> Unit,
+    title: String = stringResource(Res.string.delete_surah),
+    message: String = stringResource(Res.string.delete_surah_dialog_message),
 ) {
     Dialog(
         isVisible = showDialog,
         onDismiss = onDismiss,
-        title = stringResource(Res.string.delete_surah),
-        message = stringResource(Res.string.delete_surah_dialog_message),
+        title = title,
+        message = message,
         dismissOnClickOutside = true,
         dismissOnBackPress = true,
         onCancelClick = onDismiss,

--- a/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkViewModelTest.kt
+++ b/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkViewModelTest.kt
@@ -36,7 +36,7 @@ class BookmarkViewModelTest {
 
     @BeforeTest
     fun setUp() {
-        testDispatcher  = StandardTestDispatcher()
+        testDispatcher = StandardTestDispatcher()
         viewModel = BookmarkViewModel(
             bookmarkRepository = repository,
             dispatcher = testDispatcher,
@@ -52,8 +52,7 @@ class BookmarkViewModelTest {
             bookmarkRepository = repository,
             dispatcher = testDispatcher,
             snackBarHandler = snackbarHandler
-
-            )
+        )
         advanceUntilIdle()
 
         viewModel.uiState.test {
@@ -68,9 +67,8 @@ class BookmarkViewModelTest {
         }
     }
 
-
     @Test
-    fun `onDeleteBookmarkClick should insert bookmark id when start`() = runTest(testDispatcher) {
+    fun `onDeleteBookmarkClick should show delete confirmation dialog`() = runTest(testDispatcher) {
         everySuspend { repository.getAyahBookmarks(any(), any()) } returns fakeBookmarks
 
         viewModel = BookmarkViewModel(
@@ -79,20 +77,22 @@ class BookmarkViewModelTest {
             snackBarHandler = snackbarHandler
         )
         advanceUntilIdle()
+
         viewModel.onDeleteBookmarkClick(BOOKMARK_ID1)
+        advanceUntilIdle()
 
         viewModel.uiState.test {
             val state = awaitItem()
-            val bookmarks = state.bookmarks.asSnapshot()
-            assertFalse(bookmarks.any { it.bookmarkId == BOOKMARK_ID1 })
+            assertTrue(state.showDeleteConfirmationDialog)
+            cancelAndIgnoreRemainingEvents()
         }
     }
 
-
     @Test
-    fun `onDeleteBookmarkClick should hide single deleted bookmark from uiState`() =
+    fun `onConfirmDeleteBookmarkClick should delete bookmark successfully`() =
         runTest(testDispatcher) {
             everySuspend { repository.getAyahBookmarks(any(), any()) } returns fakeBookmarks
+            everySuspend { repository.deleteAyahBookmark(BOOKMARK_ID1) } returns Unit
 
             viewModel = BookmarkViewModel(
                 bookmarkRepository = repository,
@@ -100,31 +100,45 @@ class BookmarkViewModelTest {
                 snackBarHandler = snackbarHandler
             )
             advanceUntilIdle()
+
             viewModel.onDeleteBookmarkClick(BOOKMARK_ID1)
+            advanceUntilIdle()
+
+            viewModel.onConfirmDeleteBookmarkClick()
             advanceUntilIdle()
 
             viewModel.uiState.test {
                 val state = awaitItem()
                 val bookmarks = state.bookmarks.asSnapshot()
+
                 assertFalse(bookmarks.any { it.bookmarkId == BOOKMARK_ID1 })
+                assertFalse(state.showDeleteConfirmationDialog)
+                assertEquals(1, bookmarks.size)
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun `onDeleteBookmarkClick should hide all deleted bookmarks when multiple deletions occur`() =
+    fun `onConfirmDelete should hide all deleted bookmarks when multiple deletions occur`() =
         runTest(testDispatcher) {
             everySuspend { repository.getAyahBookmarks(any(), any()) } returns fakeBookmarks
+            everySuspend { repository.deleteAyahBookmark(any()) } returns Unit
 
             viewModel = BookmarkViewModel(
                 bookmarkRepository = repository,
                 dispatcher = testDispatcher,
                 snackBarHandler = snackbarHandler
-
-                )
+            )
             advanceUntilIdle()
+
             viewModel.onDeleteBookmarkClick(BOOKMARK_ID1)
+            advanceUntilIdle()
+            viewModel.onConfirmDeleteBookmarkClick()
+            advanceUntilIdle()
+
             viewModel.onDeleteBookmarkClick(BOOKMARK_ID2)
+            advanceUntilIdle()
+            viewModel.onConfirmDeleteBookmarkClick()
             advanceUntilIdle()
 
             viewModel.uiState.test {
@@ -145,8 +159,7 @@ class BookmarkViewModelTest {
             bookmarkRepository = repository,
             dispatcher = testDispatcher,
             snackBarHandler = snackbarHandler
-
-            )
+        )
         advanceUntilIdle()
 
         viewModel.uiState.test {
@@ -160,31 +173,63 @@ class BookmarkViewModelTest {
     }
 
     @Test
-    fun `onDeleteBookmarkClick should restore bookmark on error`() = runTest {
-        val exception = Exception("Delete failed")
-        everySuspend { repository.getAyahBookmarks(any(), any()) } returns fakeBookmarks
-        everySuspend { repository.deleteAyahBookmark(BOOKMARK_ID1) } throws exception
+    fun `onConfirmDeleteBookmarkClick should restore bookmark on error`() =
+        runTest(testDispatcher) {
+            val exception = Exception("Delete failed")
+            everySuspend { repository.getAyahBookmarks(any(), any()) } returns fakeBookmarks
+            everySuspend { repository.deleteAyahBookmark(BOOKMARK_ID1) } throws exception
 
-        viewModel = BookmarkViewModel(
-            bookmarkRepository = repository,
-            dispatcher = testDispatcher,
-            snackBarHandler = snackbarHandler
-
+            viewModel = BookmarkViewModel(
+                bookmarkRepository = repository,
+                dispatcher = testDispatcher,
+                snackBarHandler = snackbarHandler
             )
-        advanceUntilIdle()
+            advanceUntilIdle()
 
-        viewModel.onDeleteBookmarkClick(bookmarkId = BOOKMARK_ID1)
-        advanceUntilIdle()
+            viewModel.onDeleteBookmarkClick(BOOKMARK_ID1)
+            advanceUntilIdle()
 
-        viewModel.uiState.test {
-            val state = awaitItem()
-            val bookmarks = state.bookmarks.asSnapshot()
+            viewModel.onConfirmDeleteBookmarkClick()
+            advanceUntilIdle()
 
-            assertEquals(2, bookmarks.size)
-            assertTrue(bookmarks.any { it.bookmarkId == BOOKMARK_ID1 })
-            cancelAndIgnoreRemainingEvents()
+            viewModel.uiState.test {
+                val state = awaitItem()
+                val bookmarks = state.bookmarks.asSnapshot()
+
+                assertEquals(2, bookmarks.size)
+                assertTrue(bookmarks.any { it.bookmarkId == BOOKMARK_ID1 })
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
+
+    @Test
+    fun `onDismissDeleteConfirmationDialog should hide dialog without deleting`() =
+        runTest(testDispatcher) {
+            everySuspend { repository.getAyahBookmarks(any(), any()) } returns fakeBookmarks
+
+            viewModel = BookmarkViewModel(
+                bookmarkRepository = repository,
+                dispatcher = testDispatcher,
+                snackBarHandler = snackbarHandler
+            )
+            advanceUntilIdle()
+
+            viewModel.onDeleteBookmarkClick(BOOKMARK_ID1)
+            advanceUntilIdle()
+
+            viewModel.onDismissDeleteConfirmationDialog()
+            advanceUntilIdle()
+
+            viewModel.uiState.test {
+                val state = awaitItem()
+                val bookmarks = state.bookmarks.asSnapshot()
+
+                assertFalse(state.showDeleteConfirmationDialog)
+                assertEquals(2, bookmarks.size)
+                assertTrue(bookmarks.any { it.bookmarkId == BOOKMARK_ID1 })
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 
     @Test
     fun `onBackClick should emit NavigateBack effect`() = runTest(testDispatcher) {
@@ -194,7 +239,6 @@ class BookmarkViewModelTest {
             assertEquals(BookmarkEffect.NavigateBack, effect)
         }
     }
-
 
     @Test
     fun `onStartTilawahClick should emit NavigateSur effect`() = runTest(testDispatcher) {

--- a/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkViewModelTest.kt
+++ b/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/BookmarkViewModelTest.kt
@@ -83,7 +83,7 @@ class BookmarkViewModelTest {
 
         viewModel.uiState.test {
             val state = awaitItem()
-            assertTrue(state.showDeleteConfirmationDialog)
+            assertTrue(state.isDeleteConfirmationDialogVisible)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -112,7 +112,7 @@ class BookmarkViewModelTest {
                 val bookmarks = state.bookmarks.asSnapshot()
 
                 assertFalse(bookmarks.any { it.bookmarkId == BOOKMARK_ID1 })
-                assertFalse(state.showDeleteConfirmationDialog)
+                assertFalse(state.isDeleteConfirmationDialogVisible)
                 assertEquals(1, bookmarks.size)
                 cancelAndIgnoreRemainingEvents()
             }
@@ -224,7 +224,7 @@ class BookmarkViewModelTest {
                 val state = awaitItem()
                 val bookmarks = state.bookmarks.asSnapshot()
 
-                assertFalse(state.showDeleteConfirmationDialog)
+                assertFalse(state.isDeleteConfirmationDialogVisible)
                 assertEquals(2, bookmarks.size)
                 assertTrue(bookmarks.any { it.bookmarkId == BOOKMARK_ID1 })
                 cancelAndIgnoreRemainingEvents()


### PR DESCRIPTION
- Implement a confirmation dialog before deleting an aya from bookmarks.
- Generalize the `DeleteConfirmationDialog` to accept custom title and message strings.
- Update the bookmark screen and viewmodel to handle the dialog's visibility and actions.