### PR TITLE
Add clickable links support in chat

### DIFF
--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatInteractionListener.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatInteractionListener.kt
@@ -26,6 +26,8 @@ interface ChatInteractionListener : MessageListInteractionListener,
     fun onSendRecordClicked()
 
     fun onStopAudioPlayback()
+
+    fun onLinkClick(url: String)
 }
 
 interface MessageListInteractionListener {

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatInteractionListener.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatInteractionListener.kt
@@ -27,7 +27,7 @@ interface ChatInteractionListener : MessageListInteractionListener,
 
     fun onStopAudioPlayback()
 
-    fun onLinkClick(url: String)
+    fun onLinkClicked(url: String)
 }
 
 interface MessageListInteractionListener {

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatScreen.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.BackHandler
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -174,6 +175,7 @@ fun ChatScreenContent(
                 onMessageVoiceClick = interactions::onMessageVoiceClicked,
                 onFailedMessageClick = interactions::onFailedMessageClicked,
                 onMessageLongClick = interactions::onMessageLongClicked,
+                onLinkClick = interactions::onLinkClick,
             )
         }
 
@@ -252,6 +254,7 @@ private fun EffectsHandler(
     val snackBarHostController = LocalSnackBarHostController.current
     val navController = LocalNavController.current
     val scope = rememberCoroutineScope()
+    val uriHandler = LocalUriHandler.current
 
     EffectHandler(effects, key1 = navController.currentBackStackEntry) { effect ->
         when (effect) {
@@ -266,6 +269,10 @@ private fun EffectsHandler(
 
             is ChatScreenEffect.ScrollToBottom -> {
                 scope.launch { chatLazyListState.animateScrollToItem(0) }
+            }
+
+            is ChatScreenEffect.OpenUrl -> {
+                uriHandler.openUri(effect.url)
             }
         }
     }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatScreen.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatScreen.kt
@@ -175,7 +175,7 @@ fun ChatScreenContent(
                 onMessageVoiceClick = interactions::onMessageVoiceClicked,
                 onFailedMessageClick = interactions::onFailedMessageClicked,
                 onMessageLongClick = interactions::onMessageLongClicked,
-                onLinkClick = interactions::onLinkClick,
+                onLinkClick = interactions::onLinkClicked,
             )
         }
 

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatScreenEffect.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatScreenEffect.kt
@@ -6,4 +6,5 @@ sealed interface ChatScreenEffect {
     object NavigateBack : ChatScreenEffect
     data class ShowSnackBar(val snackBarData: SnackBarData) : ChatScreenEffect
     object ScrollToBottom: ChatScreenEffect
+    data class OpenUrl(val url: String) : ChatScreenEffect
 }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModel.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModel.kt
@@ -999,7 +999,7 @@ class ChatViewModel(
             )
         }
     }
-    override fun onLinkClick(url: String) {
+    override fun onLinkClicked(url: String) {
         emitEffect(ChatScreenEffect.OpenUrl(url))
     }
 

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModel.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatViewModel.kt
@@ -999,6 +999,9 @@ class ChatViewModel(
             )
         }
     }
