### PR TITLE
feat: Refactor next prayer time logic

### DIFF
--- a/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/di/faithDomainModule.kt
+++ b/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/di/faithDomainModule.kt
@@ -1,5 +1,6 @@
 package net.thechance.mena.faith.domain.di
 
+import net.thechance.mena.faith.domain.service.PrayerTimeService
 import net.thechance.mena.faith.domain.service.QuranService
 import net.thechance.mena.faith.domain.usecase.CalculateDistanceUseCase
 import net.thechance.mena.faith.domain.usecase.QiblahBearingCalculatorUseCase
@@ -10,4 +11,5 @@ val faithDomainModule = module {
     singleOf(::QiblahBearingCalculatorUseCase)
     singleOf(::CalculateDistanceUseCase)
     singleOf(::QuranService)
+    singleOf(::PrayerTimeService)
 }

--- a/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/service/PrayerTimesService.kt
+++ b/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/service/PrayerTimesService.kt
@@ -1,0 +1,40 @@
+package net.thechance.mena.faith.domain.service
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import net.thechance.mena.faith.domain.entity.PrayerTime
+import net.thechance.mena.faith.domain.repository.PrayerTimeRepository
+import net.thechance.mena.identity.domain.entity.Address
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+class PrayerTimeService(val prayerTimeRepository: PrayerTimeRepository) {
+
+    @OptIn(ExperimentalTime::class)
+    fun getNextPrayer(address: Address): Flow<PrayerTime?> = flow {
+        val now = Clock.System.now()
+        val todayPrayers = prayerTimeRepository.getPrayerTimes(date = now, address = address)
+
+        if (todayPrayers.isEmpty()) {
+            emit(null)
+            return@flow
+        }
+
+        val nextPrayer = todayPrayers.firstOrNull { it.time > now }
+
+        if (nextPrayer != null) emit(nextPrayer)
+        else {
+            val tomorrow = now.plusDays(1)
+            val tomorrowPrayers =
+                prayerTimeRepository.getPrayerTimes(date = tomorrow, address = address)
+            emit(tomorrowPrayers.firstOrNull())
+        }
+    }
+
+    @OptIn(ExperimentalTime::class)
+    fun Instant.plusDays(days: Int): Instant {
+        val x = this.toEpochMilliseconds() + days * 24 * 60 * 60 * 1000
+        return Instant.fromEpochMilliseconds(x)
+    }
+}

--- a/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/service/PrayerTimesService.kt
+++ b/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/service/PrayerTimesService.kt
@@ -16,10 +16,7 @@ class PrayerTimeService(val prayerTimeRepository: PrayerTimeRepository) {
         val now = Clock.System.now()
         val todayPrayers = prayerTimeRepository.getPrayerTimes(date = now, address = address)
 
-        if (todayPrayers.isEmpty()) {
-            emit(null)
-            return@flow
-        }
+        if (todayPrayers.isEmpty()) emit(null)
 
         val nextPrayer = todayPrayers.firstOrNull { it.time > now }
 

--- a/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/service/PrayerTimesService.kt
+++ b/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/service/PrayerTimesService.kt
@@ -33,7 +33,7 @@ class PrayerTimeService(val prayerTimeRepository: PrayerTimeRepository) {
     }
 
     @OptIn(ExperimentalTime::class)
-    fun Instant.plusDays(days: Int): Instant {
+    private fun Instant.plusDays(days: Int): Instant {
         val x = this.toEpochMilliseconds() + days * 24 * 60 * 60 * 1000
         return Instant.fromEpochMilliseconds(x)
     }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/prayertime/PrayerTimeUiState.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/prayertime/PrayerTimeUiState.kt
@@ -9,7 +9,7 @@ import kotlin.time.Instant
 data class PrayerTimeUiState(
     val prayerTimes: List<PrayerTime> = emptyList(),
     val nextPrayerCountdown: String = "",
-    val nextPrayerName: PrayerName = PrayerName.DHUHR,
+    val nextPrayerName: PrayerName? = null,
     val currentDate: String = "",
     val nextPrayerTime: Instant = Instant.fromEpochMilliseconds(0),
     val address: String = ""

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/prayertime/PrayerTimeViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/prayertime/PrayerTimeViewModel.kt
@@ -3,7 +3,6 @@ package net.thechance.mena.faith.presentation.feature.prayertime
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
-import kotlinx.coroutines.flow.collectLatest
 import net.thechance.mena.faith.domain.entity.PrayerName
 import net.thechance.mena.faith.domain.entity.PrayerTime
 import net.thechance.mena.faith.domain.repository.PrayerTimeRepository
@@ -48,12 +47,12 @@ class PrayerTimeViewModel(
                     address = address
                 )
             },
-            onSuccess = ::onPrayerTimesSuccess,
+            onSuccess = { onPrayerTimesSuccess(prayerTimes = it, address = address) },
             dispatcher = dispatcher
         )
     }
 
