### PR TITLE
feature/FTH-168-surah-screen-bugs

### DIFF
--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahInteractionListener.kt
@@ -18,6 +18,6 @@ interface SurahInteractionListener {
     fun onInitialAyahScrolled()
     fun highlightAyah(ayahNumber: Int)
     fun updateContinueTilawah(ayahNumber: Int)
-    fun onScrollPositionChanged(lastAyah: Int)
+    fun onConfigrationChange(lastAyah: Int)
     fun playSurah(surahId: Int)
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahInteractionListener.kt
@@ -18,6 +18,6 @@ interface SurahInteractionListener {
     fun onInitialAyahScrolled()
     fun highlightAyah(ayahNumber: Int)
     fun updateContinueTilawah(ayahNumber: Int)
-    fun onConfigrationChange(lastAyah: Int)
+    fun onConfigrationChange()
     fun playSurah(surahId: Int)
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahInteractionListener.kt
@@ -18,5 +18,6 @@ interface SurahInteractionListener {
     fun onInitialAyahScrolled()
     fun highlightAyah(ayahNumber: Int)
     fun updateContinueTilawah(ayahNumber: Int)
+    fun onScrollPositionChanged(lastAyah: Int)
     fun playSurah(surahId: Int)
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreen.kt
@@ -196,6 +196,7 @@ private fun Preview() {
                     override fun onInitialAyahScrolled() {}
                     override fun highlightAyah(ayahNumber: Int) {}
                     override fun updateContinueTilawah(ayahNumber: Int) {}
+                    override fun onScrollPositionChanged(lastAyah: Int) {}
                     override fun playSurah(surahId: Int) {}
 
                 },

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreen.kt
@@ -196,7 +196,7 @@ private fun Preview() {
                     override fun onInitialAyahScrolled() {}
                     override fun highlightAyah(ayahNumber: Int) {}
                     override fun updateContinueTilawah(ayahNumber: Int) {}
-                    override fun onScrollPositionChanged(lastAyah: Int) {}
+                    override fun onConfigrationChange(lastAyah: Int) {}
                     override fun playSurah(surahId: Int) {}
 
                 },

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreen.kt
@@ -196,7 +196,7 @@ private fun Preview() {
                     override fun onInitialAyahScrolled() {}
                     override fun highlightAyah(ayahNumber: Int) {}
                     override fun updateContinueTilawah(ayahNumber: Int) {}
-                    override fun onConfigrationChange(lastAyah: Int) {}
+                    override fun onConfigrationChange() {}
                     override fun playSurah(surahId: Int) {}
 
                 },

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahUiState.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahUiState.kt
@@ -16,6 +16,7 @@ data class SurahUiState(
     val selectedAyah: String = "",
     val selectedAyahNumber: Int? = null,
     val initialAyahToScroll: Int? = null,
+    val lastVisibleAyahNumber: Int? = null,
     val isLoading: Boolean = false,
     val isBasmalaVisible: Boolean = false
 )

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahUiState.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahUiState.kt
@@ -16,7 +16,7 @@ data class SurahUiState(
     val selectedAyah: String = "",
     val selectedAyahNumber: Int? = null,
     val initialAyahToScroll: Int? = null,
-    val lastVisibleAyahNumber: Int? = null,
+    val lastVisibleAyahNumber: Int = 0,
     val isLoading: Boolean = false,
     val isBasmalaVisible: Boolean = false
 )

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
@@ -70,6 +70,15 @@ class SurahViewModel(
     private fun updateReciterState(reciter: Reciter) =
         updateState { it.copy(currentReciter = reciter.toUiState()) }
 
+    override fun onScrollPositionChanged(lastAyah: Int) {
+        updateState {
+            it.copy(
+                initialAyahToScroll = lastAyah,
+                selectedAyahNumber = null
+            )
+        }
+    }
+
     override fun highlightAyah(ayahNumber: Int) {
         updateState {
             it.copy(
@@ -92,6 +101,11 @@ class SurahViewModel(
             },
             dispatcher = dispatcher
         )
+        updateState {
+            it.copy(
+                lastVisibleAyahNumber = ayahNumber,
+            )
+        }
     }
 
     // TODO("Not yet implemented")

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
@@ -70,10 +70,10 @@ class SurahViewModel(
     private fun updateReciterState(reciter: Reciter) =
         updateState { it.copy(currentReciter = reciter.toUiState()) }
 
-    override fun onConfigrationChange(lastAyah: Int) {
+    override fun onConfigrationChange() {
         updateState {
             it.copy(
-                initialAyahToScroll = lastAyah,
+                initialAyahToScroll = uiState.value.lastVisibleAyahNumber,
                 selectedAyahNumber = null
             )
         }
@@ -99,13 +99,15 @@ class SurahViewModel(
                 quranRepository.saveLastAyahForTilawah(lastAyah)
                 lastAyah
             },
-            dispatcher = dispatcher
+            dispatcher = dispatcher,
+            onSuccess = {
+                updateState {
+                    it.copy(
+                        lastVisibleAyahNumber = ayahNumber,
+                    )
+                }
+            }
         )
-        updateState {
-            it.copy(
-                lastVisibleAyahNumber = ayahNumber,
-            )
-        }
     }
 
     // TODO("Not yet implemented")

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
@@ -70,7 +70,7 @@ class SurahViewModel(
     private fun updateReciterState(reciter: Reciter) =
         updateState { it.copy(currentReciter = reciter.toUiState()) }
 
-    override fun onScrollPositionChanged(lastAyah: Int) {
+    override fun onConfigrationChange(lastAyah: Int) {
         updateState {
             it.copy(
                 initialAyahToScroll = lastAyah,

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AyatOfSurah.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AyatOfSurah.kt
@@ -32,7 +32,7 @@ fun AyatOfSurah(
 ) {
     BoxWithConstraints(modifier) {
         LaunchedEffect(maxWidth) {
-            val ayahToScroll = state.lastVisibleAyahNumber ?: 0
+            val ayahToScroll = state.lastVisibleAyahNumber ?: 1
             listener.onConfigrationChange(ayahToScroll)
 
         }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AyatOfSurah.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AyatOfSurah.kt
@@ -30,39 +30,40 @@ fun AyatOfSurah(
     state: SurahUiState,
     modifier: Modifier = Modifier
 ) {
-    BoxWithConstraints(modifier) {
-        LaunchedEffect(maxWidth) {
-            state.lastVisibleAyahNumber ?: 1
-            listener.onConfigrationChange()
 
-        }
-    }
     val lazyListState = rememberLazyListState()
     val ayahChunks = remember(state.ayatOfSurah) { state.ayatOfSurah.chunked(AYAT_PER_PAGE) }
     val preRenderedChunks = rememberPreRenderedChunks(ayahChunks)
     var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
     var currentChunkAyat by remember { mutableStateOf(listOf<Ayah>()) }
 
-    SetupScrollTracking(
-        lazyListState = lazyListState,
-        ayahChunks = ayahChunks,
-        state = state,
-        listener = listener,
-        textLayoutResult = textLayoutResult,
-        currentChunkAyat = currentChunkAyat
-    )
+    BoxWithConstraints(modifier) {
+        LaunchedEffect(maxWidth) {
+            listener.onConfigrationChange()
 
-    AyahList(
-        modifier = Modifier.fillMaxWidth(),
-        lazyListState = lazyListState,
-        state = state,
-        ayahChunks = ayahChunks,
-        preRenderedChunks = preRenderedChunks,
-        listener = listener,
-        textLayoutResult = textLayoutResult,
-        onTextLayoutResultChange = { textLayoutResult = it },
-        onChunkChanged = { currentChunkAyat = it }
-    )
+        }
+
+        SetupScrollTracking(
+            lazyListState = lazyListState,
+            ayahChunks = ayahChunks,
+            state = state,
+            listener = listener,
+            textLayoutResult = textLayoutResult,
+            currentChunkAyat = currentChunkAyat
+        )
+
+        AyahList(
+            modifier = Modifier.fillMaxWidth(),
+            lazyListState = lazyListState,
+            state = state,
+            ayahChunks = ayahChunks,
+            preRenderedChunks = preRenderedChunks,
+            listener = listener,
+            textLayoutResult = textLayoutResult,
+            onTextLayoutResultChange = { textLayoutResult = it },
+            onChunkChanged = { currentChunkAyat = it }
+        )
+    }
 }
 
 @Composable

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AyatOfSurah.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AyatOfSurah.kt
@@ -33,7 +33,7 @@ fun AyatOfSurah(
     BoxWithConstraints(modifier) {
         LaunchedEffect(maxWidth) {
             val ayahToScroll = state.lastVisibleAyahNumber ?: 0
-            listener.onScrollPositionChanged(ayahToScroll)
+            listener.onConfigrationChange(ayahToScroll)
 
         }
     }
@@ -173,7 +173,7 @@ private fun Preview() {
                 override fun onShareClick(ayahContent: String) {}
                 override fun highlightAyah(ayahNumber: Int) {}
                 override fun updateContinueTilawah(ayahNumber: Int) {}
-                override fun onScrollPositionChanged(lastAyah: Int) {}
+                override fun onConfigrationChange(lastAyah: Int) {}
                 override fun playSurah(surahId: Int) {}
                 override fun onInitialAyahScrolled() {}
             }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AyatOfSurah.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AyatOfSurah.kt
@@ -32,8 +32,8 @@ fun AyatOfSurah(
 ) {
     BoxWithConstraints(modifier) {
         LaunchedEffect(maxWidth) {
-            val ayahToScroll = state.lastVisibleAyahNumber ?: 1
-            listener.onConfigrationChange(ayahToScroll)
+            state.lastVisibleAyahNumber ?: 1
+            listener.onConfigrationChange()
 
         }
     }
@@ -173,7 +173,7 @@ private fun Preview() {
                 override fun onShareClick(ayahContent: String) {}
                 override fun highlightAyah(ayahNumber: Int) {}
                 override fun updateContinueTilawah(ayahNumber: Int) {}
-                override fun onConfigrationChange(lastAyah: Int) {}
+                override fun onConfigrationChange() {}
                 override fun playSurah(surahId: Int) {}
                 override fun onInitialAyahScrolled() {}
             }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AyatOfSurah.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AyatOfSurah.kt
@@ -1,11 +1,13 @@
 package net.thechance.mena.faith.presentation.feature.quran.surah.component
 
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -28,6 +30,13 @@ fun AyatOfSurah(
     state: SurahUiState,
     modifier: Modifier = Modifier
 ) {
+    BoxWithConstraints(modifier) {
+        LaunchedEffect(maxWidth) {
+            val ayahToScroll = state.lastVisibleAyahNumber ?: 0
+            listener.onScrollPositionChanged(ayahToScroll)
+
+        }
+    }
     val lazyListState = rememberLazyListState()
     val ayahChunks = remember(state.ayatOfSurah) { state.ayatOfSurah.chunked(AYAT_PER_PAGE) }
     val preRenderedChunks = rememberPreRenderedChunks(ayahChunks)
@@ -44,7 +53,7 @@ fun AyatOfSurah(
     )
 
     AyahList(
-        modifier = modifier,
+        modifier = Modifier.fillMaxWidth(),
         lazyListState = lazyListState,
         state = state,
         ayahChunks = ayahChunks,
@@ -164,6 +173,7 @@ private fun Preview() {
                 override fun onShareClick(ayahContent: String) {}
                 override fun highlightAyah(ayahNumber: Int) {}
                 override fun updateContinueTilawah(ayahNumber: Int) {}
+                override fun onScrollPositionChanged(lastAyah: Int) {}
                 override fun playSurah(surahId: Int) {}
                 override fun onInitialAyahScrolled() {}
             }


### PR DESCRIPTION
- Added `lastVisibleAyahNumber` to `SurahUiState` to track the last visible Ayah.
- Implemented `onScrollPositionChanged` in the `SurahInteractionListener` and `SurahViewModel` to update the state.
- Utilized a `LaunchedEffect` within `AyatOfSurah.kt` to restore the scroll position upon recomposition.
- Updated `updateContinueTilawah` to store the last visible Ayah number.