### PR TITLE
feature: hide navigation bar when exiting the main screen in dukan

### DIFF
--- a/composeApp/src/commonMain/kotlin/net/thechance/mena/appEntryPoint/LoggedInContainer.kt
+++ b/composeApp/src/commonMain/kotlin/net/thechance/mena/appEntryPoint/LoggedInContainer.kt
@@ -137,7 +137,7 @@ private fun FeatureContent(
         Crossfade(targetState = activeFeature) { feature ->
             when (feature) {
                 Feature.CHAT -> chatApi.TabEntry(updateBottomNavigationVisibility)
-                Feature.DUKAN -> dukanApi.TabEntry()
+                Feature.DUKAN -> dukanApi.TabEntry(updateBottomNavigationVisibility)
                 Feature.TREND -> trendsApi.TabEntry(updateBottomNavigationVisibility)
                 Feature.FAITH -> faithApi.TabEntry()
                 Feature.PROFILE -> identityApi.ProfileTabEntry(updateBottomNavigationVisibility)

--- a/dukan_api/src/commonMain/kotlin/net/thechance/mena/dukan/api/DukanApi.kt
+++ b/dukan_api/src/commonMain/kotlin/net/thechance/mena/dukan/api/DukanApi.kt
@@ -7,7 +7,7 @@ import kotlin.uuid.Uuid
 @OptIn(ExperimentalUuidApi::class)
 interface DukanApi {
     @Composable
-    fun TabEntry()
+    fun TabEntry(updateBottomNavigationVisibility: (Boolean) -> Unit)
 
     @Composable
     fun OrderDetailsEntry(orderId: Uuid, onNavigateBack: () -> Unit)

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/DukanApiImpl.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/DukanApiImpl.kt
@@ -10,8 +10,10 @@ import kotlin.uuid.Uuid
 @OptIn(ExperimentalUuidApi::class)
 class DukanApiImpl : DukanApi {
     @Composable
-    override fun TabEntry() {
-        DukanNavHost()
+    override fun TabEntry(updateBottomNavigationVisibility: (Boolean) -> Unit) {
+        DukanNavHost(
+            updateBottomNavigationVisibility = updateBottomNavigationVisibility
+        )
     }
 
     @Composable

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/navigation/DukanNavHost.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/navigation/DukanNavHost.kt
@@ -2,10 +2,12 @@ package net.thechance.mena.dukan.presentation.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
+import kotlinx.coroutines.flow.collectLatest
 import net.thechance.mena.dukan.presentation.screen.categoryDukans.CategoryDukansScreen
 import net.thechance.mena.dukan.presentation.screen.checkout.CheckoutScreen
 import net.thechance.mena.dukan.presentation.screen.createDukan.CreateDukanScreen
@@ -35,10 +37,22 @@ import net.thechance.mena.identity.api.IdentityFeatureApi as IdentityApi
 @Composable
 fun DukanNavHost(
     walletApi: WalletApi = koinInject(),
-    identityApi: IdentityApi = koinInject()
+    identityApi: IdentityApi = koinInject(),
+    updateBottomNavigationVisibility: (Boolean) -> Unit
 ) {
     val navController = rememberNavController()
     val coilImageLoader = provideImageLoader()
+
+    LaunchedEffect(Unit) {
+        navController.currentBackStack.collectLatest {
+            if (navController.currentDestination?.route in routsWithBottomNavigation) {
+                updateBottomNavigationVisibility(true)
+            } else {
+                updateBottomNavigationVisibility(false)
+            }
+        }
+    }
+
     CompositionLocalProvider(
         LocalNavController provides navController, LocalImageLoader provides coilImageLoader
     ) {
@@ -124,3 +138,7 @@ fun DukanNavHost(
         }
     }
 }
+
+private val routsWithBottomNavigation = listOf(
+    DukanRoute.MainScreenRoute::class.qualifiedName
+)

--- a/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/checkout/CheckoutUiStateTest.kt
+++ b/dukan_presentation/src/commonTest/kotlin/net/thechance/mena/dukan/presentation/viewModel/checkout/CheckoutUiStateTest.kt
@@ -4,9 +4,11 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.uuid.ExperimentalUuidApi
 
 class CheckoutUiStateTest {
 
+    @OptIn(ExperimentalUuidApi::class)
     @Test
     fun `default state SHOULD have empty values`() = runTest {
         val state = CheckoutUiState()


### PR DESCRIPTION
### Changes in this PR:
- Hide the navigation bar when exiting the main screen