### PR TITLE
Fix/TRN-127-Handle no internet connection in reels screen

### DIFF
--- a/trends_presentation/src/androidMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.android.kt
+++ b/trends_presentation/src/androidMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.android.kt
@@ -131,20 +131,19 @@ actual fun VideoPlayer(
                     override fun onPlayerError(error: PlaybackException) {
                         val cause = error.cause
 
-                        if (cause is UnknownHostException ||
-                            error.errorCode == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED
-                        ) {
-                            onNetworkError()
-                            return
-                        }
+                        when {
+                            cause is UnknownHostException ||
+                                    error.errorCode == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED -> {
+                                onNetworkError()
+                            }
 
-                        if (cause is HttpDataSource.InvalidResponseCodeException &&
-                            cause.responseCode == HTTP_UNAUTHORIZED_STATUS_EXCEPTION
-                        ) {
-                            onRequestRefresh()
-                            return
+                            cause is HttpDataSource.InvalidResponseCodeException &&
+                                    cause.responseCode == HTTP_UNAUTHORIZED_STATUS_EXCEPTION -> {
+                                onRequestRefresh()
+                            }
+
+                            else -> super.onPlayerError(error)
                         }
-                        super.onPlayerError(error)
                     }
 
                     override fun onPlaybackStateChanged(state: Int) {

--- a/trends_presentation/src/androidMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.android.kt
+++ b/trends_presentation/src/androidMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.android.kt
@@ -44,6 +44,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.SeekParameters
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.ui.PlayerView
+import androidx.media3.ui.R
 import kotlinx.coroutines.delay
 import net.thechance.mena.designsystem.presentation.component.progressBar.ProgressBar
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
@@ -55,6 +56,7 @@ import net.thechance.mena.trends.presentation.video_player.util.Constants.BUFFER
 import net.thechance.mena.trends.presentation.video_player.util.Constants.MAX_BUFFER_MS
 import net.thechance.mena.trends.presentation.video_player.util.Constants.MIN_BUFFER_MS
 import net.thechance.mena.trends.presentation.video_player.util.Constants.SEEK_BAR_DURATION_MS
+import java.net.UnknownHostException
 
 private const val HTTP_UNAUTHORIZED_STATUS_EXCEPTION = 403
 
@@ -67,6 +69,7 @@ actual fun VideoPlayer(
     cacheKey: String?,
     onVideoPlaying: () -> Unit,
     onRequestRefresh: () -> Unit,
+    onNetworkError: () -> Unit,
     content: @Composable () -> Unit
 ) {
     val context = LocalContext.current
@@ -126,12 +129,22 @@ actual fun VideoPlayer(
 
                 addListener(object : Player.Listener {
                     override fun onPlayerError(error: PlaybackException) {
-                        val errorCause = error.cause
-                        if (errorCause is HttpDataSource.InvalidResponseCodeException) {
-                            if (errorCause.responseCode == HTTP_UNAUTHORIZED_STATUS_EXCEPTION) {
-                                onRequestRefresh()
-                            }
-                        } else super.onPlayerError(error)
+                        val cause = error.cause
+
+                        if (cause is UnknownHostException ||
+                            error.errorCode == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED
+                        ) {
+                            onNetworkError()
+                            return
+                        }
+
+                        if (cause is HttpDataSource.InvalidResponseCodeException &&
+                            cause.responseCode == HTTP_UNAUTHORIZED_STATUS_EXCEPTION
+                        ) {
+                            onRequestRefresh()
+                            return
+                        }
+                        super.onPlayerError(error)
                     }
 
                     override fun onPlaybackStateChanged(state: Int) {

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelInteractionListener.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelInteractionListener.kt
@@ -13,4 +13,6 @@ internal interface UserReelInteractionListener {
     fun increaseReelView(reelId: String)
     fun onClickLike(reelId: String, isLiked: Boolean)
     fun onGetRefreshVideoUrl(reelId: String)
+    fun onClickRetry(reelId: String)
+    fun onNetworkError()
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
@@ -67,10 +67,11 @@ import net.thechance.mena.designsystem.presentation.component.dialog.Dialog
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.component.text.Text
-import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.trends.presentation.navigation.LocalNavController
 import net.thechance.mena.trends.presentation.navigation.Route
+import net.thechance.mena.trends.presentation.shared.base.ErrorState
+import net.thechance.mena.trends.presentation.shared.component.NoConnection
 import net.thechance.mena.trends.presentation.shared.component.TrendsAnimatedVisibility
 import net.thechance.mena.trends.presentation.shared.component.modifier.noRippleClickable
 import net.thechance.mena.trends.presentation.shared.util.ObserveAsEffect
@@ -79,7 +80,6 @@ import net.thechance.mena.trends.presentation.shared.util.gradientShadow
 import net.thechance.mena.trends.presentation.video_player.VideoPlayer
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -144,11 +144,11 @@ private fun UserReelScreenContent(
                 )
             }
 
-            dialog(state.isReelDeleted == true && state.error == null) {
+            dialog(state.isReelDeleted == true) {
                 Dialog(
                     title = stringResource(Res.string.success_delete_title),
                     message = stringResource(Res.string.success_delete_message),
-                    isVisible = state.isReelDeleted == true && state.error == null,
+                    isVisible = state.isReelDeleted == true,
                     onDismiss = {
                         listener.onDismissSuccessDialog()
                         listener.onClickBack()
@@ -166,11 +166,11 @@ private fun UserReelScreenContent(
                 )
             }
 
-            dialog(state.error != null) {
+            dialog(state.isReelDeleted == false) {
                 Dialog(
                     title = stringResource(Res.string.fail_delete_title),
                     message = stringResource(Res.string.fail_delete_message),
-                    isVisible = state.error != null,
+                    isVisible = state.isReelDeleted == false,
                     onDismiss = { listener.onDismissErrorDialog() },
                     dismissOnBackPress = true,
                     dismissOnClickOutside = true,
@@ -200,24 +200,31 @@ private fun UserReelScreenContent(
 
         TopAppBar(onBackClick = listener::onClickBack, modifier = Modifier.zIndex(5f))
 
+        val hasNetworkError = state.error is ErrorState.NoInternet
+
         VerticalPager(
             state = pagerState,
-            modifier = Modifier.fillMaxSize().background(Color.Black),
+            modifier = Modifier.fillMaxSize()
+                .background(if (hasNetworkError) Theme.colorScheme.background.surface else Color.Black),
             key = { page -> reels[page]?.id ?: page },
         ) { page ->
 
             reels[page]?.let { reel ->
-                ReelContent(
-                    reel = reel,
-                    shouldRender = (pagerState.currentPage == page),
-                    isDescriptionExpanded = state.isDescriptionExpanded,
-                    onDeleteClick = listener::onClickDelete,
-                    onDescriptionClick = listener::onClickDescription,
-                    onPublisherInfoClick = listener::onClickPublisherInfo,
-                    incrementViewsCount = { listener.increaseReelView(reel.id) },
-                    onLikeClick = { listener.onClickLike(reel.id, reel.isLiked) },
-                    onGetRefreshUrl = listener::onGetRefreshVideoUrl
-                )
+                if (hasNetworkError) {
+                    NoConnection(onRetry = { listener.onClickRetry(reel.id) })
+                } else
+                    ReelContent(
+                        reel = reel,
+                        shouldRender = (pagerState.currentPage == page),
+                        isDescriptionExpanded = state.isDescriptionExpanded,
+                        onDeleteClick = listener::onClickDelete,
+                        onDescriptionClick = listener::onClickDescription,
+                        onPublisherInfoClick = listener::onClickPublisherInfo,
+                        incrementViewsCount = { listener.increaseReelView(reel.id) },
+                        onLikeClick = { listener.onClickLike(reel.id, reel.isLiked) },
+                        onGetRefreshUrl = listener::onGetRefreshVideoUrl,
+                        onNetworkError = listener::onNetworkError
+                    )
             }
         }
     }
@@ -257,6 +264,7 @@ private fun ReelContent(
     incrementViewsCount: () -> Unit,
     onGetRefreshUrl: (reelId: String) -> Unit,
     onLikeClick: () -> Unit,
+    onNetworkError: () -> Unit
 ) {
     val rememberedUrl = remember(reel.id) { reel.videoUrl }
     VideoPlayer(
@@ -265,7 +273,8 @@ private fun ReelContent(
         isReelVisible = shouldRender,
         onVideoPlaying = incrementViewsCount,
         cacheKey = reel.id,
-        onRequestRefresh = { onGetRefreshUrl(reel.id) }
+        onRequestRefresh = { onGetRefreshUrl(reel.id) },
+        onNetworkError = onNetworkError
     ) {
         BoxWithConstraints(
             modifier = Modifier.fillMaxSize()
@@ -290,7 +299,8 @@ private fun ReelContent(
 
             PublisherInfo(
                 userName = reel.username,
-                timeOfPublish = reel.createdAt?.asString() ?: stringResource(resource = Res.string.just_now),
+                timeOfPublish = reel.createdAt?.asString()
+                    ?: stringResource(resource = Res.string.just_now),
                 description = reel.description,
                 avatar = reel.profileImageUrl,
                 modifier = Modifier.align(Alignment.BottomCenter),

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModel.kt
@@ -12,6 +12,7 @@ import net.thechance.mena.trends.domain.entity.Reel
 import net.thechance.mena.trends.domain.repository.ReelsRepository
 import net.thechance.mena.trends.presentation.screen.user_reel.args.UserReelArgs
 import net.thechance.mena.trends.presentation.shared.base.BaseViewModel
+import net.thechance.mena.trends.presentation.shared.base.ErrorState
 import net.thechance.mena.trends.presentation.shared.base.createPager
 import org.koin.android.annotation.KoinViewModel
 import org.koin.core.annotation.Provided
@@ -128,7 +129,16 @@ internal class UserReelViewModel(
         )
     }
 
-    private fun onGetRefreshVideoUrl(refreshedUrl: String, reelId: String){
+    override fun onClickRetry(reelId: String) {
+        updateState { copy(currentReelId = reelId, error = null) }
+        getFeedReals()
+    }
+
+    override fun onNetworkError() {
+        updateState { copy(error = ErrorState.NoInternet) }
+    }
+
+    private fun onGetRefreshVideoUrl(refreshedUrl: String, reelId: String) {
         state.value.reelsStateFlow.value =
             state.value.reelsStateFlow.value.map { reel ->
                 reel.takeIf { it.id != reelId }
@@ -184,7 +194,7 @@ internal class UserReelViewModel(
         tryToExecute(
             block = { reelsRepository.deleteReelById(state.value.currentReelId) },
             onSuccess = { onDeleteReelSuccess() },
-            onError = { errorState -> updateState { copy(error = errorState) } },
+            onError = { errorState -> updateState { copy(error = errorState, isReelDeleted = false) } },
             dispatcher = defaultDispatcher
         )
     }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModel.kt
@@ -26,10 +26,10 @@ internal class UserReelViewModel(
 
     init {
         updateState { copy(currentReelId = userReelArgs.realId) }
-        getFeedReals()
+        getFeedReels()
     }
 
-    private fun getFeedReals() {
+    private fun getFeedReels() {
         tryToCollectFlow(
             block = ::createPager,
             onStart = { updateState { copy(isLoading = true) } },
@@ -131,7 +131,7 @@ internal class UserReelViewModel(
 
     override fun onClickRetry(reelId: String) {
         updateState { copy(currentReelId = reelId, error = null) }
-        getFeedReals()
+        getFeedReels()
     }
 
     override fun onNetworkError() {

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModel.kt
@@ -131,7 +131,7 @@ internal class UserReelViewModel(
 
     override fun onClickRetry(reelId: String) {
         updateState { copy(currentReelId = reelId, error = null) }
-        getFeedReels()
+        onGetRefreshVideoUrl(reelId)
     }
 
     override fun onNetworkError() {

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.kt
@@ -11,5 +11,6 @@ expect fun VideoPlayer(
     cacheKey: String? = null,
     onVideoPlaying: () -> Unit,
     onRequestRefresh: () -> Unit,
+    onNetworkError: () -> Unit,
     content: @Composable () -> Unit
 )

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelViewModelTest.kt
@@ -354,6 +354,28 @@ class UserReelViewModelTest {
         }
     }
 
+    @Test
+    fun `onClickRetry should update currentReelId clear error and reload reels`() = runTest {
+        viewModel.onNetworkError()
+        advanceUntilIdle()
+
+        viewModel.onClickRetry("123")
+        advanceUntilIdle()
+
+        verifySuspend { viewModel.onGetRefreshVideoUrl(any()) }
+    }
+
+    @Test
+    fun `onNetworkError should update error state to NoInternet`() = runTest {
+        viewModel.onNetworkError()
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertThat(state.error).isEqualTo(ErrorState.NoInternet)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     @AfterTest
     fun tearDown() {
         Dispatchers.resetMain()

--- a/trends_presentation/src/iosMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.ios.kt
+++ b/trends_presentation/src/iosMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.ios.kt
@@ -141,14 +141,17 @@ actual fun VideoPlayer(
             if (item?.status == AVPlayerItemStatusFailed) {
                 val error = item.error
                 if (error != null) {
-                    if (error.domain == "NSURLErrorDomain" && error.code.toInt() == -1009) {
-                        onNetworkError()
-                        return@LaunchedEffect
-                    }
+                    when {
+                        error.domain == "NSURLErrorDomain" &&
+                                error.code.toInt() == -1009 -> {
+                            onNetworkError()
+                            return@LaunchedEffect
+                        }
 
-                    if (error.code == NSURLErrorBadServerResponse) {
-                        onRequestRefresh()
-                        return@LaunchedEffect
+                        error.code == NSURLErrorBadServerResponse -> {
+                            onRequestRefresh()
+                            return@LaunchedEffect
+                        }
                     }
                 }
             }

--- a/trends_presentation/src/iosMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.ios.kt
+++ b/trends_presentation/src/iosMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.ios.kt
@@ -73,6 +73,7 @@ actual fun VideoPlayer(
     cacheKey: String?,
     onVideoPlaying: () -> Unit,
     onRequestRefresh: () -> Unit,
+    onNetworkError: () -> Unit,
     content: @Composable () -> Unit
 ) {
     var lastPosition by rememberSaveable(url) { mutableStateOf(0.0) }
@@ -140,10 +141,14 @@ actual fun VideoPlayer(
             if (item?.status == AVPlayerItemStatusFailed) {
                 val error = item.error
                 if (error != null) {
-                    if (error.code == NSURLErrorBadServerResponse ||
-                        error.domain == "NSURLErrorDomain"
-                    ) {
+                    if (error.domain == "NSURLErrorDomain" && error.code.toInt() == -1009) {
+                        onNetworkError()
+                        return@LaunchedEffect
+                    }
+
+                    if (error.code == NSURLErrorBadServerResponse) {
                         onRequestRefresh()
+                        return@LaunchedEffect
                     }
                 }
             }

--- a/trends_presentation/src/iosMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.ios.kt
+++ b/trends_presentation/src/iosMain/kotlin/net/thechance/mena/trends/presentation/video_player/VideoPlayer.ios.kt
@@ -63,6 +63,7 @@ import platform.Foundation.NSURL
 import platform.Foundation.NSURLErrorBadServerResponse
 
 private const val PREFERRED_TIME_SCALE = 600
+private const val NSURLErrorNotConnectedToInternet = -1009
 
 @OptIn(ExperimentalForeignApi::class)
 @Composable
@@ -143,7 +144,7 @@ actual fun VideoPlayer(
                 if (error != null) {
                     when {
                         error.domain == "NSURLErrorDomain" &&
-                                error.code.toInt() == -1009 -> {
+                                error.code.toInt() == NSURLErrorNotConnectedToInternet -> {
                             onNetworkError()
                             return@LaunchedEffect
                         }


### PR DESCRIPTION
- Displays a "No Connection" message when a network error occurs while playing a reel.
- Provides a "Retry" button to allow users to reload the reel.
- Implements the necessary logic in the `UserReelViewModel` to manage network error states.
- Updates the `VideoPlayer` for both Android and iOS to detect and report network-related errors, such as `UnknownHostException` or `NSURLErrorDomain` with a no-connection error code.
- Refactors the error dialog for failed reel deletion to be based on `isReelDeleted == false` instead of a generic `error != null` check.