### PR TITLE
Fix/cht 171 navigation bar visibility and icons colors

### DIFF
--- a/composeApp/src/commonMain/kotlin/net/thechance/mena/appEntryPoint/LoggedInContainer.kt
+++ b/composeApp/src/commonMain/kotlin/net/thechance/mena/appEntryPoint/LoggedInContainer.kt
@@ -136,7 +136,7 @@ private fun FeatureContent(
     Box(modifier) {
         Crossfade(targetState = activeFeature) { feature ->
             when (feature) {
-                Feature.CHAT -> chatApi.TabEntry()
+                Feature.CHAT -> chatApi.TabEntry(updateBottomNavigationVisibility)
                 Feature.DUKAN -> dukanApi.TabEntry()
                 Feature.TREND -> trendsApi.TabEntry()
                 Feature.FAITH -> faithApi.TabEntry()

--- a/core_chat_api/src/commonMain/kotlin/net/thechance/mena/core_chat/api/CoreChatApi.kt
+++ b/core_chat_api/src/commonMain/kotlin/net/thechance/mena/core_chat/api/CoreChatApi.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 
 interface CoreChatApi {
     @Composable
-    fun TabEntry()
+    fun TabEntry(updateBottomNavigationVisibility: (Boolean) -> Unit)
 
     @Composable
     fun ChatEntry(userId: String, onNavigateBack: () -> Unit)

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/api/CoreChatApiImp.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/api/CoreChatApiImp.kt
@@ -14,8 +14,8 @@ import kotlin.uuid.ExperimentalUuidApi
 @OptIn(ExperimentalUuidApi::class)
 class CoreChatApiImp() : CoreChatApi {
     @Composable
-    override fun TabEntry() {
-        ChatNavHost()
+    override fun TabEntry(updateBottomNavigationVisibility: (Boolean) -> Unit) {
+        ChatNavHost(updateBottomNavigationVisibility = updateBottomNavigationVisibility)
     }
 
     @Composable

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/navigation/ChatNavHost.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/navigation/ChatNavHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
@@ -15,6 +16,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import coil3.compose.setSingletonImageLoaderFactory
+import kotlinx.coroutines.flow.collectLatest
 import net.thechance.mena.core_chat.presentation.components.snackBarHost.AnimatedSnackBarHost
 import net.thechance.mena.core_chat.presentation.components.snackBarHost.LocalSnackBarHostController
 import net.thechance.mena.core_chat.presentation.components.snackBarHost.SnackBarHostController
@@ -35,6 +37,7 @@ val LocalNavController = staticCompositionLocalOf<NavController> {
 @Composable
 fun ChatNavHost(
     walletApi: WalletApi = koinInject(),
+    updateBottomNavigationVisibility: (Boolean) -> Unit = {},
     onNavigateBackFromChat: () -> Unit = {},
     onNavigateBackFromShareMessage: () -> Unit = {},
     startDestination: ChatRoute = HomeRoute
@@ -44,6 +47,16 @@ fun ChatNavHost(
     setSingletonImageLoaderFactory { coilImageLoader }
     val navController = rememberNavController()
     val snackBarHostController = remember { SnackBarHostController() }
+
+    LaunchedEffect(Unit) {
+        navController.currentBackStack.collectLatest {
+            if (navController.currentDestination?.route in routsWithBottomNavigation) {
+                updateBottomNavigationVisibility(true)
+            } else {
+                updateBottomNavigationVisibility(false)
+            }
+        }
+    }
 
     Box(
         modifier = Modifier.fillMaxSize()
@@ -79,3 +92,8 @@ fun ChatNavHost(
         }
     }
 }
+
+private val routsWithBottomNavigation = listOf(
+    HomeRoute::class.qualifiedName,
+    WalletRoute::class.qualifiedName
+)

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/navigation/ChatNavHost.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/navigation/ChatNavHost.kt
@@ -76,12 +76,8 @@ fun ChatNavHost(
                 composable<ChatDetailsRoute> { ChatScreen(onClickBackFromChat = onNavigateBackFromChat) }
                 composable<WalletRoute> {
                     walletApi.WalletEntry(
-                        navigateBack = {
-                            navController.popBackStack()
-                        },
-                        updateBottomNavigationVisibility = {
-                            //pass updateBottomNavigationVisibility here
-                        },
+                        navigateBack = { navController.popBackStack() },
+                        updateBottomNavigationVisibility = updateBottomNavigationVisibility,
                     )
                 }
                 composable<ShareMessageRoute> { ShareMessageScreen(onClickBack = onNavigateBackFromShareMessage) }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatScreen.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/ChatScreen.kt
@@ -13,31 +13,23 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.BackHandler
-import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -55,9 +47,9 @@ import net.thechance.mena.core_chat.presentation.screen.chat.components.ChatHead
 import net.thechance.mena.core_chat.presentation.screen.chat.components.ChatInputBar
 import net.thechance.mena.core_chat.presentation.screen.chat.components.ChatList
 import net.thechance.mena.core_chat.presentation.screen.chat.components.FullImagePagerView
+import net.thechance.mena.core_chat.presentation.screen.chat.components.MessageReactionDialog
 import net.thechance.mena.core_chat.presentation.screen.chat.components.RecordingBar
 import net.thechance.mena.core_chat.presentation.screen.chat.components.chatActionsMenuDialog
-import net.thechance.mena.core_chat.presentation.screen.chat.components.MessageReactionDialog
 import net.thechance.mena.core_chat.presentation.screen.chat.components.resendFailedMessageDialog
 import net.thechance.mena.core_chat.presentation.utils.EffectHandler
 import net.thechance.mena.core_chat.presentation.utils.PaginationTrigger
@@ -90,7 +82,11 @@ fun ChatScreen(onClickBackFromChat: () -> Unit = {}) {
 
     AudioLifecycleObserver(viewModel)
 
-    EffectsHandler(effects = effects, chatLazyListState = chatLazyListState, onClickBackFromChat = onClickBackFromChat)
+    EffectsHandler(
+        effects = effects,
+        chatLazyListState = chatLazyListState,
+        onClickBackFromChat = onClickBackFromChat
+    )
 
     ChatScreenContent(
         state = state,
@@ -115,11 +111,6 @@ fun ChatScreenContent(
         }
     }
 
-    val keyboardHeight = WindowInsets.ime.getBottom(LocalDensity.current)
-    val maxKeyboardHeight = rememberKeyboardMaxHeight()
-    val shouldAddOffset = remember(keyboardHeight) { keyboardHeight > maxKeyboardHeight * 0.53 }
-
-    val chatInputBarOffset = if (shouldAddOffset) Constants.NAVIGATION_BAR_HEIGHT else 0
     val keyboardController = LocalSoftwareKeyboardController.current
 
     Box(
@@ -138,6 +129,13 @@ fun ChatScreenContent(
                         .fillMaxWidth()
                 )
             },
+            bottomBar = {
+                ChatInputBarContent(
+                    state = state,
+                    interactions = interactions,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            },
             overlays = {
                 resendFailedMessageDialog(
                     showResendMessageDialog = state.isResendMessageDialogVisible,
@@ -151,32 +149,24 @@ fun ChatScreenContent(
                     showConfirmDeleteChatDialog = state.isConfirmDeleteChatDialogVisible,
                     actionsMenuInteractionListener = interactions as ActionsMenuInteractionListener
                 )
-            }
+            },
+            modifier = Modifier.imePadding()
         ) {
-            Box(){
-                ChatList(
-                    items = state.chatListItems,
-                    chatAvatarUrl = state.chatAvatarUrl,
-                    chatListState = chatLazyListState,
-                    onMessageClick = interactions::onMessageClicked,
-                    onMessageImageClick = interactions::onMessageImageClicked,
-                    onMessageVoiceClick = interactions::onMessageVoiceClicked,
-                    onFailedMessageClick = interactions::onFailedMessageClicked,
-                    onMessageLongClick = interactions::onMessageLongClicked,
-                    onLinkClick = interactions::onLinkClicked,
-                    modifier = Modifier.imePadding()
-                        .padding(bottom = if (keyboardHeight > maxKeyboardHeight * 0.53) 0.dp else 80.dp)
-                        .clickable(
-                            indication = null,
-                            interactionSource = remember { MutableInteractionSource() }) { keyboardController?.hide() }
-                )
-                ChatInputBarContent(
-                    state = state,
-                    interactions = interactions,
-                    modifier = Modifier
-                        .fillMaxWidth().align(Alignment.BottomCenter).imePadding().offset(y = chatInputBarOffset.dp)
-                )
-            }
+            ChatList(
+                items = state.chatListItems,
+                chatAvatarUrl = state.chatAvatarUrl,
+                chatListState = chatLazyListState,
+                onMessageClick = interactions::onMessageClicked,
+                onMessageImageClick = interactions::onMessageImageClicked,
+                onMessageVoiceClick = interactions::onMessageVoiceClicked,
+                onFailedMessageClick = interactions::onFailedMessageClicked,
+                onMessageLongClick = interactions::onMessageLongClicked,
+                onLinkClick = interactions::onLinkClicked,
+                modifier = Modifier
+                    .clickable(
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() }) { keyboardController?.hide() }
+            )
         }
 
         AnimatedVisibility(
@@ -313,22 +303,4 @@ private fun EffectsHandler(
             }
         }
     }
-}
-
-private object Constants{
-    const val NAVIGATION_BAR_HEIGHT = 74
-}
-
-@Composable
-private fun rememberKeyboardMaxHeight(): Int {
-    val density = LocalDensity.current
-    val imeBottom = WindowInsets.ime.getBottom(density)
-
-    var maxHeight by remember { mutableStateOf(0) }
-
-    if (imeBottom > maxHeight) {
-        maxHeight = imeBottom
-    }
-
-    return maxHeight
 }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatList.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatList.kt
@@ -4,7 +4,6 @@ package net.thechance.mena.core_chat.presentation.screen.chat.components
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -44,9 +43,7 @@ fun ChatList(
     val isConnectedToNetwork by rememberNetworkStatus()
 
     LazyColumn(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(horizontal = Theme.spacing._12),
+        modifier = modifier.padding(horizontal = Theme.spacing._12),
         state = chatListState,
         reverseLayout = true,
         contentPadding = PaddingValues(top = Theme.spacing._16)

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatList.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/ChatList.kt
@@ -2,8 +2,10 @@
 
 package net.thechance.mena.core_chat.presentation.screen.chat.components
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -43,10 +45,13 @@ fun ChatList(
     val isConnectedToNetwork by rememberNetworkStatus()
 
     LazyColumn(
-        modifier = modifier.padding(horizontal = Theme.spacing._12),
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = Theme.spacing._12),
         state = chatListState,
         reverseLayout = true,
-        contentPadding = PaddingValues(top = Theme.spacing._16)
+        contentPadding = PaddingValues(top = Theme.spacing._16),
+        verticalArrangement = Arrangement.Bottom
     ) {
         itemsIndexed(
             items = items,

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/RecordingBar.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/chat/components/RecordingBar.kt
@@ -171,6 +171,7 @@ private fun SendButton(
         Icon(
             painter = painterResource(Res.drawable.ic_send),
             contentDescription = null,
+            tint = Theme.colorScheme.primary.onPrimary,
             modifier = Modifier.size(20.dp)
         )
     }

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/contacts/components/CircularAvatar.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/contacts/components/CircularAvatar.kt
@@ -34,6 +34,7 @@ fun CircularAvatar(
         Icon(
             painter = painterResource(Res.drawable.ic_profile_placeholder),
             contentDescription = null,
+            tint = Theme.colorScheme.primary.primary,
         )
 
         if (!contactImageUri.isNullOrBlank()) {

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/components/WeatherAndNextPrayerCard.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/screen/home/components/WeatherAndNextPrayerCard.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
@@ -72,7 +73,8 @@ private fun WeatherAndPrayerContent(
             painter = painterResource(Res.drawable.prayer_weather_pattern_shape),
             contentDescription = null,
             contentScale = ContentScale.Fit,
-            modifier = Modifier.align(Alignment.CenterEnd).padding(end = 8.dp)
+            modifier = Modifier.align(Alignment.CenterEnd).padding(end = 8.dp),
+            colorFilter = ColorFilter.tint(Theme.colorScheme.primary.onPrimary)
         )
         Column(
             verticalArrangement = Arrangement.spacedBy(
@@ -125,7 +127,7 @@ private fun RowInfoCard(
             Image(
                 painter = leadingIcon,
                 contentDescription = null,
-                modifier = Modifier
+                colorFilter = ColorFilter.tint(Theme.colorScheme.primary.onPrimary)
             )
         }
         Text(

--- a/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/shared/BaseViewModel.kt
+++ b/core_chat_presentation/src/commonMain/kotlin/net/thechance/mena/core_chat/presentation/shared/BaseViewModel.kt
@@ -20,13 +20,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEmpty
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import org.koin.core.component.KoinComponent
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 


### PR DESCRIPTION
# What have been done
- control navigation bar visibility in chat feature
- update chat screen keyboard padding calculation after hiding navigation bar
- fix voice record bottom bar position
- fix some icons color in dark theme

screenshots:
<img width="294" height="677" alt="image" src="https://github.com/user-attachments/assets/f2389f9e-f0a7-47a0-99a9-e84e0c843127" />
<img width="301" height="682" alt="image" src="https://github.com/user-attachments/assets/8fc0e369-b4ea-43ad-84e9-d7fbdef272eb" />
<img width="310" height="695" alt="image" src="https://github.com/user-attachments/assets/acf90cd3-81a0-42e4-bd9a-270764394eae" />
<img width="303" height="693" alt="image" src="https://github.com/user-attachments/assets/bfd5b341-8a27-4a09-b914-4a4f68b9968d" />
