### PR TITLE
refactor: Move AppBar to Scaffold in ProfileScreen to make it sticky

### DIFF
--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/profile/ProfileScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/profile/ProfileScreen.kt
@@ -114,6 +114,12 @@ class ProfileScreen : BaseScreen<
                     snackBarState = state.snackBarUiState,
                     onDismiss = listener::onDismissSnackBar,
                 )
+            },
+            topBar = {
+                AppBar(
+                    title = stringResource(Res.string.profile_title),
+                    trailingContent = { ShareIcon(onClick = listener::onShareClicked) }
+                )
             }
         )
         {
@@ -128,13 +134,6 @@ class ProfileScreen : BaseScreen<
                     contentPadding = PaddingValues(horizontal = Theme.spacing._16),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    item {
-                        AppBar(
-                            contentPadding = PaddingValues(horizontal = 0.dp, vertical = 14.dp),
-                            title = stringResource(Res.string.profile_title),
-                            trailingContent = { ShareIcon(onClick = listener::onShareClicked) }
-                        )
-                    }
                     item {
                         AnimatedVisibility(
                             visible = state.isSuccess,


### PR DESCRIPTION
this pr set top bar in profile screen to be sticky be moving it to the scaffold topBar parameter 