### PR TITLE
feat: update BasmalaHeader to use theme color

### DIFF
--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/BasmalaHeader.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/BasmalaHeader.kt
@@ -6,11 +6,13 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import mena.faith_presentation.generated.resources.Res
 import mena.faith_presentation.generated.resources.bismillah
 import mena.faith_presentation.generated.resources.ic_bismillah
+import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.faith.presentation.designSystem.theme.QuranTheme
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -23,6 +25,7 @@ internal fun BasmalaHeader(
 ) {
     Image(
         painter = painterResource(Res.drawable.ic_bismillah),
+        colorFilter = ColorFilter.tint(Theme.colorScheme.primary.primary),
         contentDescription = stringResource(Res.string.bismillah),
         modifier = Modifier
             .padding(horizontal = 74.dp)


### PR DESCRIPTION
Apply a color filter to the `BasmalaHeader` image, tinting it with the primary color from the application's theme. This ensures the "Bismillah" image color is consistent with the current theme.