### PR TITLE
Fix/TRN-132 UI notes

### DIFF
--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishScreen.kt
@@ -17,9 +17,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mena.trends_presentation.generated.resources.Res
 import mena.trends_presentation.generated.resources.add_categories_to_video
-import mena.trends_presentation.generated.resources.back_arrow
 import mena.trends_presentation.generated.resources.choose_categories
-import mena.trends_presentation.generated.resources.ic_arrow_left
 import mena.trends_presentation.generated.resources.ic_hint
 import mena.trends_presentation.generated.resources.new_trend
 import mena.trends_presentation.generated.resources.publish_hint
@@ -33,6 +31,7 @@ import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.trends.presentation.navigation.LocalNavController
 import net.thechance.mena.trends.presentation.navigation.Route
+import net.thechance.mena.trends.presentation.shared.component.BackIcon
 import net.thechance.mena.trends.presentation.shared.component.CategoryItem
 import net.thechance.mena.trends.presentation.shared.component.LoadingProgressBar
 import net.thechance.mena.trends.presentation.shared.component.TrendsAnimatedVisibility
@@ -168,10 +167,7 @@ private fun CategoryPublishAppBar(
     AppBar(
         onLeadingClick = onBackClick,
         leadingContent = {
-            Icon(
-                painter = painterResource(Res.drawable.ic_arrow_left),
-                contentDescription = stringResource(Res.string.back_arrow)
-            )
+            BackIcon()
         },
         title = stringResource(Res.string.new_trend),
         trailingContent = { UploadPageNumber(page = 3) }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/category_publish/CategoryPublishScreen.kt
@@ -77,7 +77,11 @@ private fun CategoryPublishContent(
                 PrimaryButton(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = Theme.spacing._16),
+                        .padding(
+                            start = Theme.spacing._16,
+                            end = Theme.spacing._16,
+                            bottom = Theme.spacing._24
+                        ),
                     text = stringResource(resource = Res.string.upload_video),
                     onClick = listener::onClickPublish,
                     isEnabled = state.isPublishButtonEnabled,
@@ -155,7 +159,7 @@ private fun CategoryPublishScreenBody(
         }
     }
 
-   TrendsAnimatedVisibility(visible = state.isLoading) {
+    TrendsAnimatedVisibility(visible = state.isLoading) {
         LoadingProgressBar()
     }
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
@@ -1,28 +1,23 @@
 package net.thechance.mena.trends.presentation.screen.home
 
-import app.cash.paging.compose.itemKey
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
 import app.cash.paging.compose.LazyPagingItems
 import app.cash.paging.compose.collectAsLazyPagingItems
+import app.cash.paging.compose.itemKey
 import mena.trends_presentation.generated.resources.Res
 import mena.trends_presentation.generated.resources.add_reel
 import mena.trends_presentation.generated.resources.edit_tags
@@ -33,6 +28,7 @@ import mena.trends_presentation.generated.resources.manage_trends
 import mena.trends_presentation.generated.resources.trends_title
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBarOptionContainer
+import net.thechance.mena.designsystem.presentation.component.button.FabButton
 import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
@@ -46,7 +42,6 @@ import net.thechance.mena.trends.presentation.shared.base.toErrorState
 import net.thechance.mena.trends.presentation.shared.component.LoadingProgressBar
 import net.thechance.mena.trends.presentation.shared.component.NoConnection
 import net.thechance.mena.trends.presentation.shared.component.TrendsAnimatedVisibility
-import net.thechance.mena.trends.presentation.shared.component.modifier.noRippleClickable
 import net.thechance.mena.trends.presentation.shared.util.ObserveAsEffect
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -153,15 +148,11 @@ private fun AddTrendFAB(
     modifier: Modifier = Modifier,
     onClickFab: () -> Unit
 ) {
-    Icon(
+    FabButton(
         painter = painterResource(Res.drawable.ic_add_real),
         contentDescription = stringResource(Res.string.add_reel),
+        onClick = onClickFab,
         modifier = modifier
-            .padding(end = Theme.spacing._16, bottom = Theme.spacing._16)
-            .size(56.dp)
-            .clip(RoundedCornerShape(Theme.radius.md))
-            .background(Theme.colorScheme.primary.primary)
-            .noRippleClickable { onClickFab() }
             .padding(Theme.spacing._16),
     )
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/component/ReelCard.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/component/ReelCard.kt
@@ -94,7 +94,7 @@ private fun ReelHeaderSection(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = Theme.spacing._12, vertical = Theme.spacing._8),
+                .padding(horizontal = Theme.spacing._12, vertical = Theme.spacing._12),
             verticalAlignment = Alignment.CenterVertically
         ) {
             AsyncImage(

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/manage_my_trends/ManageTrendsScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/manage_my_trends/ManageTrendsScreen.kt
@@ -1,7 +1,6 @@
 package net.thechance.mena.trends.presentation.screen.manage_my_trends
 
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -32,6 +31,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -40,8 +42,7 @@ import androidx.paging.LoadState
 import app.cash.paging.compose.LazyPagingItems
 import app.cash.paging.compose.collectAsLazyPagingItems
 import app.cash.paging.compose.itemKey
-import coil3.compose.AsyncImagePainter
-import coil3.compose.rememberAsyncImagePainter
+import coil3.compose.AsyncImage
 import mena.trends_presentation.generated.resources.Res
 import mena.trends_presentation.generated.resources.back_arrow
 import mena.trends_presentation.generated.resources.favorite
@@ -269,23 +270,29 @@ private fun ManageMyTrendsAppBar(onBackClick: () -> Unit) {
 
 @Composable
 private fun UserAvatar(profileImageUrl: String, modifier: Modifier = Modifier) {
-    val painter = rememberAsyncImagePainter(profileImageUrl)
+    val errorPainter = painterResource(Res.drawable.ic_placeholder_profile)
+    val tintColor = Theme.colorScheme.shadePrimary
+    val tintedErrorPainter = remember(errorPainter) {
+        object : Painter() {
+            override val intrinsicSize = errorPainter.intrinsicSize
 
-    if (painter.state.value is AsyncImagePainter.State.Success) {
-        Image(
-            painter = painter,
-            contentDescription = stringResource(Res.string.profile_image_desc),
-            modifier = modifier.size(100.dp).clip(CircleShape),
-            contentScale = ContentScale.Crop
-        )
-    } else {
-        Icon(
-            painter = painterResource(Res.drawable.ic_placeholder_profile),
-            contentDescription = stringResource(Res.string.profile_image_desc),
-            modifier = modifier.size(100.dp).clip(CircleShape),
-            tint = Theme.colorScheme.shadePrimary,
-        )
+            override fun DrawScope.onDraw() {
+                with(errorPainter) {
+                    draw(
+                        size = size,
+                        colorFilter = ColorFilter.tint(tintColor)
+                    )
+                }
+            }
+        }
     }
+    AsyncImage(
+        model = profileImageUrl,
+        contentDescription = stringResource(Res.string.profile_image_desc),
+        error = tintedErrorPainter,
+        modifier = modifier.size(100.dp).clip(CircleShape),
+        contentScale = ContentScale.Crop
+    )
 }
 
 @Composable

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/manage_my_trends/ManageTrendsScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/manage_my_trends/ManageTrendsScreen.kt
@@ -1,6 +1,7 @@
 package net.thechance.mena.trends.presentation.screen.manage_my_trends
 
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -39,7 +40,8 @@ import androidx.paging.LoadState
 import app.cash.paging.compose.LazyPagingItems
 import app.cash.paging.compose.collectAsLazyPagingItems
 import app.cash.paging.compose.itemKey
-import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+import coil3.compose.rememberAsyncImagePainter
 import mena.trends_presentation.generated.resources.Res
 import mena.trends_presentation.generated.resources.back_arrow
 import mena.trends_presentation.generated.resources.favorite
@@ -258,7 +260,8 @@ private fun ManageMyTrendsAppBar(onBackClick: () -> Unit) {
         leadingContent = {
             Icon(
                 painter = painterResource(Res.drawable.ic_arrow_left),
-                contentDescription = stringResource(Res.string.back_arrow)
+                contentDescription = stringResource(Res.string.back_arrow),
+                tint = Color.White
             )
         }
     )
@@ -266,13 +269,23 @@ private fun ManageMyTrendsAppBar(onBackClick: () -> Unit) {
 
 @Composable
 private fun UserAvatar(profileImageUrl: String, modifier: Modifier = Modifier) {
-    AsyncImage(
-        model = profileImageUrl,
-        contentDescription = stringResource(Res.string.profile_image_desc),
-        error = painterResource(Res.drawable.ic_placeholder_profile),
-        modifier = modifier.size(100.dp).clip(CircleShape),
-        contentScale = ContentScale.Crop
-    )
+    val painter = rememberAsyncImagePainter(profileImageUrl)
+
+    if (painter.state.value is AsyncImagePainter.State.Success) {
+        Image(
+            painter = painter,
+            contentDescription = stringResource(Res.string.profile_image_desc),
+            modifier = modifier.size(100.dp).clip(CircleShape),
+            contentScale = ContentScale.Crop
+        )
+    } else {
+        Icon(
+            painter = painterResource(Res.drawable.ic_placeholder_profile),
+            contentDescription = stringResource(Res.string.profile_image_desc),
+            modifier = modifier.size(100.dp).clip(CircleShape),
+            tint = Theme.colorScheme.shadePrimary,
+        )
+    }
 }
 
 @Composable

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/manage_my_trends/ManageTrendsScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/manage_my_trends/ManageTrendsScreen.kt
@@ -44,9 +44,7 @@ import app.cash.paging.compose.collectAsLazyPagingItems
 import app.cash.paging.compose.itemKey
 import coil3.compose.AsyncImage
 import mena.trends_presentation.generated.resources.Res
-import mena.trends_presentation.generated.resources.back_arrow
 import mena.trends_presentation.generated.resources.favorite
-import mena.trends_presentation.generated.resources.ic_arrow_left
 import mena.trends_presentation.generated.resources.ic_empty_trends
 import mena.trends_presentation.generated.resources.ic_paly_now
 import mena.trends_presentation.generated.resources.ic_placeholder_profile
@@ -67,6 +65,7 @@ import net.thechance.mena.trends.presentation.navigation.Route
 import net.thechance.mena.trends.presentation.screen.home.component.EmptyTrends
 import net.thechance.mena.trends.presentation.shared.base.ErrorState
 import net.thechance.mena.trends.presentation.shared.base.toErrorState
+import net.thechance.mena.trends.presentation.shared.component.BackIcon
 import net.thechance.mena.trends.presentation.shared.component.BaseAsyncImage
 import net.thechance.mena.trends.presentation.shared.component.LoadingProgressBar
 import net.thechance.mena.trends.presentation.shared.component.NoConnection
@@ -259,11 +258,7 @@ private fun ManageMyTrendsAppBar(onBackClick: () -> Unit) {
         onLeadingClick = onBackClick,
         title = stringResource(Res.string.manage_trends_title),
         leadingContent = {
-            Icon(
-                painter = painterResource(Res.drawable.ic_arrow_left),
-                contentDescription = stringResource(Res.string.back_arrow),
-                tint = Color.White
-            )
+            BackIcon()
         }
     )
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/manage_my_trends/ManageTrendsScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/manage_my_trends/ManageTrendsScreen.kt
@@ -179,6 +179,7 @@ private fun ManageTrendsScreenBody(
             Text(
                 text = state.profile.userName,
                 style = Theme.typography.label.medium,
+                color = Theme.colorScheme.shadePrimary,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(bottom = Theme.spacing._32)

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/update_categories/UpdateCategoriesScreen.kt
@@ -14,17 +14,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mena.trends_presentation.generated.resources.Res
-import mena.trends_presentation.generated.resources.back_arrow
 import mena.trends_presentation.generated.resources.change_tags
 import mena.trends_presentation.generated.resources.choose_interests
 import mena.trends_presentation.generated.resources.help_text
-import mena.trends_presentation.generated.resources.ic_arrow_left
 import mena.trends_presentation.generated.resources.save_change
 import mena.trends_presentation.generated.resources.tags_updated_failure
 import mena.trends_presentation.generated.resources.tags_updated_success
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
 import net.thechance.mena.designsystem.presentation.component.button.PrimaryButton
-import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
@@ -32,6 +29,7 @@ import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.trends.presentation.navigation.LocalNavController
 import net.thechance.mena.trends.presentation.navigation.Route
 import net.thechance.mena.trends.presentation.shared.base.ErrorState
+import net.thechance.mena.trends.presentation.shared.component.BackIcon
 import net.thechance.mena.trends.presentation.shared.component.CategoryItem
 import net.thechance.mena.trends.presentation.shared.component.LoadingProgressBar
 import net.thechance.mena.trends.presentation.shared.component.NoConnection
@@ -41,7 +39,6 @@ import net.thechance.mena.trends.presentation.shared.util.ObserveAsEffect
 import net.thechance.mena.trends.presentation.snackbar.LocalSnackbarController
 import net.thechance.mena.trends.presentation.snackbar.SnackBarData
 import org.jetbrains.compose.resources.getString
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
@@ -185,10 +182,7 @@ private fun ChangeTagsAppBar(onBackClick: () -> Unit) {
     AppBar(
         onLeadingClick = onBackClick,
         leadingContent = {
-            Icon(
-                painter = painterResource(Res.drawable.ic_arrow_left),
-                contentDescription = stringResource(Res.string.back_arrow)
-            )
+            BackIcon()
         },
         title = stringResource(Res.string.change_tags),
     )

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/upload_reel/UploadReelScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/upload_reel/UploadReelScreen.kt
@@ -20,19 +20,17 @@ import io.github.vinceglb.filekit.size
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import mena.trends_presentation.generated.resources.Res
-import mena.trends_presentation.generated.resources.back_arrow
-import mena.trends_presentation.generated.resources.ic_arrow_left
 import mena.trends_presentation.generated.resources.new_trend
 import mena.trends_presentation.generated.resources.upload_video
 import mena.trends_presentation.generated.resources.upload_video_description
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
-import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.trends.presentation.navigation.LocalNavController
 import net.thechance.mena.trends.presentation.navigation.Route
 import net.thechance.mena.trends.presentation.shared.base.toStringResource
+import net.thechance.mena.trends.presentation.shared.component.BackIcon
 import net.thechance.mena.trends.presentation.shared.component.NextButton
 import net.thechance.mena.trends.presentation.shared.component.TrendsAnimatedVisibility
 import net.thechance.mena.trends.presentation.shared.component.UploadPageNumber
@@ -46,7 +44,6 @@ import net.thechance.mena.trends.presentation.shared.util.isIdle
 import net.thechance.mena.trends.presentation.snackbar.LocalSnackbarController
 import net.thechance.mena.trends.presentation.snackbar.SnackBarData
 import org.jetbrains.compose.resources.getString
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -176,10 +173,7 @@ private fun UploadReelScreenTopBar(
     AppBar(
         onLeadingClick = onBackClick,
         leadingContent = {
-            Icon(
-                painter = painterResource(Res.drawable.ic_arrow_left),
-                contentDescription = stringResource(Res.string.back_arrow)
-            )
+            BackIcon()
         },
         title = stringResource(Res.string.new_trend),
         trailingContent = { UploadPageNumber(page = 1) }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
@@ -48,13 +48,11 @@ import coil3.compose.rememberAsyncImagePainter
 import kotlinx.coroutines.launch
 import mena.trends_presentation.generated.resources.Res
 import mena.trends_presentation.generated.resources.avatar_image
-import mena.trends_presentation.generated.resources.back_arrow
 import mena.trends_presentation.generated.resources.confirmation_message
 import mena.trends_presentation.generated.resources.delete
 import mena.trends_presentation.generated.resources.delete_reel
 import mena.trends_presentation.generated.resources.fail_delete_message
 import mena.trends_presentation.generated.resources.fail_delete_title
-import mena.trends_presentation.generated.resources.ic_arrow_left
 import mena.trends_presentation.generated.resources.ic_delete
 import mena.trends_presentation.generated.resources.ic_eye
 import mena.trends_presentation.generated.resources.ic_like
@@ -71,6 +69,7 @@ import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.trends.presentation.navigation.LocalNavController
 import net.thechance.mena.trends.presentation.navigation.Route
 import net.thechance.mena.trends.presentation.shared.base.ErrorState
+import net.thechance.mena.trends.presentation.shared.component.BackIcon
 import net.thechance.mena.trends.presentation.shared.component.NoConnection
 import net.thechance.mena.trends.presentation.shared.component.TrendsAnimatedVisibility
 import net.thechance.mena.trends.presentation.shared.component.modifier.noRippleClickable
@@ -245,10 +244,7 @@ private fun TopAppBar(
             .padding(top = Theme.spacing._8),
         contentPadding = PaddingValues(0.dp),
         leadingContent = {
-            Icon(
-                painter = painterResource(resource = Res.drawable.ic_arrow_left),
-                contentDescription = stringResource(resource = Res.string.back_arrow),
-            )
+            BackIcon()
         },
         onLeadingClick = { onBackClick() }
     )

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserReelScreen.kt
@@ -266,7 +266,7 @@ private fun ReelContent(
 ) {
     val rememberedUrl = remember(reel.id) { reel.videoUrl }
     VideoPlayer(
-        modifier = Modifier.background(Theme.colorScheme.primary.primary),
+        modifier = Modifier.background(Color.Black),
         url = rememberedUrl,
         isReelVisible = shouldRender,
         onVideoPlaying = incrementViewsCount,
@@ -347,7 +347,7 @@ private fun PublisherInfo(
             Column(Modifier.padding(bottom = Theme.spacing._16)) {
                 Text(
                     text = userName,
-                    color = Theme.colorScheme.primary.onPrimary,
+                    color = Color.White,
                     style = Theme.typography.label.medium,
                     modifier = Modifier.padding(vertical = Theme.spacing._2)
                         .clickable { onPublisherInfoClick() },
@@ -367,7 +367,7 @@ private fun PublisherInfo(
                 modifier = Modifier
                     .animateContentSize()
                     .clickable { onDescriptionClick(isDescriptionExpanded) },
-                color = Theme.colorScheme.primary.onPrimary,
+                color = Color.White,
                 style = Theme.typography.label.medium,
                 maxLines = if (isDescriptionExpanded) Int.MAX_VALUE else 1
             )

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/video_description/VideoDescriptionScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/video_description/VideoDescriptionScreen.kt
@@ -24,14 +24,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mena.trends_presentation.generated.resources.Res
 import mena.trends_presentation.generated.resources.add_video_description_subtitle
 import mena.trends_presentation.generated.resources.add_video_description_title
-import mena.trends_presentation.generated.resources.back_arrow
 import mena.trends_presentation.generated.resources.characters
 import mena.trends_presentation.generated.resources.characters_color_animation_label
 import mena.trends_presentation.generated.resources.hint
-import mena.trends_presentation.generated.resources.ic_arrow_left
 import mena.trends_presentation.generated.resources.new_trend
 import net.thechance.mena.designsystem.presentation.component.appBar.AppBar
-import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.component.textField.MultiLineTextField
@@ -39,10 +36,10 @@ import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.trends.presentation.navigation.LocalNavController
 import net.thechance.mena.trends.presentation.navigation.Route
+import net.thechance.mena.trends.presentation.shared.component.BackIcon
 import net.thechance.mena.trends.presentation.shared.component.NextButton
 import net.thechance.mena.trends.presentation.shared.component.UploadPageNumber
 import net.thechance.mena.trends.presentation.shared.util.ObserveAsEffect
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
@@ -136,10 +133,7 @@ private fun DescriptionAppBar(onBackClick: () -> Unit) {
     AppBar(
         title = stringResource(Res.string.new_trend),
         leadingContent = {
-            Icon(
-                painter = painterResource(Res.drawable.ic_arrow_left),
-                contentDescription = stringResource(Res.string.back_arrow)
-            )
+            BackIcon()
         },
         trailingContent = { UploadPageNumber(page = 2) },
         onLeadingClick = onBackClick

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/component/BackIcon.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/component/BackIcon.kt
@@ -1,0 +1,23 @@
+package net.thechance.mena.trends.presentation.shared.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import mena.trends_presentation.generated.resources.Res
+import mena.trends_presentation.generated.resources.back_arrow
+import mena.trends_presentation.generated.resources.ic_arrow_left
+import net.thechance.mena.designsystem.presentation.component.icon.Icon
+import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun BackIcon(
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        painter = painterResource(Res.drawable.ic_arrow_left),
+        contentDescription = stringResource(Res.string.back_arrow),
+        tint = Theme.colorScheme.shadePrimary,
+        modifier = modifier
+    )
+}

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/component/EditButton.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/component/EditButton.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import mena.trends_presentation.generated.resources.Res
 import mena.trends_presentation.generated.resources.edit_button_description
@@ -48,7 +47,7 @@ internal fun EditButton(
             painter = painterResource(resource = Res.drawable.ic_edit),
             contentDescription = stringResource(resource = Res.string.edit_button_description),
             modifier = Modifier.size(size = 20.dp),
-            tint = Color.Unspecified
+            tint = Theme.colorScheme.primary.onPrimary,
         )
     }
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/component/VideoLoadingCardItem.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/component/VideoLoadingCardItem.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -56,6 +57,7 @@ fun VideoLoadingCardItem(
     modifier: Modifier = Modifier,
     onAction: (VideoAction) -> Unit
 ) {
+    val iconColor = remember { Color(0xFF141B34) }
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -79,7 +81,7 @@ fun VideoLoadingCardItem(
                 .padding(Theme.spacing._8),
             painter = painterResource(Res.drawable.ic_video),
             contentDescription = stringResource(Res.string.thumbnail),
-            tint = Color(0xFF141B34)
+            tint = iconColor
         )
 
         Column(

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/component/VideoLoadingCardItem.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/component/VideoLoadingCardItem.kt
@@ -8,11 +8,11 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -20,7 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import mena.trends_presentation.generated.resources.Res
 import mena.trends_presentation.generated.resources.error
@@ -59,6 +59,7 @@ fun VideoLoadingCardItem(
     Row(
         modifier = modifier
             .fillMaxWidth()
+            .height(IntrinsicSize.Max)
             .clip(RoundedCornerShape(Theme.radius.md))
             .background(Theme.colorScheme.primary.onPrimary)
             .padding(
@@ -67,7 +68,8 @@ fun VideoLoadingCardItem(
                 end = Theme.spacing._12,
                 bottom = 14.dp
             ),
-        horizontalArrangement = Arrangement.SpaceBetween
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
             modifier = Modifier
@@ -77,28 +79,27 @@ fun VideoLoadingCardItem(
                 .padding(Theme.spacing._8),
             painter = painterResource(Res.drawable.ic_video),
             contentDescription = stringResource(Res.string.thumbnail),
-            tint = Theme.colorScheme.brand.brand
+            tint = Color(0xFF141B34)
         )
 
-        Column(Modifier.padding(start = Theme.spacing._8)) {
-            Row(Modifier.heightIn(min = 40.dp)) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .height(IntrinsicSize.Max)
+                .padding(start = Theme.spacing._8),
+            verticalArrangement = Arrangement.spacedBy(Theme.spacing._4)
+        ) {
             VideoInfoSection(
-                    modifier = Modifier
-                        .fillMaxHeight()
-                        .weight(1f)
-                        .padding(end = Theme.spacing._16),
-                    title = title,
-                    sizeUploaded = sizeUploaded,
-                    videoSize = videoSize,
-                    uploadingState = uploadingState
-                )
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .weight(1f)
+                    .padding(end = Theme.spacing._16),
+                title = title,
+                sizeUploaded = sizeUploaded,
+                videoSize = videoSize,
+                uploadingState = uploadingState
+            )
 
-                VideoActionsSection(
-                    modifier = Modifier.fillMaxHeight(),
-                    uploadingState = uploadingState,
-                    onAction = onAction
-                )
-            }
             AnimatedVisibility(
                 visible = uploadingState.isUploading,
                 enter = fadeIn(),
@@ -113,6 +114,12 @@ fun VideoLoadingCardItem(
                 )
             }
         }
+
+        VideoActionsSection(
+            modifier = Modifier.fillMaxHeight(),
+            uploadingState = uploadingState,
+            onAction = onAction
+        )
     }
 }
 
@@ -126,7 +133,7 @@ private fun VideoInfoSection(
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.SpaceBetween
+        verticalArrangement = Arrangement.spacedBy(Theme.spacing._4)
     ) {
         Text(
             text = title,
@@ -166,7 +173,7 @@ private fun VideoActionsSection(
     onAction: (VideoAction) -> Unit
 ) {
     Box(modifier = modifier) {
-        AnimatedVisibility (
+        AnimatedVisibility(
             visible = uploadingState.isUploading,
             enter = fadeIn(),
             exit = fadeOut()
@@ -186,7 +193,7 @@ private fun VideoActionsSection(
             modifier = Modifier.align(Alignment.CenterEnd),
             horizontalArrangement = Arrangement.spacedBy(Theme.spacing._16),
         ) {
-            AnimatedVisibility (
+            AnimatedVisibility(
                 visible = uploadingState.isFailed || uploadingState.isSuccess,
                 enter = fadeIn(),
                 exit = fadeOut()
@@ -200,7 +207,7 @@ private fun VideoActionsSection(
                     tint = Theme.colorScheme.shadeSecondary
                 )
             }
-            AnimatedVisibility (
+            AnimatedVisibility(
                 visible = uploadingState.isFailed,
                 enter = fadeIn(),
                 exit = fadeOut()

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/component/VideoLoadingCardItem.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/component/VideoLoadingCardItem.kt
@@ -85,7 +85,6 @@ fun VideoLoadingCardItem(
         Column(
             modifier = Modifier
                 .weight(1f)
-                .height(IntrinsicSize.Max)
                 .padding(start = Theme.spacing._8),
             verticalArrangement = Arrangement.spacedBy(Theme.spacing._4)
         ) {
@@ -133,7 +132,7 @@ private fun VideoInfoSection(
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(Theme.spacing._4)
+        verticalArrangement = Arrangement.spacedBy(Theme.spacing._8)
     ) {
         Text(
             text = title,


### PR DESCRIPTION
## This PR solves the following ui issues

- username color in manage my trends
- place holder avatar in manage my trends in dark mode
- back button in dark mode (also made a shared composable for back icon)
- fab design in home screen (used design system fab)
- profile picture in home screen card (padding -> 12 vertically)
- icon edit in upload video screen tint
- delete icon in upload screen not centered
- upload amount padding in upload screen
- bottom padding in publish category screen
- background color in user reel screen when open a video