### PR TITLE
Fix/ Preserve description state on like action

### DIFF
--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import net.thechance.mena.trends.domain.entity.Reel
 import net.thechance.mena.trends.domain.repository.ReelsRepository
 import net.thechance.mena.trends.presentation.shared.base.BaseViewModel
 import net.thechance.mena.trends.presentation.shared.base.createPager
@@ -34,8 +35,16 @@ internal class HomeViewModel(
                 updateState { copy(error = error) }
             },
             dispatcher = defaultDispatcher,
-            onSuccess = { updatedReel -> updateReelInPagingData(reelId) { updatedReel.toUiState() } }
+            onSuccess = { updatedReel ->
+                onAddLikeSuccess(reelId = reelId, updatedReel = updatedReel)
+            }
         )
+    }
+
+    private fun onAddLikeSuccess(reelId: String, updatedReel: Reel) {
+        updateReelInPagingData(reelId) {
+            updatedReel.toUiState().copy(isDescriptionExpanded = it.isDescriptionExpanded)
+        }
     }
 
     private fun updateLikesOnUi(reelId: String) {
@@ -135,7 +144,7 @@ internal class HomeViewModel(
         )
     }
 
-    private fun onGetRefreshedThumbnailSuccess(refreshedUrl: String, reelId: String){
+    private fun onGetRefreshedThumbnailSuccess(refreshedUrl: String, reelId: String) {
         state.value.reelsStateFlow.value =
             state.value.reelsStateFlow.value.map { reel ->
                 reel.takeIf { it.id != reelId }


### PR DESCRIPTION
Extract the success logic for adding a like into a new `onAddLikeSuccess` function. This change ensures that the `isDescriptionExpanded` state is preserved when a reel is updated after a user likes it.

[Screen_recording_20251113_150951.webm](https://github.com/user-attachments/assets/5cb28522-322f-4a14-b7a9-b2633aed3bbc)
