### PR TITLE
Fix: deep link not open first time

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.Light.NoActionBar">
         <activity
-            android:launchMode="singleInstance"
+            android:launchMode="singleTop"
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.Light.NoActionBar">
         <activity
-            android:launchMode="singleTop"
+            android:launchMode="singleInstance"
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>

--- a/composeApp/src/androidMain/kotlin/net/thechance/mena/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/net/thechance/mena/MainActivity.kt
@@ -29,6 +29,10 @@ class MainActivity : ComponentActivity() {
         val localizer: AppLocalizer by inject()
         localizer.applyLocaleToContext()
 
+        mainEntryViewModel.onDeepLinkChange(
+            deepLink = parseDeepLinkFromIntent(intent)
+        )
+
         setContent {
             App()
         }


### PR DESCRIPTION
This change passes the parsed deeplink from the intent to the `MainEntryViewModel` when the `MainActivity` is created. So, to make sure the deep link is opened if the activity was destroyed.