### PR TITLE
Fix/FTH 193 play surah error snackbar and correct states bar color

### DIFF
--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/NearbyMosquesScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/NearbyMosquesScreen.kt
@@ -103,6 +103,7 @@ private fun Content(
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     Scaffold(
+        statusBarColor = Theme.colorScheme.background.surfaceLow,
         topBar = {
             AppBar(
                 modifier = Modifier.background(Theme.colorScheme.background.surfaceLow),

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
@@ -321,7 +321,9 @@ class SurahViewModel(
                 }
                 quranPlayer.playAyah(ayahSoundUrl)
             },
-            onSuccess = { updateSurahPlayback() })
+            onSuccess = { updateSurahPlayback() },
+            dispatcher = Main
+        )
     }
 
     private fun handleLoadSurahSuccess(ayat: List<Ayah>) {


### PR DESCRIPTION
* Set the `statusBarColor` in the `Scaffold` of `NearbyMosquesScreen.kt` 

* Updated the `SurahViewModel` to explicitly set the coroutine `dispatcher` to `Main` when playing Surah , ensuring play are performed on the main thread.