### PR TITLE
FIx No SnackBar Provided Crash within in Addresses API for Faith tab

### DIFF
--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/api/IdentityFeatureApiImpl.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/api/IdentityFeatureApiImpl.kt
@@ -63,6 +63,13 @@ class IdentityFeatureApiImpl : IdentityFeatureApi {
     }
 
     @Composable
+    override fun NavigateToAddressesScreen(onNavigateBack: (() -> Unit)?) {
+        IdentityFeatureRoot {
+            Navigator(MyAddressesScreen(onNavigateBack = onNavigateBack))
+        }
+    }
+
+    @Composable
     private fun IdentityFeatureRoot(content: @Composable () -> Unit) {
         val snackBarController = remember { IdentitySnackBarController() }
 
@@ -147,10 +154,5 @@ class IdentityFeatureApiImpl : IdentityFeatureApi {
                 phoneNumber = lastPhoneNumber
             )
         }
-    }
-
-    @Composable
-    override fun NavigateToAddressesScreen(onNavigateBack: (() -> Unit)?) {
-        Navigator(MyAddressesScreen(onNavigateBack = onNavigateBack))
     }
 }


### PR DESCRIPTION
This PR wrap `NavigateToAddressesScreen` composable with the `IdentityFeatureRoot` to fix current crash and ensure consistent UI, including snackbar handling, across the identity feature.