+    override fun onLinkClick(url: String) {
+        emitEffect(ChatScreenEffect.OpenUrl(url))
+    }
 
     companion object {
         const val PAGE_SIZE = 40

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatList.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatList.kt
@@ -38,6 +38,7 @@ fun ChatList(
     onFailedMessageClick: (MessageUiState) -> Unit,
     onMessageLongClick: (MessageUiState) -> Unit,
     onMessageVoiceClick: (Uuid) -> Unit,
+    onLinkClick: (String) -> Unit,
 ) {
     val isConnectedToNetwork by rememberNetworkStatus()
 
@@ -82,6 +83,7 @@ fun ChatList(
                 onMessageVoiceClick = onMessageVoiceClick,
                 onFailedMessageClick = onFailedMessageClick,
                 onMessageLongClick = onMessageLongClick,
+                onLinkClick = onLinkClick,
                 modifier = Modifier.padding(bottom = paddingBottom)
             )
         }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatListItem.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatListItem.kt
@@ -35,6 +35,7 @@ fun ChatListItem(
     onMessageVoiceClick: (Uuid) -> Unit,
     onFailedMessageClick: (MessageUiState) -> Unit,
     onMessageLongClick: (MessageUiState) -> Unit,
+    onLinkClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     when (item) {
@@ -64,6 +65,7 @@ fun ChatListItem(
                 onMessageClick = { onMessageClick(item.messageDetails.id) },
                 onMessageLongClick = { onMessageLongClick(item) },
                 onFailClick = { onFailedMessageClick(item) },
+                onLinkClick = onLinkClick,
             )
         }
 

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ClickableUrlText.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ClickableUrlText.kt
@@ -1,0 +1,43 @@
+package net.thechance.mena.core_chat.presentation.screen.chat.components
+
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+
+@Composable
+fun ClickableUrlText(
+    text: AnnotatedString,
+    style: TextStyle,
+    color: Color,
+    onUrlClick: (String) -> Unit,
+    onTextClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var textLayoutResult: TextLayoutResult? = null
+
+    BasicText(
+        text = text,
+        style = style.copy(color = color),
+        onTextLayout = { textLayoutResult = it },
+        modifier = modifier.pointerInput(Unit) {
+            detectTapGestures { offset ->
+                when (val url = textLayoutResult?.findUrlAtPosition(text, offset)) {
+                    null -> onTextClick()
+                    else -> onUrlClick(url)
+                }
+            }
+        }
+    )
+}
+
+private fun TextLayoutResult.findUrlAtPosition(text: AnnotatedString, offset: Offset): String? {
+    val position = getOffsetForPosition(offset)
+    return text.getStringAnnotations(tag = "URL", start = position, end = position).firstOrNull()?.item
+}

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/TextMessageLayout.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/TextMessageLayout.kt
@@ -24,9 +24,11 @@ import androidx.compose.ui.unit.dp
 import kotlinx.datetime.LocalDateTime
 import net.thechance.mena.core_chat.domain.entity.MessageReaction
 import net.thechance.mena.core_chat.domain.entity.MessageStatus
-import net.thechance.mena.core_chat.presentation.screen.contacts.components.CircularAvatar
 import net.thechance.mena.core_chat.presentation.screen.chat.MessageDetailsUiState
 import net.thechance.mena.core_chat.presentation.screen.chat.TextMessageUiState
+import net.thechance.mena.core_chat.presentation.screen.contacts.components.CircularAvatar
+import net.thechance.mena.core_chat.presentation.utils.containsUrl
+import net.thechance.mena.core_chat.presentation.utils.detectAndStyleUrls
 import net.thechance.mena.core_chat.presentation.utils.now
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
@@ -46,6 +48,7 @@ fun TextMessageLayout(
     onFailClick: () -> Unit = {},
     onMessageLongClick: () -> Unit = {},
     onMessageClick: () -> Unit = {},
+    onLinkClick: (String) -> Unit = {},
 ) {
     val messageBackground =
         if (message.messageDetails.isMine) Theme.colorScheme.background.surfaceLow
@@ -123,7 +126,7 @@ fun TextMessageLayout(
                         .clip(messageShape)
                         .sizeIn(minWidth = 56.dp, minHeight = 30.dp)
                         .combinedClickable(
-                            onClick = onMessageClick,
+                            onClick = { if (!containsUrl(message.text)) onMessageClick() },
                             onLongClick = onMessageLongClick
                         )
                         .background(color = messageBackground, shape = messageShape)
@@ -133,11 +136,23 @@ fun TextMessageLayout(
                         ),
                     contentAlignment = Alignment.Center
                 ) {
-                    Text(
-                        text = message.text,
-                        style = Theme.typography.body.small,
-                        color = Theme.colorScheme.shadeSecondary
-                    )
+                    val styledText = detectAndStyleUrls(text = message.text, linkColor = Theme.colorScheme.brand.brand)
+
+                    if (containsUrl(message.text)) {
+                        ClickableUrlText(
+                            text = styledText,
+                            style = Theme.typography.body.small,
+                            color = Theme.colorScheme.shadeSecondary,
+                            onUrlClick = onLinkClick,
+                            onTextClick = onMessageClick
+                        )
+                    } else {
+                        Text(
+                            text = message.text,
+                            style = Theme.typography.body.small,
+                            color = Theme.colorScheme.shadeSecondary
+                        )
+                    }
                 }
             }
 
@@ -150,7 +165,7 @@ fun TextMessageLayout(
                 if (!message.messageDetails.isMine && message.messageDetails.reactions.isNotEmpty()) {
                     ReactionBubble(
                         reactions = message.messageDetails.reactions,
-                        modifier= Modifier.offset(y = (-8).dp)
+                        modifier = Modifier.offset(y = (-8).dp)
                     )
                 }
 
@@ -166,8 +181,9 @@ fun TextMessageLayout(
                 if (message.messageDetails.isMine && message.messageDetails.reactions.isNotEmpty()) {
                     ReactionBubble(
                         reactions = message.messageDetails.reactions,
-                        modifier= Modifier.offset(y = (-8).dp)
-                    )                }
+                        modifier = Modifier.offset(y = (-8).dp)
+                    )
+                }
             }
         }
     }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/TextMessageLayout.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/TextMessageLayout.kt
