### PR TITLE
Feature/TRN 136 bottom navigation visibility

### DIFF
--- a/composeApp/src/commonMain/kotlin/net/thechance/mena/appEntryPoint/LoggedInContainer.kt
+++ b/composeApp/src/commonMain/kotlin/net/thechance/mena/appEntryPoint/LoggedInContainer.kt
@@ -138,7 +138,7 @@ private fun FeatureContent(
             when (feature) {
                 Feature.CHAT -> chatApi.TabEntry()
                 Feature.DUKAN -> dukanApi.TabEntry()
-                Feature.TREND -> trendsApi.TabEntry()
+                Feature.TREND -> trendsApi.TabEntry(updateBottomNavigationVisibility)
                 Feature.FAITH -> faithApi.TabEntry()
                 Feature.PROFILE -> identityApi.ProfileTabEntry(updateBottomNavigationVisibility)
                 Feature.WALLET -> walletApi.WalletEntry(navigateBack = {})

--- a/trends_api/src/commonMain/kotlin/net/thechance/mena/trends/api/TrendsApi.kt
+++ b/trends_api/src/commonMain/kotlin/net/thechance/mena/trends/api/TrendsApi.kt
@@ -4,5 +4,5 @@ import androidx.compose.runtime.Composable
 
 interface TrendsApi {
     @Composable
-    fun TabEntry()
+    fun TabEntry(updateBottomNavigationVisibility: (Boolean) -> Unit)
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/TrendsApiImpl.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/TrendsApiImpl.kt
@@ -8,7 +8,9 @@ import org.koin.core.annotation.Single
 class TrendsApiImpl() : TrendsApi {
 
     @Composable
-    override fun TabEntry() {
-        TrendsNavHost()
+    override fun TabEntry(updateBottomNavigationVisibility: (Boolean) -> Unit) {
+        TrendsNavHost(
+            updateBottomNavigationVisibility = updateBottomNavigationVisibility
+        )
     }
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/TrendsNavGraph.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/TrendsNavGraph.kt
@@ -59,6 +59,8 @@ fun TrendsNavHost(
         LocalImageLoader provides coilLoader,
         LocalDarkTheme provides isDarkTheme
     ) {
+        handleBottomNavigationVisibility(updateBottomNavigationVisibility)
+
         Box(modifier = Modifier.fillMaxSize()) {
 
             NavHost(

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/TrendsNavGraph.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/TrendsNavGraph.kt
@@ -40,7 +40,8 @@ import org.koin.compose.koinInject
 
 @Composable
 fun TrendsNavHost(
-    appThemeService: AppThemeService = koinInject()
+    appThemeService: AppThemeService = koinInject(),
+    updateBottomNavigationVisibility: (Boolean) -> Unit
 ) {
 
     val navController = rememberNavController()

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/handleBottomNavigationVisibility.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/navigation/handleBottomNavigationVisibility.kt
@@ -1,0 +1,37 @@
+package net.thechance.mena.trends.presentation.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.navigation.NavDestination
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.compose.currentBackStackEntryAsState
+
+@Composable
+@Suppress("ComposableNaming")
+internal fun handleBottomNavigationVisibility(
+    updateBottomNavigationVisibility: (Boolean) -> Unit
+) {
+    val navController = LocalNavController.current
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = navBackStackEntry?.destination
+
+    LaunchedEffect(currentDestination) {
+        val shouldShowBottomNav = isBottomNavigationVisible(currentDestination)
+        updateBottomNavigationVisibility(shouldShowBottomNav)
+    }
+}
+
+private fun isBottomNavigationVisible(destination: NavDestination?): Boolean {
+    val routeWithBottomNavigation = listOf(
+        Route.MainContainer::class,
+        Route.Home::class
+    )
+
+    return destination?.hierarchy?.any { destination ->
+        routeWithBottomNavigation.any { route ->
+            destination.hasRoute(route)
+        }
+    } ?: true
+}


### PR DESCRIPTION
## Description
- handle app bottom navigation visibility for Trends
---

## Changes Made
- pass `updateBottomNavigationVisibility` callback to Trends API
- create `handleBottomNavigationVisibility` to show bottom navigation in `MainContainer` and `Home` routes

---

## Screenshots 

https://github.com/user-attachments/assets/b88bf445-6623-4214-b9f6-aeddd00869c4