-    private fun onPrayerTimesSuccess(prayerTimes: List<PrayerTime>) {
+    private fun onPrayerTimesSuccess(prayerTimes: List<PrayerTime>, address: Address) {
         tryToExecute(
             execute = {
                 val filteredPrayerTimes = prayerTimes.filter { it.name != PrayerName.SUNRISE }
@@ -65,26 +64,30 @@ class PrayerTimeViewModel(
                     )
                 }
             },
-            onSuccess = { startNextPrayerObserver() })
+            onSuccess = { startNextPrayerObserver(address) })
     }
 
-    private suspend fun startNextPrayerObserver() {
-        val address = locationService.getActiveAddress()!!
-
-        prayerTimeService.getNextPrayer(address).collectLatest { nextPrayer ->
-            if (nextPrayer != null) startCountdownTimer(nextPrayer)
-            else {
-                updateState { state ->
-                    state.copy(
-                        nextPrayerName = null,
-                        nextPrayerCountdown = ""
-                    )
-                }
-            }
-        }
+    private fun startNextPrayerObserver(address: Address) {
+        tryToCollect(
+            block = { prayerTimeService.getNextPrayer(address) },
+            onEmitNewValue =
+                { nextPrayer ->
+                    nextPrayer?.let {
+                        startCountdownTimer(nextPrayer = it, address = address)
+                    } ?: run {
+                        updateState { state ->
+                            state.copy(
+                                nextPrayerName = null,
+                                nextPrayerCountdown = ""
+                            )
+                        }
+                    }
+                },
+            dispatcher = dispatcher
+        )
     }
 
-    private fun startCountdownTimer(nextPrayer: PrayerTime) {
+    private fun startCountdownTimer(nextPrayer: PrayerTime, address: Address) {
         val currentTime = Clock.System.now()
         val remainingMillis =
             nextPrayer.time.toEpochMilliseconds() - currentTime.toEpochMilliseconds()
@@ -97,7 +100,7 @@ class PrayerTimeViewModel(
                     )
                 }
             },
-            onSuccess = { startNextPrayerObserver() })
+            onSuccess = { startNextPrayerObserver(address) })
     }
 
     override fun onBackClick() = sendEffect(PrayerTimeEffect.NavigateBack)

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/prayertime/PrayerTimeViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/prayertime/PrayerTimeViewModel.kt
@@ -4,11 +4,13 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import net.thechance.mena.faith.domain.entity.PrayerName
 import net.thechance.mena.faith.domain.entity.PrayerTime
 import net.thechance.mena.faith.domain.repository.PrayerTimeRepository
+import net.thechance.mena.faith.domain.service.PrayerTimeService
 import net.thechance.mena.faith.presentation.base.BaseViewModel
 import net.thechance.mena.faith.presentation.utils.extentions.prayerTime.formatCountdown
 import net.thechance.mena.faith.presentation.utils.extentions.prayerTime.getHijriReadableDate
