### PR TITLE
Improve `ChatList` stability by using unique item keys

### DIFF
--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatList.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatList.kt
@@ -15,7 +15,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import net.thechance.mena.core_chat.presentation.screen.chat.AudioMessageUiState
 import net.thechance.mena.core_chat.presentation.screen.chat.ChatListItem
+import net.thechance.mena.core_chat.presentation.screen.chat.DateSeparator
 import net.thechance.mena.core_chat.presentation.screen.chat.ImageMessageUiState
 import net.thechance.mena.core_chat.presentation.screen.chat.ImagesGroupChatItem
 import net.thechance.mena.core_chat.presentation.screen.chat.MessageUiState
@@ -48,7 +50,15 @@ fun ChatList(
     ) {
         itemsIndexed(
             items = items,
-            key = { index,_ -> index }
+            key = { _, item ->
+                when (item) {
+                    is TextMessageUiState -> item.messageDetails.id.toString()
+                    is ImagesGroupChatItem -> item.imagesUiState.first().messageDetails.id.toString()
+                    is ImageMessageUiState -> item.messageDetails.id.toString()
+                    is AudioMessageUiState -> item.messageDetails.id.toString()
+                    is DateSeparator -> item.label.toString()
+                }
+            }
         ) { _ , item ->
             val isLastItem = items.indexOf(item) == 0
             val paddingBottom = if (isLastItem)


### PR DESCRIPTION
Use unique identifiers for items in the chat list instead of relying on their index. This prevents recomposition issues and improves performance by assigning stable keys for `TextMessageUiState`, `ImagesGroupChatItem`, `ImageMessageUiState`, `AudioMessageUiState`, and `DateSeparator`.

https://github.com/user-attachments/assets/2b17e5c5-8fc9-4708-90fd-2b7d04ab342e

