### PR TITLE
fix: improve map navigation on android and ios

### DIFF
--- a/faith_presentation/src/androidMain/kotlin/net/thechance/mena/faith/presentation/utils/MapNavigator.android.kt
+++ b/faith_presentation/src/androidMain/kotlin/net/thechance/mena/faith/presentation/utils/MapNavigator.android.kt
@@ -12,18 +12,23 @@ internal actual class MapNavigatorImpl(
         val lat = coordinate.latitude
         val lon = coordinate.longitude
 
-        val gmmIntentUri = "geo:$lat,$lon?q=$lat,$lon(Mosque)".toUri()
-        val mapIntent = Intent(Intent.ACTION_VIEW, gmmIntentUri).apply {
-            setPackage("com.google.android.apps.maps")
-        }
+        val geoIntent = Intent(
+            Intent.ACTION_VIEW,
+            "geo:$lat,$lon?q=$lat,$lon(Mosque)".toUri()
+        )
 
-        if (mapIntent.resolveActivity(context.packageManager) != null) {
-            context.startActivity(mapIntent)
+        if (geoIntent.resolveActivity(context.packageManager) != null) {
+            val chooserIntent = Intent.createChooser(geoIntent, null).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(chooserIntent)
         } else {
             val browserIntent = Intent(
                 Intent.ACTION_VIEW,
                 "https://www.google.com/maps/search/?api=1&query=$lat,$lon".toUri()
-            )
+            ).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
             context.startActivity(browserIntent)
         }
     }

--- a/faith_presentation/src/androidMain/kotlin/net/thechance/mena/faith/presentation/utils/MapNavigator.android.kt
+++ b/faith_presentation/src/androidMain/kotlin/net/thechance/mena/faith/presentation/utils/MapNavigator.android.kt
@@ -8,7 +8,7 @@ import net.thechance.mena.faith.presentation.feature.mosque.Coordinate
 internal actual class MapNavigatorImpl(
     private val context: Context
 ) : MapNavigator {
-    actual override fun openMapAtCoordinate(coordinate: Coordinate)  {
+    actual override fun openMapAtCoordinate(coordinate: Coordinate) {
         val lat = coordinate.latitude
         val lon = coordinate.longitude
 

--- a/faith_presentation/src/iosMain/kotlin/net/thechance/mena/faith/presentation/utils/MapNavigator.ios.kt
+++ b/faith_presentation/src/iosMain/kotlin/net/thechance/mena/faith/presentation/utils/MapNavigator.ios.kt
@@ -8,6 +8,10 @@ internal actual class MapNavigatorImpl : MapNavigator {
     actual override fun openMapAtCoordinate(coordinate: Coordinate) {
         val url =
             NSURL(string = "http://maps.apple.com/?ll=${coordinate.latitude},${coordinate.longitude}")
-        UIApplication.sharedApplication.openURL(url)
+        UIApplication.sharedApplication().openURL(
+            url,
+            options = emptyMap<Any?, Any?>(),
+            completionHandler = null
+        )
     }
 }

--- a/faith_presentation/src/iosMain/kotlin/net/thechance/mena/faith/presentation/utils/MapNavigator.ios.kt
+++ b/faith_presentation/src/iosMain/kotlin/net/thechance/mena/faith/presentation/utils/MapNavigator.ios.kt
@@ -6,7 +6,8 @@ import platform.UIKit.UIApplication
 
 internal actual class MapNavigatorImpl : MapNavigator {
     actual override fun openMapAtCoordinate(coordinate: Coordinate) {
-        val url = NSURL(string = "http://maps.apple.com/?ll=${coordinate.latitude},${coordinate.longitude}")
+        val url =
+            NSURL(string = "http://maps.apple.com/?ll=${coordinate.latitude},${coordinate.longitude}")
         UIApplication.sharedApplication.openURL(url)
     }
 }

--- a/faith_presentation/src/iosMain/kotlin/net/thechance/mena/faith/presentation/utils/MapNavigator.ios.kt
+++ b/faith_presentation/src/iosMain/kotlin/net/thechance/mena/faith/presentation/utils/MapNavigator.ios.kt
@@ -7,8 +7,6 @@ import platform.UIKit.UIApplication
 internal actual class MapNavigatorImpl : MapNavigator {
     actual override fun openMapAtCoordinate(coordinate: Coordinate) {
         val url = NSURL(string = "http://maps.apple.com/?ll=${coordinate.latitude},${coordinate.longitude}")
-        if (url != null) {
-            UIApplication.sharedApplication.openURL(url)
-        }
+        UIApplication.sharedApplication.openURL(url)
     }
 }


### PR DESCRIPTION
On Android, use a chooser Intent to allow the user to select their preferred maps app instead of defaulting to Google Maps.

On iOS, simplify the `openURL` call by removing a redundant null check.


https://github.com/user-attachments/assets/6cf5bb8f-b14b-4dea-99f5-3d4d7fa1c1ff

