### PR TITLE
Fix ios audio playback and duration handling

### DIFF
--- a/core_chat_presentation/src/iosMain/kotlin/net/thechance/mena/core_chat/presentation/utils/AudioPlayer.ios.kt
+++ b/core_chat_presentation/src/iosMain/kotlin/net/thechance/mena/core_chat/presentation/utils/AudioPlayer.ios.kt
@@ -6,6 +6,8 @@ import io.github.vinceglb.filekit.utils.toByteArray
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.AVFAudio.AVAudioPlayer
 import platform.AVFAudio.AVAudioPlayerDelegateProtocol
+import platform.AVFoundation.AVURLAsset
+import platform.CoreMedia.CMTimeGetSeconds
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSURL
 import platform.Foundation.NSData
@@ -26,26 +28,24 @@ actual fun convertAudioFileToByteArray(filePath: String): ByteArray {
 class IOSAudioPlayer : AudioPlayer {
     private var audioPlayer: AVAudioPlayer? = null
     private var currentFilePath: String? = null
+    private var cachedDurationMs: Long = 0L
 
     override fun play(filePath: String) {
-        if (audioPlayer != null && currentFilePath == filePath && audioPlayer?.isPlaying() == false) {
-            audioPlayer?.play()
+        if (audioPlayer != null && currentFilePath == filePath) {
+            if (audioPlayer?.isPlaying() == false) audioPlayer?.play()
             return
         }
-
         stop()
-
         val fileManager = NSFileManager.defaultManager
         if (!fileManager.fileExistsAtPath(filePath)) {
             throw IllegalArgumentException("File does not exist: $filePath")
         }
-
         val url = NSURL.fileURLWithPath(filePath)
         val player = AVAudioPlayer(url, null)
-
+        player.prepareToPlay()
         audioPlayer = player
+        cachedDurationMs = (player.duration * 1000).toLong().coerceAtLeast(0L)
         player.play()
-
         player.delegate = object : NSObject(), AVAudioPlayerDelegateProtocol {
             override fun audioPlayerDidFinishPlaying(player: AVAudioPlayer, successfully: Boolean) {
                 player.pause()
@@ -61,33 +61,31 @@ class IOSAudioPlayer : AudioPlayer {
     }
 
     override fun stop() {
-        audioPlayer?.apply {
-            if (isPlaying()) stop()
-        }
+        audioPlayer?.apply { if (isPlaying()) stop() }
         audioPlayer = null
         currentFilePath = null
+        cachedDurationMs = 0L
     }
 
-    override fun release() {
-        stop()
-    }
+    override fun release() { stop() }
 
     override fun getDuration(filePath: String): Long {
         val fileManager = NSFileManager.defaultManager
         if (!fileManager.fileExistsAtPath(filePath)) {
             throw IllegalArgumentException("File does not exist: $filePath")
         }
-
         val url = NSURL.fileURLWithPath(filePath)
-        val player = AVAudioPlayer(url, null)
-        return player.duration.toLong()
+        val asset = AVURLAsset.URLAssetWithURL(url, null)
+        val seconds = CMTimeGetSeconds(asset.duration)
+        return if (seconds.isFinite() && seconds > 0) (seconds * 1000).toLong() else 0L
     }
 
     override fun getDurationOfCurrentAudio(): Long {
-        return currentFilePath?.let(::getDuration) ?: throw IllegalArgumentException("there is not current audio")
+        val path = currentFilePath ?: throw IllegalArgumentException("There is no current audio loaded")
+        return if (cachedDurationMs > 0) cachedDurationMs else getDuration(path)
     }
 
     override fun getCurrentPosition(): Long {
-        return audioPlayer?.currentTime?.toLong() ?: 0L
+        return ((audioPlayer?.currentTime ?: 0.0) * 1000).toLong()
     }
 }


### PR DESCRIPTION
This pull request refactors the `IOSAudioPlayer` class in `AudioPlayer.ios.kt` to improve audio playback management and duration handling. The main changes include introducing a cached duration mechanism, more accurate duration calculations using AVFoundation, and some code clean-up for clarity and efficiency.