### PR TITLE
Fix/IDN-199 Fix refresh token failure loop

### DIFF
--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/repository/AuthenticationRepositoryImpl.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/repository/AuthenticationRepositoryImpl.kt
@@ -15,6 +15,7 @@ import net.thechance.mena.identity.data.mapper.toDomain
 import net.thechance.mena.identity.data.utils.postJson
 import net.thechance.mena.identity.data.utils.safeWrapper
 import net.thechance.mena.identity.domain.entity.PhoneNumber
+import net.thechance.mena.identity.domain.exception.UnAuthorizedException
 import net.thechance.mena.identity.domain.model.AuthenticationTokens
 import net.thechance.mena.identity.domain.repository.AuthenticationRepository
 import kotlin.concurrent.Volatile
@@ -50,14 +51,19 @@ class AuthenticationRepositoryImpl(
     }
 
     override suspend fun refreshAccessToken(): String {
-        val response: AuthenticationResponse = safeWrapper {
-            client.postJson(
-                RefreshRequestDto(settings.refreshToken),
-                REFRESH_ENDPOINT
-            )
+        return try {
+            val response: AuthenticationResponse = safeWrapper {
+                client.postJson(
+                    RefreshRequestDto(settings.refreshToken),
+                    REFRESH_ENDPOINT
+                )
+            }
+            saveTokens(response.toDomain(), shouldEmit = !isTemporaryTokenMode)
+            settings.accessToken
+        } catch (e: UnAuthorizedException) {
+            saveTokens(createEmptyTokens(), shouldEmit = true)
+            throw e
         }
-        saveTokens(response.toDomain(), shouldEmit = !isTemporaryTokenMode)
-        return settings.accessToken
     }
 
     override suspend fun getAccessToken(): String = settings.accessToken
@@ -84,8 +90,8 @@ class AuthenticationRepositoryImpl(
     }
 
     override suspend fun clearAuthTokens() {
-        saveTokensToSettings(createEmptyTokens())
         isTemporaryTokenMode = false
+        saveTokens(createEmptyTokens(), shouldEmit = true)
     }
 
     override fun observeTokenChange(): StateFlow<String> = observableToken


### PR DESCRIPTION
### Fix refresh token failure loop

- Summary: Stop refresh retries on 401; emit blank token and navigate to login.
- Changes:
  - On refresh 401 (invalid/expired refresh token), clear tokens and emit to observers.
  - Emit blank token in `clearAuthTokens()` to trigger login routing.
- Reason: Refresh token can be invalid due to expiration, revocation, rotation, or stale persisted token.