### PR TITLE
add full screen option to the scaffold

### DIFF
--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/scaffold/Scaffold.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/scaffold/Scaffold.kt
@@ -44,9 +44,9 @@ fun Scaffold(
         modifier = modifier
             .fillMaxSize()
             .applyIf(hasBlur) { blur(4.dp) }
-            .background(statusBarColor)
             .applyIf(!fullScreen) {
-                windowInsetsPadding(WindowInsets.statusBars)
+                background(statusBarColor)
+                    .windowInsetsPadding(WindowInsets.statusBars)
                     .navigationBarsPadding()
                     .systemBarsPadding()
             },

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/scaffold/Scaffold.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/scaffold/Scaffold.kt
@@ -19,12 +19,14 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.designsystem.presentation.util.applyIf
 
 @Composable
 fun Scaffold(
     modifier: Modifier = Modifier,
     backgroundColor: Color = Theme.colorScheme.background.surface,
     statusBarColor: Color = backgroundColor,
+    fullScreen: Boolean = false,
     topBar: @Composable () -> Unit = {},
     bottomBar: @Composable () -> Unit = {},
     snakeBar: @Composable () -> Unit = {},
@@ -41,13 +43,13 @@ fun Scaffold(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .then(
-                if (hasBlur) Modifier.blur(4.dp) else Modifier
-            )
+            .applyIf(hasBlur) { blur(4.dp) }
             .background(statusBarColor)
-            .windowInsetsPadding(WindowInsets.statusBars)
-            .navigationBarsPadding()
-            .systemBarsPadding(),
+            .applyIf(!fullScreen) {
+                windowInsetsPadding(WindowInsets.statusBars)
+                    .navigationBarsPadding()
+                    .systemBarsPadding()
+            },
         contentAlignment = Alignment.Center
     ) {
         Column(

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/util/modifiers.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/util/modifiers.kt
@@ -1,0 +1,10 @@
+package net.thechance.mena.designsystem.presentation.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun Modifier.applyIf(
+    condition: Boolean,
+    newModifiers: @Composable Modifier.() -> Modifier
+): Modifier = if (condition) this.newModifiers() else this


### PR DESCRIPTION
Add fullScreen option to the Scaffold component, allowing screens to render without system bar padding. 
When enabled, the Scaffold expands to use the entire display area, providing a true full-screen experience.

```
Scaffold(
    fullScreen = state.showFullScreen,
    ...
```

