### PR TITLE
refactor: Pass ayah content directly to onShareClick

### DIFF
--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahInteractionListener.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahInteractionListener.kt
@@ -10,7 +10,7 @@ interface SurahInteractionListener {
     fun onClosePlayerClick()
     fun onPreviousAyahClick()
     fun onDismissActionButtons()
-    fun onShareClick()
+    fun onShareClick(content: String)
     fun onBookmarkClick(ayahNumber: Int)
     fun onAyahLongPress(ayahContent: String, ayahIndex: Int)
     fun onSearchClick()

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreen.kt
@@ -52,6 +52,7 @@ fun SurahScreen(
                     ),
                 )
             }
+
             is SurahScreenEffect.NavigateToSearchScreen -> {
                 navController.navigate(
                     SearchRoute(effect.surahId)
@@ -191,7 +192,7 @@ private fun Preview() {
                     listener = object : SurahInteractionListener {
                         override fun onBackClick() {}
                         override fun onDismissActionButtons() {}
-                        override fun onShareClick() {}
+                        override fun onShareClick(content: String) {}
                         override fun onBookmarkClick(ayahNumber: Int) {}
                         override fun onAyahLongPress(ayahContent: String, ayahIndex: Int) {}
                         override fun onSearchClick() {}

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
@@ -204,21 +204,20 @@ class SurahViewModel(
         }
     }
 
-    override fun onShareClick() {
+    override fun onShareClick(content: String) {
         val surahId: Int = uiState.value.surahId
         val ayahNumber: Int = uiState.value.selectedAyahNumber ?: 1
-        val ayahContent: String = uiState.value.selectedAyah
         updateState {
             it.copy(
                 isAyahActionButtonsVisible = false,
-                selectedAyah = ayahContent,
+                selectedAyah = content,
                 selectedAyahNumber = null
             )
         }
         sendEffect(SurahScreenEffect.ShareAyah(
             surahId = surahId.toString(),
             ayahNumber = ayahNumber,
-            ayahContent = ayahContent,
+            ayahContent = content,
         ))
     }
 

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AnimatedQuranPlayer.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AnimatedQuranPlayer.kt
@@ -60,7 +60,7 @@ private fun Preview(){
                     override fun onReciterClick(surahId: Int) {}
                     override fun onPreviousAyahClick() {}
                     override fun onDismissActionButtons() {}
-                    override fun onShareClick() {}
+                    override fun onShareClick(content: String) {}
                     override fun onBookmarkClick(ayahNumber: Int) {}
                     override fun onAyahLongPress(
                         ayahContent: String,

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AyahActionButtons.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AyahActionButtons.kt
@@ -67,7 +67,7 @@ internal fun AnimatedAyahActionButtons(
             AyahActionButtons(
                 onBookmarkClick = { listener.onBookmarkClick(selectedAyah?.number ?: 0) },
                 onCopyClick = { listener.onCopyClick(ayahContent = state.selectedAyah) },
-                onShareClick = { listener.onShareClick() },
+                onShareClick = { listener.onShareClick(selectedAyah?.content ?: "") },
                 onListenClick = { listener.onListenClick() }
             )
         }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AyatOfSurah.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/AyatOfSurah.kt
@@ -177,7 +177,7 @@ private fun Preview() {
                     override fun onDismissActionButtons() {}
                     override fun onBookmarkClick(ayahNumber: Int) {}
                     override fun onCopyClick(ayahContent: String) {}
-                    override fun onShareClick() {}
+                    override fun onShareClick(content: String) {}
                     override fun highlightAyah(ayahNumber: Int) {}
                     override fun updateContinueTilawah(ayahNumber: Int) {}
                     override fun playSurah(surahNumber: Int) {}

--- a/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModelTest.kt
+++ b/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModelTest.kt
@@ -347,7 +347,7 @@ class SurahViewModelTest {
         everySuspend { quranRepository.getAyatOfSurah(DEFAULT_SURAH_ID) } returns dummyAyat
         testViewModel.onAyahLongPress(TEST_AYAH_CONTENT, TEST_AYAH_INDEX)
 
-        testViewModel.onShareClick()
+        testViewModel.onShareClick(testViewModel.uiState.value.selectedAyah)
         advanceUntilIdle()
 
         assertFalse(testViewModel.uiState.value.isAyahActionButtonsVisible)
@@ -355,7 +355,7 @@ class SurahViewModelTest {
 
     @Test
     fun `onShareClick should update selectedAyah with ayah content when called`() = runTest {
-        testViewModel.onShareClick()
+        testViewModel.onShareClick(testViewModel.uiState.value.selectedAyah)
         assertEquals("", testViewModel.uiState.value.selectedAyah)
     }
 
@@ -365,7 +365,7 @@ class SurahViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         testViewModel.uiEffect.test {
-            testViewModel.onShareClick()
+            testViewModel.onShareClick(testViewModel.uiState.value.selectedAyah)
 
             assertEquals(
                 SurahScreenEffect.ShareAyah(


### PR DESCRIPTION

This refactors the `onShareClick` function to accept the ayah content as a `String` parameter. This removes the need to fetch the content from the `UiState`, simplifying the logic in the ViewModel and ensuring the correct content is shared.

The change is propagated through the `SurahInteractionListener`, composables (`AyahActionButtons`, `AnimatedQuranPlayer`), and the `SurahViewModel` and its corresponding tests.