### PR TITLE
Fix/dkn 214 upload image background and border of edit icon

### DIFF
--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/cropImage/components/CropImageBottomContainer.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/cropImage/components/CropImageBottomContainer.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.attafitamim.krop.core.images.ImageSrc
 import mena.dukan_presentation.generated.resources.Res
 import mena.dukan_presentation.generated.resources.save
@@ -19,14 +20,12 @@ fun CropImageBottomContainer(
     PrimaryButton(
         text = stringResource(Res.string.save),
         modifier = Modifier.fillMaxWidth()
-            .padding(horizontal = Theme.spacing._16,),
+            .padding(horizontal = Theme.spacing._16),
         onClick = onSaveClicked,
     )
     UploadAnotherImageButton(
         onClick = onUploadAnotherImageClicked,
-        modifier = Modifier.padding(top = Theme.spacing._12)
-            .padding(
-                horizontal = Theme.spacing._16,
-            ),
+        modifier = Modifier.padding(top = Theme.spacing._8, bottom = 18.dp)
+            .padding(horizontal = Theme.spacing._16)
     )
 }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/cropImage/components/UploadImageBox.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/cropImage/components/UploadImageBox.kt
@@ -1,4 +1,5 @@
 @file:OptIn(ExperimentalTime::class)
+
 package net.thechance.mena.dukan.presentation.screen.cropImage.components
 
 import androidx.compose.foundation.Image
@@ -13,7 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -22,16 +23,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.geometry.CornerRadius
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathEffect
-import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.attafitamim.krop.core.images.ImageSrc
 import com.attafitamim.krop.filekit.toImageSrc
@@ -48,6 +44,7 @@ import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.identity.domain.util.AppTheme
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -87,7 +84,7 @@ fun UploadImageContainer(
         {
             if (isFilePickerLaunching.value.not()) {
                 val now = Clock.System.now().toEpochMilliseconds()
-                if (now - lastLaunchTimeMillis.value > debounceTimeMillis ) {
+                if (now - lastLaunchTimeMillis.value > debounceTimeMillis) {
                     lastLaunchTimeMillis.value = now
                     isFilePickerLaunching.value = true
                     filePickerLauncher.launch()
@@ -107,6 +104,7 @@ fun UploadImageContainer(
                 .aspectRatio(16f / 9f)
                 .align(Alignment.TopCenter)
                 .clip(SquircleShape(radius))
+                .background(Theme.colorScheme.primary.onPrimary)
                 .drawWithContent {
                     drawContent()
                     drawSquircle(
@@ -123,7 +121,11 @@ fun UploadImageContainer(
                         )
                     )
                 }
-                .clickable { safeLaunch() },
+                .clickable(
+                    onClick = { safeLaunch() },
+                    indication = null,
+                    interactionSource = null
+                ),
             contentAlignment = Alignment.Center
         ) {
 
@@ -154,12 +156,12 @@ fun UploadImageContainer(
                     .size(40.dp)
                     .align(Alignment.BottomCenter)
                     .offset(y = 20.dp)
-                    .clip(shape = CircleShape)
+                    .clip(RoundedCornerShape(radius))
                     .background(Theme.colorScheme.primary.primary)
                     .border(
                         width = 1.dp,
                         color = Theme.colorScheme.background.surface,
-                        shape = SquircleShape(radius)
+                        shape = RoundedCornerShape(radius)
                     )
                     .clickable { safeLaunch() },
                 contentAlignment = Alignment.Center
@@ -178,7 +180,7 @@ fun UploadImageContainer(
 @Preview
 @Composable
 private fun UploadImageContainerPreview() {
-    MenaTheme {
+    MenaTheme(appTheme = AppTheme.DARK.name) {
         UploadImageContainer(onClick = {}, null)
     }
 }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/cropImage/components/UploadImageBox.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/cropImage/components/UploadImageBox.kt
@@ -144,7 +144,8 @@ fun UploadImageContainer(
                     Text(
                         text = stringResource(Res.string.click_to_upload),
                         color = Theme.colorScheme.primary.primary,
-                        style = Theme.typography.label.medium
+                        style = Theme.typography.label.medium,
+                        modifier = Modifier.padding(start = 18.dp)
                     )
                 }
             }

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/cropImage/components/UploadImageBox.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/cropImage/components/UploadImageBox.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/cropImage/components/ZoomControlsComponent.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/cropImage/components/ZoomControlsComponent.kt
@@ -71,7 +71,7 @@ fun ZoomControls(
         )
 
         Box(
-            modifier = modifier
+            modifier = Modifier
                 .width(1.dp)
                 .height(20.dp)
                 .background(Theme.colorScheme.stroke)


### PR DESCRIPTION
- Fix ui bugs of upload image in create dukan
## Before 
- ![WhatsApp Image 2025-11-20 at 01 18 57_0da09a3c](https://github.com/user-attachments/assets/c86ddfe9-b182-4f74-b6a2-5eeb92960b5e)
- ![WhatsApp Image 2025-11-20 at 01 18 40_f161ba26](https://github.com/user-attachments/assets/256c3d12-612a-4f7a-99ff-0e7ba537dcef)
- ![WhatsApp Image 2025-11-20 at 01 18 27_468ff748](https://github.com/user-attachments/assets/5b9375f7-cc86-4faa-892c-8569d61165dc)

## After
- <img width="1280" height="2856" alt="Screenshot_20251120_012556" src="https://github.com/user-attachments/assets/e5eb96d3-717a-4f53-a990-38f33971d1d1" />
- <img width="1280" height="2856" alt="Screenshot_20251120_012629" src="https://github.com/user-attachments/assets/4e99baee-3481-4a2a-8203-bcd591e150ff" />
- <img width="1280" height="2856" alt="Screenshot_20251120_012642" src="https://github.com/user-attachments/assets/87f215d2-41d8-43a3-bc90-6edf7e89fc05" />


