### PR TITLE
fix: leading icon tint and direction of the country code

### DIFF
--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/textField/MobileNumberTextField.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/textField/MobileNumberTextField.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.dp
 import mena.design_system.generated.resources.Res
 import mena.design_system.generated.resources.ic_arrow_down
@@ -106,8 +107,10 @@ fun MobileNumberLeadingContent(
         )
 
         Text(
-            text = "\u200E$countryCode",
-            style = Theme.typography.label.medium,
+            text = countryCode,
+            style = Theme.typography.label.medium.copy(
+                textDirection = TextDirection.Ltr
+            ),
             modifier = Modifier.padding(start = 4.dp, end = 2.dp),
             color = Theme.colorScheme.shadePrimary,
         )

--- a/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/textField/MobileNumberTextField.kt
+++ b/design_system/src/commonMain/kotlin/net/thechance/mena/designsystem/presentation/component/textField/MobileNumberTextField.kt
@@ -3,7 +3,6 @@ package net.thechance.mena.designsystem.presentation.component.textField
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -107,15 +106,16 @@ fun MobileNumberLeadingContent(
         )
 
         Text(
-            text = countryCode,
+            text = "\u200E$countryCode",
             style = Theme.typography.label.medium,
             modifier = Modifier.padding(start = 4.dp, end = 2.dp),
-            color = Theme.colorScheme.shadePrimary
+            color = Theme.colorScheme.shadePrimary,
         )
 
         Icon(
             painter = painterResource(Res.drawable.ic_arrow_down),
             contentDescription = "arrow down",
+            tint = Theme.colorScheme.shadePrimary,
             modifier = Modifier.size(16.dp)
         )
     }


### PR DESCRIPTION
**Before:**
<img width="480" height="165" alt="image" src="https://github.com/user-attachments/assets/1f3e74e5-58a9-43a1-846a-85825ae0d276" />

**After:**
<img width="480" height="380" alt="image" src="https://github.com/user-attachments/assets/f2452f24-23a1-4dd6-adac-f2a659ee062d" />
