### PR TITLE
fix: prevent main content from showing when offline

### DIFF
--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/main/MainScreen.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/main/MainScreen.kt
@@ -184,30 +184,33 @@ private fun MainContent(
             targetState = state.isConnected,
             transitionSpec = { fadeTransitionSpec() }
         ) { isConnected ->
-            if (isConnected) return@AnimatedContent
-            NoInternetContent(
-                onRetry = listener::onRetryClicked,
-                modifier = Modifier.fillMaxSize()
-            )
+            if (!isConnected) {
+                NoInternetContent(
+                    onRetry = listener::onRetryClicked,
+                    modifier = Modifier.fillMaxSize()
+                )
+                return@AnimatedContent
+            }
         }
-
-        AnimatedContent(
-            targetState = isEmptyContent,
-            transitionSpec = { fadeTransitionSpec() }
-        ) { isEmptyContent ->
-            if (isEmptyContent) {
-                EmptyStateContent(
-                    image = Res.drawable.dukan_pending,
-                    title = Res.string.dukan_main_content_empty_error_title,
-                    body = Res.string.dukan_main_content_empty_error_body
-                )
-            } else {
-                MainScreenSections(
-                    state = state,
-                    bestNearestDukan = bestNearestDukan,
-                    dukans = dukans,
-                    listener = listener
-                )
+        if (state.isConnected) {
+            AnimatedContent(
+                targetState = isEmptyContent,
+                transitionSpec = { fadeTransitionSpec() }
+            ) { isEmptyContent ->
+                if (isEmptyContent) {
+                    EmptyStateContent(
+                        image = Res.drawable.dukan_pending,
+                        title = Res.string.dukan_main_content_empty_error_title,
+                        body = Res.string.dukan_main_content_empty_error_body
+                    )
+                } else {
+                    MainScreenSections(
+                        state = state,
+                        bestNearestDukan = bestNearestDukan,
+                        dukans = dukans,
+                        listener = listener
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
# Resolved the issue where the content overlapped with the no-internet screen.

# Before
<img width="425" height="885" alt="image" src="https://github.com/user-attachments/assets/e19e2a39-0828-47c2-b685-420433c024de" />

# After
<img width="431" height="900" alt="image" src="https://github.com/user-attachments/assets/0a9ae9d9-e3b4-4b1c-9ca5-3aa4ce282d2c" />
