### PR TITLE
Fix/FTH 180 Stop Repeating Initial State In Surah

### DIFF
--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
@@ -97,7 +97,7 @@ class SurahViewModel(
     override fun playSurah(surahId: Int) {}
 
     override fun onInitialAyahScrolled() {
-        if (uiState.value.isAyahSoundPlaying) return
+        if (uiState.value.isAyahSoundPlaying || uiState.value.isPlayerVisible) return
         viewModelScope.launch {
             delay(2000L)
             updateState { it.copy(selectedAyahNumber = null, initialAyahToScroll = null) }
@@ -268,6 +268,7 @@ class SurahViewModel(
         }
         updateSurahName(surahArgs.surahId)
     }
+
     private fun updateSurahName(surahId: Int) {
         tryToExecute(
             execute = { quranRepository.getSurahById(surahId) },


### PR DESCRIPTION
ensures that the `onInitialAyahScrolled` method does not trigger its logic if either the Ayah sound is currently playing or the player UI is visible, preventing unwanted state updates during playback or when the player is open.

Behavior update:

* Prevented `onInitialAyahScrolled` from updating state when the player is visible, in addition to when Ayah sound is playing, by adding a check for `uiState.value.isPlayerVisible`.