### PR TITLE
Fix/IDN-238 Fix login after logout uses previous account

### DIFF
--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/identityDataModule.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/di/identityDataModule.kt
@@ -8,9 +8,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import net.thechance.mena.identity.data.dataSource.local.database.IdentityDatabase
 import net.thechance.mena.identity.data.dataSource.local.database.dao.UserDao
+import net.thechance.mena.identity.data.repository.ApplicationInfoRepositoryImpl
 import net.thechance.mena.identity.data.repository.AuthenticationRepositoryImpl
 import net.thechance.mena.identity.data.repository.ImagesRepositoryImpl
-import net.thechance.mena.identity.data.repository.ApplicationInfoRepositoryImpl
 import net.thechance.mena.identity.data.repository.RegisterRepositoryImpl
 import net.thechance.mena.identity.data.repository.RegistrationDraftRepositoryImpl
 import net.thechance.mena.identity.data.repository.ResetPasswordRepositoryImpl
@@ -20,9 +20,9 @@ import net.thechance.mena.identity.data.repository.location.AddressesRepositoryI
 import net.thechance.mena.identity.data.repository.location.GeocoderWrapper
 import net.thechance.mena.identity.data.repository.location.MobileGeocoderWrapper
 import net.thechance.mena.identity.domain.repository.AddressesRepository
+import net.thechance.mena.identity.domain.repository.ApplicationInfoRepository
 import net.thechance.mena.identity.domain.repository.AuthenticationRepository
 import net.thechance.mena.identity.domain.repository.ImagesRepository
-import net.thechance.mena.identity.domain.repository.ApplicationInfoRepository
 import net.thechance.mena.identity.domain.repository.RegisterRepository
 import net.thechance.mena.identity.domain.repository.RegistrationDraftRepository
 import net.thechance.mena.identity.domain.repository.ResetPasswordRepository
@@ -52,7 +52,11 @@ val identityDataModule = module {
     }
 
     single<AuthenticationRepository> {
-        AuthenticationRepositoryImpl(client = get(named(IDENTITY_CLIENT)), settings = get())
+        AuthenticationRepositoryImpl(
+            client = get(named(IDENTITY_CLIENT)),
+            settings = get(),
+            userDao = get()
+        )
     }
 
     single<ResetPasswordRepository> {

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/repository/AuthenticationRepositoryImpl.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/repository/AuthenticationRepositoryImpl.kt
@@ -2,8 +2,12 @@ package net.thechance.mena.identity.data.repository
 
 import com.russhwolf.settings.Settings
 import io.ktor.client.HttpClient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
+import net.thechance.mena.identity.data.dataSource.local.database.dao.UserDao
 import net.thechance.mena.identity.data.dataSource.local.setting.accessToken
 import net.thechance.mena.identity.data.dataSource.local.setting.imageUploadCompleted
 import net.thechance.mena.identity.data.dataSource.local.setting.lastRegistrationPhoneNumber
@@ -12,8 +16,9 @@ import net.thechance.mena.identity.data.dto.auth.request.LoginRequestDto
 import net.thechance.mena.identity.data.dto.auth.request.RefreshRequestDto
 import net.thechance.mena.identity.data.dto.auth.response.AuthenticationResponse
 import net.thechance.mena.identity.data.mapper.toDomain
-import net.thechance.mena.identity.data.utils.postJson
+import net.thechance.mena.identity.data.utils.invalidateAuthTokens
 import net.thechance.mena.identity.data.utils.postEmpty
+import net.thechance.mena.identity.data.utils.postJson
 import net.thechance.mena.identity.data.utils.safeWrapper
 import net.thechance.mena.identity.domain.entity.PhoneNumber
 import net.thechance.mena.identity.domain.model.AuthenticationTokens
@@ -22,7 +27,8 @@ import kotlin.concurrent.Volatile
 
 class AuthenticationRepositoryImpl(
     private val client: HttpClient,
-    private val settings: Settings
+    private val settings: Settings,
+    private val userDao: UserDao? = null
 ) : AuthenticationRepository {
 
     private val observableToken: MutableStateFlow<String> = MutableStateFlow(
@@ -48,11 +54,27 @@ class AuthenticationRepositoryImpl(
             LOGIN_ENDPOINT
         )
         saveAuthTokens(response.toDomain())
+        try {
+            client.invalidateAuthTokens()
+        } catch (_: Exception) {
+        }
     }
 
     override suspend fun logout() {
         safeWrapper {
             client.postEmpty(LOGOUT_ENDPOINT)
+        }
+        try {
+            client.invalidateAuthTokens()
+        } catch (_: Exception) {
+        }
+        if (userDao != null) {
+            withContext(Dispatchers.IO) {
+                try {
+                    userDao.deleteUser()
+                } catch (_: Exception) {
+                }
+            }
         }
         clearAuthTokens()
     }
@@ -65,6 +87,10 @@ class AuthenticationRepositoryImpl(
             )
         }
         saveTokens(response.toDomain(), shouldEmit = !isTemporaryTokenMode)
+        try {
+            client.invalidateAuthTokens()
+        } catch (_: Exception) {
+        }
         return settings.accessToken
     }
 

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/repository/UserRepositoryImpl.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/repository/UserRepositoryImpl.kt
@@ -25,6 +25,7 @@ import net.thechance.mena.identity.data.utils.postFileWithDataAndTokens
 import net.thechance.mena.identity.data.utils.postJson
 import net.thechance.mena.identity.data.utils.postEmpty
 import net.thechance.mena.identity.data.utils.safeWrapper
+import net.thechance.mena.identity.data.utils.invalidateAuthTokens
 import net.thechance.mena.identity.domain.model.AuthenticationTokens
 import net.thechance.mena.identity.domain.entity.Gender
 import net.thechance.mena.identity.domain.entity.User
@@ -115,6 +116,10 @@ class UserRepositoryImpl(
     override suspend fun deleteAccount() {
         safeWrapper {
             client.postEmpty(DELETE_ACCOUNT_PATH)
+        }
+        try {
+            client.invalidateAuthTokens()
+        } catch (_: Exception) {
         }
         withContext(dispatcher) {
             try {

--- a/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/utils/HttpClientExtensions.kt
+++ b/identity_data/src/commonMain/kotlin/net/thechance/mena/identity/data/utils/HttpClientExtensions.kt
@@ -1,0 +1,12 @@
+package net.thechance.mena.identity.data.utils
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.auth.authProvider
+import io.ktor.client.plugins.auth.providers.BearerAuthProvider
+
+fun HttpClient.invalidateAuthTokens() {
+    try {
+        authProvider<BearerAuthProvider>()?.clearToken()
+    } catch (_: Throwable) {
+    }
+}


### PR DESCRIPTION
Switching accounts after logout reused the previous session due to Ktor Auth bearer token caching. Clear the cache on login, logout, and refresh; also clear local user on logout.

#### Changes
- Add `HttpClient.invalidateAuthTokens()` in common to clear bearer cache.
- Call `invalidateAuthTokens()` after `login`, `logout`, `refreshAccessToken`.
- Clear local user data on `logout`.