### PR TITLE
Fix: Contact US Opening Empty URL and Crashes in Offline Mode

### DIFF
--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/contactUs/ContactUsUIState.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/contactUs/ContactUsUIState.kt
@@ -6,7 +6,7 @@ import org.jetbrains.compose.resources.StringResource
 data class ContactUsUIState(
     val isLoading: Boolean = true,
     val urlToOpen: MutableSharedFlow<String> = MutableSharedFlow(),
-    val displayedFacebookAccount: String = "MENA-THE-CHANCE",
+    val displayedFacebookAccount: String = "",
     val email: String = "",
     val phoneNumber: String = "",
     val facebookUrl: String = "",

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/contactUs/ContactUsViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/contactUs/ContactUsViewModel.kt
@@ -40,6 +40,7 @@ class ContactUsViewModel(
             copy(
                 email = contactInfo.email,
                 phoneNumber = contactInfo.phoneNumber,
+                displayedFacebookAccount = "MENA-THE-CHANCE",
                 facebookUrl = contactInfo.facebookAccount,
                 isLoading = false
             )
@@ -48,18 +49,26 @@ class ContactUsViewModel(
 
 
     override fun onClickEmailAddress() {
+        if (state.value.email.isBlank())
+            return
+
         val emailUrl = "$EMAIL_URL_PREFIX${state.value.email}"
         sendNewEffect(ContactUsUIEffect.OpenUrl(emailUrl))
     }
 
     override fun onClickPhoneNumber() {
+        if (state.value.phoneNumber.isBlank())
+            return
+
         val phoneUrl = "$PHONE_URL_PREFIX${state.value.phoneNumber}"
         sendNewEffect(ContactUsUIEffect.OpenUrl(phoneUrl))
     }
 
     override fun onClickFacebookAccount() {
-        val facebookUrl = state.value.facebookUrl
-        sendNewEffect(ContactUsUIEffect.OpenUrl(facebookUrl))
+        if (state.value.facebookUrl.isBlank())
+            return
+
+        sendNewEffect(ContactUsUIEffect.OpenUrl(state.value.facebookUrl))
     }
 
     override fun onClearErrorMessage() {
@@ -86,6 +95,7 @@ class ContactUsViewModel(
             else -> mapErrorToMessage(ErrorState.GenericError(throwable))
         }
     }
+
     companion object {
         private const val EMAIL_URL_PREFIX = "mailto:"
         private const val PHONE_URL_PREFIX = "tel:"

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/contactUs/components/ContactCard.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/contactUs/components/ContactCard.kt
@@ -42,6 +42,7 @@ internal fun ContactCard(
                 SquircleShape(Theme.radius.lg)
             )
             .clickable(
+                enabled = info.isNotBlank(),
                 interactionSource = remember { MutableInteractionSource() },
                 indication = rippleIndication(),
                 onClick = onClick


### PR DESCRIPTION
This PR prevents users from clicking on contact cards that have no information (e.g., an empty email or phone number).

- Add guards in `ContactUsViewModel` to block `OpenUrl` effects for blank email, phone, or Facebook URLs.
- Disable the `clickable` modifier in the `ContactCard` composable when the `info` string is blank.
- Adjust initial state in `ContactUsUIState` for `displayedFacebookAccount` to be empty.


https://github.com/user-attachments/assets/4d8ffbf1-a2a1-4f64-9508-808a9d6d4f14


This PR fixes the following issues #1079 and #1080