### PR TITLE
refactor: update BottomSheet scrim color to use Black with alpha

### DIFF
--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/bottomSheet/BottomSheet.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/bottomSheet/BottomSheet.kt
@@ -76,7 +76,7 @@ fun ScaffoldScope.BottomSheet(
     dismissOnBackPress: Boolean = true,
     dismissOnClickOutside: Boolean = true,
     containerColor: Color = Theme.colorScheme.background.surface,
-    scrimColor: Color = Theme.colorScheme.primary.primary.copy(0.55f),
+    scrimColor: Color = Color.Black.copy(0.55f),
     cornerShape: Shape = RoundedCornerShape(
         topStart = Theme.radius.xl,
         topEnd = Theme.radius.xl


### PR DESCRIPTION
this pr fixes bottom sheet overlay color
- Before
 ![Screenshot_20251120-170950_MENA.jpg](https://github.com/user-attachments/assets/7c124647-bc92-42c7-adba-17dcbf204799)
![Screenshot_20251120-171104_MENA.jpg](https://github.com/user-attachments/assets/c487aadc-23da-4f6b-94a5-8794d61e3152)

- After

![Screenshot_20251120-171549_MENA.jpg](https://github.com/user-attachments/assets/930817d0-a3e2-4b5e-9020-fd59ec9ca8b0)

![Screenshot_20251120-171653_MENA.jpg](https://github.com/user-attachments/assets/b40cc3fd-6f44-4f09-ad97-9dd6f9259349)