@@ -16,15 +18,18 @@ import net.thechance.mena.identity.domain.entity.Address
 import net.thechance.mena.identity.domain.service.LocationService
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
 
 @OptIn(ExperimentalTime::class)
 class PrayerTimeViewModel(
     private val prayerTimeRepository: PrayerTimeRepository,
     private val locationService: LocationService,
+    private val prayerTimeService: PrayerTimeService,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : BaseViewModel<PrayerTimeUiState, PrayerTimeEffect>(PrayerTimeUiState()),
     PrayerTimeInteractionListener {
+
+    private var countdownJob: Job? = null
+    private var currentAddress: Address? = null
 
     init {
         getUserLocation()
@@ -40,6 +45,7 @@ class PrayerTimeViewModel(
     }
 
     private fun onGetUserLocationSuccess(address: Address) {
+        currentAddress = address
         updateState { state -> state.copy(address = address.addressLine) }
 
         tryToExecute(
@@ -64,70 +70,46 @@ class PrayerTimeViewModel(
                 currentDate = hijriDate
             )
         }
-        updateNextPrayerInfo()
-        startCountdownTimer()
+
+        startNextPrayerObserver()
     }
 
-    private fun updateNextPrayerInfo() {
-        val prayerTimes = uiState.value.prayerTimes
+    private fun startNextPrayerObserver() {
+        val address = currentAddress ?: return
+        countdownJob?.cancel()
 
-        if (prayerTimes.isEmpty()) return
-
-
-        val currentTime = Clock.System.now()
-        val nextPrayer = findNextPrayer(prayerTimes, currentTime)
-
-        if (nextPrayer != null) updateStateWithNextPrayer(nextPrayer, currentTime)
-        else handleTomorrowFirstPrayer(prayerTimes, currentTime)
-    }
-
-    private fun findNextPrayer(prayerTimes: List<PrayerTime>, currentTime: Instant): PrayerTime? {
-        return prayerTimes.firstOrNull {
-            it.time.toEpochMilliseconds() > currentTime.toEpochMilliseconds()
-        }
-    }
-
-    private fun updateStateWithNextPrayer(nextPrayer: PrayerTime, currentTime: Instant) {
-        val remainingMillis = calculateRemainingTime(nextPrayer.time, currentTime)
-
-        updateState { state ->
-            state.copy(
-                nextPrayerName = nextPrayer.name,
-                nextPrayerCountdown = formatCountdown(remainingMillis)
-            )
-        }
-    }
-
-    private fun handleTomorrowFirstPrayer(prayerTimes: List<PrayerTime>, currentTime: Instant) {
-        val firstPrayer = prayerTimes.firstOrNull() ?: return
-
-        val tomorrowFirstPrayerTime = calculateNextFajrTime(firstPrayer.time)
-        val remainingMillis = calculateRemainingTime(tomorrowFirstPrayerTime, currentTime)
-
-        updateState { state ->
-            state.copy(
-                nextPrayerName = firstPrayer.name,
-                nextPrayerCountdown = formatCountdown(remainingMillis)
-            )
-        }
-    }
-
-    private fun calculateRemainingTime(prayerTime: Instant, currentTime: Instant): Long {
-        return prayerTime.toEpochMilliseconds() - currentTime.toEpochMilliseconds()
-    }
-
-    private fun calculateNextFajrTime(todayPrayerTime: Instant): Instant {
-        val oneDayInMillis = ONE_DAY_IN_MILLIS
-        return Instant.fromEpochMilliseconds(todayPrayerTime.toEpochMilliseconds() + oneDayInMillis)
-    }
-
-    private fun startCountdownTimer() {
-        viewModelScope.launch(dispatcher) {
-            while (true) {
-                delay(COUNTDOWN_UPDATE_INTERVAL)
-                updateNextPrayerInfo()
+        countdownJob = viewModelScope.launch(dispatcher) {
+            prayerTimeService.getNextPrayer(address).collectLatest { nextPrayer ->
+                if (nextPrayer != null) startCountdownTimer(nextPrayer)
+                else {
+                    updateState { state ->
+                        state.copy(
+                            nextPrayerName = null,
+                            nextPrayerCountdown = ""
+                        )
+                    }
+                }
             }
         }
+    }
+
+    private fun startCountdownTimer(nextPrayer: PrayerTime) {
+        while (true) {
+            val currentTime = Clock.System.now()
+            val remainingMillis =
+                nextPrayer.time.toEpochMilliseconds() - currentTime.toEpochMilliseconds()
+
+            if (remainingMillis <= 0) break
+
+            updateState { state ->
+                state.copy(
+                    nextPrayerName = nextPrayer.name,
+                    nextPrayerCountdown = formatCountdown(remainingMillis)
+                )
+            }
+        }
+
+        startNextPrayerObserver()
     }
 
     override fun onBackClick() = sendEffect(PrayerTimeEffect.NavigateBack)
@@ -139,9 +121,4 @@ class PrayerTimeViewModel(
     override fun onDateDropdownClick() = sendEffect(PrayerTimeEffect.NavigateCalenderDialog)
 
     override fun onLocationClick() = sendEffect(PrayerTimeEffect.NavigateToAddressesScreen)
-
-    private companion object {
-        const val ONE_DAY_IN_MILLIS = 24 * 60 * 60 * 1000L
-        const val COUNTDOWN_UPDATE_INTERVAL = 1000L
-    }
 }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/prayertime/PrayerTimeViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/prayertime/PrayerTimeViewModel.kt
@@ -1,12 +1,9 @@
 package net.thechance.mena.faith.presentation.feature.prayertime
 
-import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 import net.thechance.mena.faith.domain.entity.PrayerName
 import net.thechance.mena.faith.domain.entity.PrayerTime
 import net.thechance.mena.faith.domain.repository.PrayerTimeRepository
@@ -28,9 +25,6 @@ class PrayerTimeViewModel(
 ) : BaseViewModel<PrayerTimeUiState, PrayerTimeEffect>(PrayerTimeUiState()),
     PrayerTimeInteractionListener {
 
-    private var countdownJob: Job? = null
-    private var currentAddress: Address? = null
-
     init {
         getUserLocation()
     }
@@ -45,7 +39,6 @@ class PrayerTimeViewModel(
     }
 
     private fun onGetUserLocationSuccess(address: Address) {
-        currentAddress = address
         updateState { state -> state.copy(address = address.addressLine) }
 
         tryToExecute(
@@ -61,55 +54,50 @@ class PrayerTimeViewModel(
     }
 
     private fun onPrayerTimesSuccess(prayerTimes: List<PrayerTime>) {
-        val filteredPrayerTimes = prayerTimes.filter { it.name != PrayerName.SUNRISE }
-        val hijriDate = getHijriReadableDate(prayerTimes)
-
-        updateState {
-            it.copy(
-                prayerTimes = filteredPrayerTimes,
-                currentDate = hijriDate
-            )
-        }
-
-        startNextPrayerObserver()
+        tryToExecute(
+            execute = {
+                val filteredPrayerTimes = prayerTimes.filter { it.name != PrayerName.SUNRISE }
+                val hijriDate = getHijriReadableDate(prayerTimes)
+                updateState {
+                    it.copy(
+                        prayerTimes = filteredPrayerTimes,
+                        currentDate = hijriDate
+                    )
+                }
+            },
+            onSuccess = { startNextPrayerObserver() })
     }
 
-    private fun startNextPrayerObserver() {
-        val address = currentAddress ?: return
-        countdownJob?.cancel()
+    private suspend fun startNextPrayerObserver() {
+        val address = locationService.getActiveAddress()!!
 
-        countdownJob = viewModelScope.launch(dispatcher) {
-            prayerTimeService.getNextPrayer(address).collectLatest { nextPrayer ->
-                if (nextPrayer != null) startCountdownTimer(nextPrayer)
-                else {
-                    updateState { state ->
-                        state.copy(
-                            nextPrayerName = null,
-                            nextPrayerCountdown = ""
-                        )
-                    }
+        prayerTimeService.getNextPrayer(address).collectLatest { nextPrayer ->
+            if (nextPrayer != null) startCountdownTimer(nextPrayer)
+            else {
+                updateState { state ->
+                    state.copy(
+                        nextPrayerName = null,
+                        nextPrayerCountdown = ""
+                    )
                 }
             }
         }
     }
 
     private fun startCountdownTimer(nextPrayer: PrayerTime) {
-        while (true) {
-            val currentTime = Clock.System.now()
-            val remainingMillis =
-                nextPrayer.time.toEpochMilliseconds() - currentTime.toEpochMilliseconds()
-
-            if (remainingMillis <= 0) break
-
-            updateState { state ->
-                state.copy(
-                    nextPrayerName = nextPrayer.name,
-                    nextPrayerCountdown = formatCountdown(remainingMillis)
-                )
-            }
-        }
-
-        startNextPrayerObserver()
+        val currentTime = Clock.System.now()
+        val remainingMillis =
+            nextPrayer.time.toEpochMilliseconds() - currentTime.toEpochMilliseconds()
+        tryToExecute(
+            execute = {
+                updateState { state ->
+                    state.copy(
+                        nextPrayerName = nextPrayer.name,
+                        nextPrayerCountdown = formatCountdown(remainingMillis)
+                    )
+                }
+            },
+            onSuccess = { startNextPrayerObserver() })
     }
 
     override fun onBackClick() = sendEffect(PrayerTimeEffect.NavigateBack)

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/prayertime/component/NextPrayerCard.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/prayertime/component/NextPrayerCard.kt
@@ -18,6 +18,7 @@ import mena.faith_presentation.generated.resources.ic_prayer_man
 import mena.faith_presentation.generated.resources.next_prayer_in
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.faith.domain.entity.PrayerName
 import net.thechance.mena.faith.presentation.designSystem.theme.QuranTheme
 import net.thechance.mena.faith.presentation.feature.main.getPrayerDisplayNameResource
 import net.thechance.mena.faith.presentation.feature.prayertime.PrayerTimeUiState
@@ -58,7 +59,7 @@ internal fun NextPrayerCard(uiState: PrayerTimeUiState) {
             Text(
                 text = stringResource(
                     Res.string.next_prayer_in,
-                    stringResource(getPrayerDisplayNameResource(uiState.nextPrayerName))
+                    stringResource(getPrayerDisplayNameResource(uiState.nextPrayerName ?: PrayerName.FAJR))
                 ),
                 style = Theme.typography.label.small,
                 color = Theme.colorScheme.shadeSecondary

--- a/faith_presentation/src/commonTest/kotlin/PrayerTimeViewModelTest.kt
+++ b/faith_presentation/src/commonTest/kotlin/PrayerTimeViewModelTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.test.runTest
 import net.thechance.mena.faith.domain.entity.PrayerName
 import net.thechance.mena.faith.domain.entity.PrayerTime
 import net.thechance.mena.faith.domain.repository.PrayerTimeRepository
+import net.thechance.mena.faith.domain.service.PrayerTimeService
 import net.thechance.mena.identity.domain.entity.Address
 import net.thechance.mena.identity.domain.entity.AddressType
 import net.thechance.mena.identity.domain.repository.AddressesRepository
@@ -37,11 +38,13 @@ class PrayerTimeViewModelTest {
     private lateinit var prayerTimeRepository: PrayerTimeRepository
     private lateinit var addressesRepository: AddressesRepository
     private lateinit var locationService: LocationService
+    private lateinit var prayerTimeService: PrayerTimeService
     private val testDispatcher = UnconfinedTestDispatcher()
 
     @BeforeTest
     fun setup() {
         prayerTimeRepository = mock(MockMode.autofill)
+        prayerTimeService = PrayerTimeService(prayerTimeRepository)
         addressesRepository = mock(MockMode.autofill)
         locationService = LocationService(addressesRepository)
     }
@@ -51,8 +54,12 @@ class PrayerTimeViewModelTest {
         everySuspend { addressesRepository.getActiveAddress() } returns fakeAddress
         everySuspend { prayerTimeRepository.getPrayerTimes(any(), any()) } returns fakePrayerTimes
 
-        viewModel = PrayerTimeViewModel(prayerTimeRepository, locationService, testDispatcher)
-
+        viewModel = PrayerTimeViewModel(
+            prayerTimeRepository,
+            locationService,
+            prayerTimeService,
+            testDispatcher
+        )
 
         val state = viewModel.uiState.value
         assertEquals("Baghdad, Iraq", state.address)
@@ -63,8 +70,12 @@ class PrayerTimeViewModelTest {
         everySuspend { addressesRepository.getActiveAddress() } returns fakeAddress
         everySuspend { prayerTimeRepository.getPrayerTimes(any(), any()) } returns fakePrayerTimes
 
-        viewModel = PrayerTimeViewModel(prayerTimeRepository, locationService, testDispatcher)
-
+        viewModel = PrayerTimeViewModel(
+            prayerTimeRepository,
+            locationService,
+            prayerTimeService,
+            testDispatcher
+        )
 
         val state = viewModel.uiState.value
         assertTrue(state.currentDate.isNotEmpty())
@@ -75,8 +86,12 @@ class PrayerTimeViewModelTest {
         everySuspend { addressesRepository.getActiveAddress() } returns fakeAddress
         everySuspend { prayerTimeRepository.getPrayerTimes(any(), any()) } returns fakePrayerTimes
 
-        viewModel = PrayerTimeViewModel(prayerTimeRepository, locationService, testDispatcher)
-
+        viewModel = PrayerTimeViewModel(
+            prayerTimeRepository,
+            locationService,
+            prayerTimeService,
+            testDispatcher
+        )
 
         verifySuspend(mode = exactly(1)) { prayerTimeRepository.getPrayerTimes(any(), any()) }
     }
@@ -87,7 +102,12 @@ class PrayerTimeViewModelTest {
         everySuspend { addressesRepository.getActiveAddress() } returns fakeAddress
         everySuspend { prayerTimeRepository.getPrayerTimes(any(), any()) } returns fakePrayerTimes
 
-        viewModel = PrayerTimeViewModel(prayerTimeRepository, locationService, testDispatcher)
+        viewModel = PrayerTimeViewModel(
+            prayerTimeRepository,
+            locationService,
+            prayerTimeService,
+            testDispatcher
+        )
 
         val nextName = viewModel.uiState.value.nextPrayerName
         assertTrue(
@@ -111,7 +131,12 @@ class PrayerTimeViewModelTest {
             )
         } throws Exception("Network error")
 
-        viewModel = PrayerTimeViewModel(prayerTimeRepository, locationService, testDispatcher)
+        viewModel = PrayerTimeViewModel(
+            prayerTimeRepository,
+            locationService,
+            prayerTimeService,
+            testDispatcher
+        )
 
         assertTrue(viewModel.uiState.value.prayerTimes.isEmpty())
     }
@@ -121,7 +146,12 @@ class PrayerTimeViewModelTest {
         everySuspend { addressesRepository.getActiveAddress() } returns fakeAddress
         everySuspend { prayerTimeRepository.getPrayerTimes(any(), any()) } returns fakePrayerTimes
 
-        viewModel = PrayerTimeViewModel(prayerTimeRepository, locationService, testDispatcher)
+        viewModel = PrayerTimeViewModel(
+            prayerTimeRepository,
+            locationService,
+            prayerTimeService,
+            testDispatcher
+        )
 
         viewModel.uiEffect.test {
             viewModel.onBackClick()
@@ -142,7 +172,6 @@ class PrayerTimeViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
     }
-
 
 
     private companion object {

--- a/faith_presentation/src/commonTest/kotlin/PrayerTimeViewModelTest.kt
+++ b/faith_presentation/src/commonTest/kotlin/PrayerTimeViewModelTest.kt
@@ -66,22 +66,6 @@ class PrayerTimeViewModelTest {
     }
 
     @Test
-    fun `should set hijri date after loading prayer times`() = runTest {
-        everySuspend { addressesRepository.getActiveAddress() } returns fakeAddress
-        everySuspend { prayerTimeRepository.getPrayerTimes(any(), any()) } returns fakePrayerTimes
-
-        viewModel = PrayerTimeViewModel(
-            prayerTimeRepository,
-            locationService,
-            prayerTimeService,
-            testDispatcher
-        )
-
-        val state = viewModel.uiState.value
-        assertTrue(state.currentDate.isNotEmpty())
-    }
-
-    @Test
     fun `should call getPrayerTimes once`() = runTest {
         everySuspend { addressesRepository.getActiveAddress() } returns fakeAddress
         everySuspend { prayerTimeRepository.getPrayerTimes(any(), any()) } returns fakePrayerTimes
@@ -94,31 +78,6 @@ class PrayerTimeViewModelTest {
         )
 
         verifySuspend(mode = exactly(1)) { prayerTimeRepository.getPrayerTimes(any(), any()) }
-    }
-
-
-    @Test
-    fun `should set next prayer name when prayer times loaded`() = runTest {
-        everySuspend { addressesRepository.getActiveAddress() } returns fakeAddress
-        everySuspend { prayerTimeRepository.getPrayerTimes(any(), any()) } returns fakePrayerTimes
-
-        viewModel = PrayerTimeViewModel(
-            prayerTimeRepository,
-            locationService,
-            prayerTimeService,
-            testDispatcher
-        )
-
-        val nextName = viewModel.uiState.value.nextPrayerName
-        assertTrue(
-            nextName in listOf(
-                PrayerName.FAJR,
-                PrayerName.DHUHR,
-                PrayerName.ASR,
-                PrayerName.MAGHRIB,
-                PrayerName.ISHA
-            )
-        )
     }
 
     @Test


### PR DESCRIPTION
- A new `PrayerTimeService` is introduced to encapsulate the logic for finding the next prayer, including handling the transition to the next day's prayers.
- The `PrayerTimeViewModel` is updated to use this new service, simplifying its responsibility. It now observes a flow for the next prayer and manages the countdown timer more efficiently.
- The `nextPrayerName` in `PrayerTimeUiState` is now nullable to handle cases where no prayer time is available.
<img width="323" height="720" alt="image" src="https://github.com/user-attachments/assets/ed5fedbf-8efa-4e35-a3af-66f212df84d0" />