@@ -136,9 +136,9 @@ fun TextMessageLayout(
                         ),
                     contentAlignment = Alignment.Center
                 ) {
-                    val styledText = detectAndStyleUrls(text = message.text, linkColor = Theme.colorScheme.brand.brand)
 
                     if (containsUrl(message.text)) {
+                        val styledText = detectAndStyleUrls(text = message.text, linkColor = Theme.colorScheme.brand.brand)
                         ClickableUrlText(
                             text = styledText,
                             style = Theme.typography.body.small,

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/utils/UrlDetectionUtils.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/utils/UrlDetectionUtils.kt
@@ -1,0 +1,53 @@
+package net.thechance.mena.core_chat.presentation.utils
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+
+fun detectAndStyleUrls(text: String, linkColor: Color): AnnotatedString {
+    val matches = UrlDetectionHelper.URL_PATTERN.findAll(text).toList()
+
+    if (matches.isEmpty()) return AnnotatedString(text)
+
+    return buildAnnotatedString {
+        var currentIndex = 0
+
+        for (match in matches) {
+            val start = match.range.first
+            val end = match.range.last + 1
+
+            if (currentIndex < start) append(text.substring(currentIndex, start))
+
+            val urlStartIndex = length
+            append(match.value)
+            val urlEndIndex = length
+
+            addStringAnnotation(
+                tag = "URL",
+                annotation = "https://${match.value}",
+                start = urlStartIndex,
+                end = urlEndIndex
+            )
+
+            addStyle(
+                style = SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline),
+                start = urlStartIndex,
+                end = urlEndIndex
+            )
+
+            currentIndex = end
+        }
+
+        if (currentIndex < text.length) append(text.substring(currentIndex))
+
+    }
+}
+
+fun containsUrl(text: String): Boolean = UrlDetectionHelper.URL_PATTERN.containsMatchIn(text)
+
+private object UrlDetectionHelper {
+    val URL_PATTERN =
+        Regex(pattern = "(https?://[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]+|www\\.[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]+)", option = RegexOption.IGNORE_CASE)
+}


### PR DESCRIPTION
Implemented automatic URL detection in text messages with clickable links that open in browser. Added regex pattern to identify URLs (including www. prefixes), styled them with underline and custom color, and added click handling to open links externally. 

https://github.com/user-attachments/assets/8f61e2fe-beb7-486b-9478-333628fece93

