### PR TITLE
update permissions controller binding in chat and sync contact screens

### DIFF
--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatScreen.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatScreen.kt
@@ -64,7 +64,7 @@ fun ChatScreen(onClickBackFromChat: () -> Unit = {}) {
 
     val viewModel: ChatViewModel = koinViewModel(parameters = { parametersOf(controller) })
 
-    BindEffect(controller)
+    BindEffect(viewModel.permissionsController)
 
     BackHandler(enabled = true) {
         viewModel.onBackClicked()

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModel.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModel.kt
@@ -68,7 +68,7 @@ class ChatViewModel(
     private val audioRecordRepository: AudioRecordRepository,
     private val userRepository: UserRepository,
     private val imageDownloaderService: ImageDownloaderService,
-    private val permissionsController: PermissionsController,
+    val permissionsController: PermissionsController,
     private val audioPlayer: AudioPlayer,
     chatArgs: ChatArgs,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/syncContacts/SyncContactsScreen.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/syncContacts/SyncContactsScreen.kt
@@ -49,7 +49,7 @@ fun SyncContactsScreen() {
     val factory = rememberPermissionsControllerFactory()
     val controller = remember(factory) { factory.createPermissionsController() }
     val viewModel: SyncContactsViewModel = koinViewModel { parametersOf(controller) }
-    BindEffect(controller)
+    BindEffect(viewModel.permissionsController)
 
     val state by viewModel.state.collectAsStateWithLifecycle()
     val effects = viewModel.effect

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/syncContacts/SyncContactsViewModel.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/syncContacts/SyncContactsViewModel.kt
@@ -21,7 +21,7 @@ import org.jetbrains.compose.resources.StringResource
 
 class SyncContactsViewModel(
     private val contactsRepository: ContactsRepository,
-    private val permissionsController: PermissionsController,
+    val permissionsController: PermissionsController,
     private val syncContactsScreenArgs: SyncContactsScreenArgs,
     private val settingsOpener: SettingsOpener,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,


### PR DESCRIPTION
Updated the permissions controller binding logic in the chat and contact synchronization screens to ensure correct handling of permissions within these flows. This change aims to fix the Memory Leak.