### PR TITLE
fix: update addBookmark method

### DIFF
--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/service/BookmarkApiService.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/remote/service/BookmarkApiService.kt
@@ -14,7 +14,7 @@ import net.thechance.mena.faith.data.remote.model.bookmark.AyahBookmarkDto
 interface BookmarkApiService {
 
     @POST("faith/ayah/bookmarks")
-    suspend fun addBookmark(@Body request: AddBookmarkRequest): Response<AyahBookmarkDto>
+    suspend fun addBookmark(@Body request: AddBookmarkRequest): Response<Unit>
 
     @GET("faith/ayah/bookmarks")
     suspend fun getBookmarks(

--- a/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/repository/BookmarkRepositoryImpl.kt
+++ b/faith_data/src/commonMain/kotlin/net/thechance/mena/faith/data/repository/BookmarkRepositoryImpl.kt
@@ -5,8 +5,6 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import net.thechance.mena.faith.data.database.AyahDao
 import net.thechance.mena.faith.data.mapper.ayahBookmark.toAyahBookmark
-import net.thechance.mena.faith.data.mapper.toAyah
-import net.thechance.mena.faith.data.mapper.toSurah
 import net.thechance.mena.faith.data.remote.model.PageResponse
 import net.thechance.mena.faith.data.remote.model.bookmark.AddBookmarkRequest
 import net.thechance.mena.faith.data.remote.model.bookmark.AyahBookmarkDto
@@ -17,7 +15,6 @@ import net.thechance.mena.faith.domain.entity.AyahBookmark
 import net.thechance.mena.faith.domain.repository.BookmarkRepository
 import net.thechance.mena.identity.domain.service.LocalizationService
 import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
 
 @OptIn(ExperimentalTime::class)
 class BookmarkRepositoryImpl(
@@ -26,8 +23,8 @@ class BookmarkRepositoryImpl(
     private val localizationService: LocalizationService,
 ) : BookmarkRepository {
 
-    override suspend fun addAyahBookmark(surahId: Int, ayahNumber: Int): AyahBookmark {
-        val bookmarkDto = executeApiSafely<AyahBookmarkDto> {
+    override suspend fun addAyahBookmark(surahId: Int, ayahNumber: Int) {
+        executeApiSafely<Unit> {
             bookmarkApiService.addBookmark(
                 AddBookmarkRequest(
                     surahId = surahId,
@@ -35,16 +32,6 @@ class BookmarkRepositoryImpl(
                 )
             )
         }
-
-        val surah = executeLocalSafely { ayahDao.getSurah(surahId) }
-        val ayah = executeLocalSafely { ayahDao.getAyah(ayahId = ayahNumber, surahId = surahId) }
-
-        return AyahBookmark(
-            id = bookmarkDto.id.toInt(),
-            surah = surah.toSurah(localizationService.getCurrentLanguage()),
-            ayah = ayah.toAyah(),
-            createdAt = Instant.parse(bookmarkDto.createdAt)
-        )
     }
 
     override suspend fun getAyahBookmarks(pageNumber: Int, pageSize: Int): List<AyahBookmark> {

--- a/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/BookmarkRepositoryImplTest.kt
+++ b/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/BookmarkRepositoryImplTest.kt
@@ -93,7 +93,7 @@ class BookmarkRepositoryImplTest {
             val bookmark = repository.addAyahBookmark(surahId = 1, ayahNumber = 1)
 
             // Then
-            assertThat(bookmark).isEqualTo(AYAH_BOOKMARK_ITEM)
+            assertThat(bookmark).isEqualTo(Unit)
         }
 
     @Test
@@ -238,21 +238,5 @@ class BookmarkRepositoryImplTest {
             createdAt = "2023-01-01T00:00:00Z"
         )
 
-        val AYAH_BOOKMARK_ITEM = AyahBookmark(
-            id = 1,
-            surah = Surah(
-                id = 1,
-                order = Surah.SurahOrder.AlFatihah,
-                name = "Al-Fatiha",
-                ayahCount = 2,
-            ),
-            ayah = Ayah(
-                number = 1,
-                surahId = 1,
-                content = "Ayah content",
-                plainContent = "Ayah plain content"
-            ),
-            createdAt = Instant.parse("2023-01-01T00:00:00Z")
-        )
     }
 }

--- a/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/BookmarkRepositoryImplTest.kt
+++ b/faith_data/src/commonTest/kotlin/net/thechance/mena/faith/data/repository/BookmarkRepositoryImplTest.kt
@@ -154,7 +154,7 @@ class BookmarkRepositoryImplTest {
     }
 
     @OptIn(InternalAPI::class)
-    private fun successfulAddBookmarkResponse(): Response<AyahBookmarkDto> {
+    private fun successfulAddBookmarkResponse(): Response<Unit> {
         val mockHttpResponse: HttpResponse = mock(MockMode.autofill) {
             everySuspend { status } returns HttpStatusCode.OK
         }
@@ -162,7 +162,7 @@ class BookmarkRepositoryImplTest {
         return Response.success(
             body = AYAH_BOOKMARK_ITEM_DTO,
             rawResponse = mockHttpResponse
-        ) as Response<AyahBookmarkDto>
+        ) as Response<Unit>
     }
 
     @OptIn(InternalAPI::class)

--- a/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/repository/BookmarkRepository.kt
+++ b/faith_domain/src/commonMain/kotlin/net/thechance/mena/faith/domain/repository/BookmarkRepository.kt
@@ -4,6 +4,6 @@ import net.thechance.mena.faith.domain.entity.AyahBookmark
 
 interface BookmarkRepository {
     suspend fun getAyahBookmarks(pageNumber: Int, pageSize: Int): List<AyahBookmark>
-    suspend fun addAyahBookmark(surahId: Int, ayahNumber: Int): AyahBookmark
+    suspend fun addAyahBookmark(surahId: Int, ayahNumber: Int)
     suspend fun deleteAyahBookmark(ayahBookmarkId: Int)
 }


### PR DESCRIPTION
refactors the way ayah bookmarks are added by changing the `addAyahBookmark` method to no longer return a bookmark object, both in the domain interface and repository implementation. Instead, the method now only performs the action of adding a bookmark
