### PR TITLE
refactor: Decouple QuranTheme and add auto-mirroring for icons

### DIFF
--- a/faith_presentation/src/commonMain/composeResources/drawable/arrow_left.xml
+++ b/faith_presentation/src/commonMain/composeResources/drawable/arrow_left.xml
@@ -2,7 +2,8 @@
     android:width="16dp"
     android:height="16dp"
     android:viewportWidth="16"
-    android:viewportHeight="16">
+    android:autoMirrored="true"
+android:viewportHeight="16">
   <path
       android:pathData="M9.647,12.353L5.293,8L9.647,3.646L10.354,4.353L6.707,8L10.354,11.646L9.647,12.353Z"
       android:fillColor="#000000"

--- a/faith_presentation/src/commonMain/composeResources/drawable/ic_arrow_right.xml
+++ b/faith_presentation/src/commonMain/composeResources/drawable/ic_arrow_right.xml
@@ -1,10 +1,11 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="16dp"
     android:height="16dp"
+    android:autoMirrored="true"
     android:viewportWidth="16"
     android:viewportHeight="16">
-  <path
-      android:pathData="M6.354,3.646L10.707,8L6.354,12.354L5.646,11.646L9.293,8L5.647,4.354L6.354,3.646Z"
-      android:fillColor="#000000"
-      android:fillType="evenOdd"/>
+    <path
+        android:fillColor="#000000"
+        android:fillType="evenOdd"
+        android:pathData="M6.354,3.646L10.707,8L6.354,12.354L5.646,11.646L9.293,8L5.647,4.354L6.354,3.646Z" />
 </vector>

--- a/faith_presentation/src/commonMain/composeResources/values-ar/strings.xml
+++ b/faith_presentation/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="qiblah">قبله</string>
+    <!-- General Terms -->
+    <string name="sur">سور</string>
+    <string name="quran">قرآن</string>
+    <string name="makki">مكية</string>
+    <string name="madani">مدنية</string>
+    <string name="ayat">ايات</string>
+
+    <string name="qiblah">القبلة</string>
     <plurals name="time_seconds_ago">
         <item quantity="zero">منذ أقل من ثانية</item>
         <item quantity="one">منذ ثانية واحدة</item>
@@ -78,6 +85,8 @@
     <string name="no_results_found_title">لم يتم العثور على نتائج!</string>
     <string name="no_results_found_subtitle">يرجى المحاولة مرة أخرى بكلمة بحث أخرى.</string>
     <string name="back">رجوع</string>
+    <string name="motion_configuration">حرك هاتقك علي شكل ثمانية كما هو مُبين في الشكل المقابل</string>
+    <string name="continue_btn">استمر</string>
     <string name="upload_mosque_image">اضف صورة للمسجد</string>
     <string name="click_to_upload">اضغط للرفع</string>
     <string name="faith_title">الإيمان</string>
@@ -100,8 +109,9 @@
     <string name="navigate_next">الانتقال للشاشة التالية</string>
     <string name="surah_al_fatiha">الفاتحة</string>
     <string name="mosque_image_description">أيقونة المسجد</string>
-    <string name="device_angle_to_qiblah">زاوية الجهاز إلى القبله</string>
-    <string name="qibla_direction">اتجاه القبله</string>
+    <string name="device_angle_to_qiblah">زاوية الجهاز إلى القبلة</string>
+    <string name="calibrate_device">ظبط زاوية الجهاز</string>
+    <string name="qibla_direction">اتجاه القبلة</string>
     <string name="surah_ayah_format">%1$s: %2$d آية</string>
     <string name="cancel_icon">أيقونة الإلغاء</string>
     <string name="mosque_details">تفاصيل المسجد</string>
@@ -125,19 +135,24 @@
 
 
     <!--  Downloaded sur  -->
-    <string name="downloaded_sur">السور المحمله</string>
+    <string name="downloaded_sur">السور التي تم تنزيلها</string>
     <string name="reciter_list">قائمة القرآء</string>
-    <string name="delete_surah">حذف السوره</string>
+    <string name="delete_surah">حذف السورة</string>
     <string name="delete">حذف</string>
-    <string name="delete_surah_dialog_message">هل انت متأكد من انك تريد حذف هذة السوره من التنزيلات؟</string>
-    <string name="surah_deleted_successfully">تم حذف السوره بنجاح</string>
+    <string name="delete_surah_dialog_message">هل انت متأكد من انك تريد حذف هذة السورة من التنزيلات؟</string>
+    <string name="surah_deleted_successfully">تم حذف السورة بنجاح</string>
     <string name="listen">استماع</string>
-    <string name="download_icon">ايقونة التنزيل</string>
+    <string name="download_icon">أيقونة التنزيل</string>
     <string name="prayer_time"> وقت الصلاة </string>
     <string name="kilometer_unit">كم</string>
     <string name="add_mosque_message">تمت إضافة المسجد بنجاح.</string>
     <string name="mosque_image">صورة المسجد</string>
     <string name="read_all_surah">تلاوة السورة</string>
     <string name="remove_aya">حذف الآية</string>
+    <string name="bookmark_added_successfully">تم إضافة الإشارة المرجعية بنجاح</string>
+    <string name="bookmark_removed_successfully">تم حذف الإشارة المرجعية بنجاح</string>
+    <string name="send_to">إرسال إلي</string>
+    <string name="bookmark">إشارة مرجعية</string>
+    <string name="copy">نسخ</string>
     <string name="remove_aya_message">هل أنت متأكد من حذف هذة الاية من الإشارات المرجعية</string>
 </resources>

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/designSystem/theme/QuranTheme.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/designSystem/theme/QuranTheme.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.remember
-import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.typography.Typography
 import net.thechance.mena.faith.presentation.designSystem.typography.LocalQuranTypography
 import net.thechance.mena.faith.presentation.designSystem.typography.QuranTypography
@@ -12,14 +11,12 @@ import net.thechance.mena.faith.presentation.designSystem.typography.QuranTypogr
 
 @Composable
 internal fun QuranTheme(content: @Composable () -> Unit) {
-    MenaTheme {
         val fontFamily = getFontFamily()
         val quranTypography = remember { QuranTypography.create(fontFamily) }
         CompositionLocalProvider(
             value = LocalQuranTypography provides quranTypography,
             content = content
         )
-    }
 }
 
 internal val Typography.quran: QuranTypography

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/FaithFeatureCard.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/main/components/FaithFeatureCard.kt
@@ -45,7 +45,7 @@ fun FaithFeatureCard(
     ) {
         Image(
             painter = painterResource(Res.drawable.ic_column_mosque),
-            stringResource(Res.string.mosque_image_description),
+            contentDescription = stringResource(Res.string.mosque_image_description),
             modifier = Modifier
                 .align(Alignment.CenterEnd)
                 .fillMaxHeight()


### PR DESCRIPTION
- Refactor `QuranTheme` to remove the dependency on `MenaTheme`.
- Enable `autoMirrored="true"` for `arrow_left` and `arrow_right` drawables to support RTL layouts.
- Update and add various Arabic string resources for better localization.
- Fix the `contentDescription` parameter name in `FaithFeatureCard`.
- Add `highlightAyah` to set the initial scroll position and highlight a specific ayah.
- Implement `playSurah` to start audio playback from a selected ayah to the end of the surah.
- Add `onInitialAyahScrolled` to reset ayah selection state after scrolling.
- Include corresponding unit tests for the new functionality.

<img width="328" height="447" alt="image" src="https://github.com/user-attachments/assets/6d9113ad-c167-4471-8bbb-78c68c17e3b5" />
