### PR TITLE
Fix: Edit Profile Screen Should Return User's BirthDate initially

### DIFF
--- a/identity_domain/src/commonMain/kotlin/net/thechance/mena/identity/domain/util/dateFormatter.kt
+++ b/identity_domain/src/commonMain/kotlin/net/thechance/mena/identity/domain/util/dateFormatter.kt
@@ -15,4 +15,4 @@ fun getCurrentDate(): LocalDate {
     return LocalDate(currentDate.year, currentDate.month, currentDate.day)
 }
 
-fun LocalDate?.orCurrent() = this ?: getCurrentDate()
+fun LocalDate?.orCurrentDate() = this ?: getCurrentDate()

--- a/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/mapper/EffectMapperTest.kt
+++ b/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/mapper/EffectMapperTest.kt
@@ -48,8 +48,8 @@ class EffectMapperTest {
 
     @Test
     fun `createNavigateToEditProfileEffect should return NavigateToEditProfileScreen effect`() {
-        val result = createNavigateToEditProfileEffect()
+        val result = createNavigateToEditProfileEffect(null)
 
-        assertEquals(ProfileScreenUIEffect.NavigateToEditProfileScreen, result)
+        assertEquals(ProfileScreenUIEffect.NavigateToEditProfileScreen(), result)
     }
 }

--- a/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileViewModelTest.kt
+++ b/identity_presentation/src/androidUnitTest/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileViewModelTest.kt
@@ -63,28 +63,11 @@ class EditUserProfileViewModelTest() : BaseCoroutineTest() {
     }
 
     @Test
-    fun `user information should be updated, when init called`() = runTest {
-        coEvery { userRepository.getUser() } returns flowOf(fakeUser)
-
-        viewModel
+    fun `user information should be updated, when getInitialUserInfo called`() = runTest {
+        viewModel.getInitialUserInfo(user = fakeUser)
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(viewModel.state.value.firstName).isEqualTo("User")
-        coVerify(exactly = 1) { userRepository.getUser() }
-    }
-
-    @Test
-    fun `ShowSnackBarError should be sent, when init throws Exception`() = runTest {
-        coEvery { userRepository.getUser() } throws Exception()
-
-        viewModel
-
-        viewModel.effect.test {
-            testDispatcher.scheduler.advanceUntilIdle()
-            assertThat(awaitItem()).isInstanceOf(EditUserProfileUIEffect.ShowSnackBarError::class)
-        }
-
-        coVerify(exactly = 1) { userRepository.getUser() }
     }
 
     @Test

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/mapper/EffectMapper.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/mapper/EffectMapper.kt
@@ -1,5 +1,6 @@
 package net.thechance.mena.identity.presentation.mapper
 
+import net.thechance.mena.identity.domain.entity.User
 import net.thechance.mena.identity.presentation.screen.addresses.addEditLocation.AddEditLocationScreenUIEffect
 import net.thechance.mena.identity.presentation.screen.addresses.shared.AddressUIState
 import net.thechance.mena.identity.presentation.screen.login.LoginScreenUIEffect
@@ -15,6 +16,8 @@ fun createNavigateToHomeEffect(): LoginScreenUIEffect {
     return LoginScreenUIEffect.NavigateToHome
 }
 
-fun createNavigateToEditProfileEffect(): ProfileScreenUIEffect {
-    return ProfileScreenUIEffect.NavigateToEditProfileScreen
+fun createNavigateToEditProfileEffect(
+    userInfo: User?
+): ProfileScreenUIEffect {
+    return ProfileScreenUIEffect.NavigateToEditProfileScreen(userInfo = userInfo)
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileScreen.kt
@@ -47,6 +47,7 @@ import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.scaffold.Scaffold
 import net.thechance.mena.designsystem.presentation.component.text.Text
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
+import net.thechance.mena.identity.domain.entity.User
 import net.thechance.mena.identity.presentation.base.BaseScreen
 import net.thechance.mena.identity.presentation.components.GregorianDatePicker
 import net.thechance.mena.identity.presentation.components.snackBar.IdentitySnackBarController
@@ -63,18 +64,28 @@ import net.thechance.mena.identity.presentation.util.rememberCameraPicker
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.core.parameter.parametersOf
+import kotlin.uuid.ExperimentalUuidApi
 
-class EditUserProfileScreen : BaseScreen<
+class EditUserProfileScreen(
+    val userInfo: User?
+) : BaseScreen<
     EditUserProfileViewModel,
     EditUserProfileUIState,
     EditUserProfileUIEffect,
     EditUserProfileInteractionListener>() {
+
+    @OptIn(ExperimentalUuidApi::class)
     @Composable
     override fun Content() {
         val factory = rememberPermissionsControllerFactory()
         val controller = remember(factory) { factory.createPermissionsController() }
         val viewModel: EditUserProfileViewModel =
             getScreenModel(parameters = { parametersOf(controller) })
+
+        LaunchedEffect(Unit) {
+            viewModel.getInitialUserInfo(user = userInfo)
+        }
+
         InitScreen(viewModel)
         BindEffect(viewModel.permissionsController)
     }
@@ -226,11 +237,13 @@ class EditUserProfileScreen : BaseScreen<
                     style = Theme.typography.title.small
                 )
 
-                GregorianDatePicker(
-                    modifier = Modifier.padding(top = Theme.spacing._4),
-                    selectedDate = state.birthDate,
-                    onDateChange = listener::onChangeDate,
-                )
+                state.birthDate?.let { birthDate ->
+                    GregorianDatePicker(
+                        modifier = Modifier.padding(top = Theme.spacing._4),
+                        selectedDate = birthDate,
+                        onDateChange = listener::onChangeDate,
+                    )
+                }
 
                 GenderToggleSection(
                     gender = state.gender,

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/editProfile/EditUserProfileViewModel.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
 package net.thechance.mena.identity.presentation.screen.editProfile
 
 import androidx.compose.ui.graphics.ImageBitmap
@@ -7,6 +9,7 @@ import dev.icerock.moko.permissions.Permission
 import dev.icerock.moko.permissions.PermissionsController
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.IO
 import kotlinx.datetime.LocalDate
 import mena.identity_presentation.generated.resources.Res
@@ -24,8 +27,7 @@ import net.thechance.mena.identity.domain.repository.ImagesRepository
 import net.thechance.mena.identity.domain.repository.RegistrationDraftRepository
 import net.thechance.mena.identity.domain.repository.UserRepository
 import net.thechance.mena.identity.domain.useCase.validation.age.AgeValidator
-import net.thechance.mena.identity.domain.util.getCurrentDate
-import net.thechance.mena.identity.domain.util.orCurrent
+import net.thechance.mena.identity.domain.util.orCurrentDate
 import net.thechance.mena.identity.presentation.base.BaseScreenModel
 import net.thechance.mena.identity.presentation.base.errorState.ErrorState
 import net.thechance.mena.identity.presentation.mapper.mapAuthenticationErrorToMessage
@@ -35,6 +37,7 @@ import org.jetbrains.compose.resources.StringResource
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class EditUserProfileViewModel(
     val permissionsController: PermissionsController,
     private val ageValidator: AgeValidator,
@@ -43,29 +46,19 @@ class EditUserProfileViewModel(
     private val imageDecoder: ImageDecoder,
     private val authenticationRepository: AuthenticationRepository,
     private val registrationDraftRepository: RegistrationDraftRepository,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : BaseScreenModel<EditUserProfileUIState, EditUserProfileUIEffect>(EditUserProfileUIState()),
     EditUserProfileInteractionListener {
+
     @OptIn(ExperimentalUuidApi::class)
     var userId: Uuid? = null
 
-    init {
-        getUserInfo()
-    }
+    fun getInitialUserInfo(user: User?) {
+        if (user == null)
+            return
 
-    private fun getUserInfo() {
-        tryToCollect(
-            function = { userRepository.getUser() },
-            onNewValue = ::updateUserInfo,
-            onError = ::onGetUserInfoError,
-            dispatcher = dispatcher
-        )
-    }
-
-    @OptIn(ExperimentalUuidApi::class)
-    private fun updateUserInfo(user: User) {
+        userId = user.id
         updateState {
-            userId = user.id
             copy(
                 username = user.username.lowercase(),
                 firstName = user.firstName,
@@ -228,14 +221,6 @@ class EditUserProfileViewModel(
         )
     }
 
-    private fun onGetUserInfoError(throwable: Throwable) {
-        sendNewEffect(
-            EditUserProfileUIEffect.ShowSnackBarError(
-                errorStringResource = mapErrorMessage(throwable)
-            )
-        )
-    }
-
     private fun validateFormInputs(): Boolean {
         val currentState = state.value
 
@@ -267,7 +252,7 @@ class EditUserProfileViewModel(
                 false
             }
 
-            !ageValidator.isValid(currentState.birthDate.orCurrent()) -> {
+            currentState.birthDate != null && !ageValidator.isValid(currentState.birthDate) -> {
                 sendNewEffect(
                     EditUserProfileUIEffect.ShowSnackBarError(
                         errorStringResource = Res.string.error_age_restriction
@@ -286,16 +271,18 @@ class EditUserProfileViewModel(
             throw Exception("User ID not found")
         }
 
-        val value = state.value
-        val user = User(
-            id = userId!!,
-            firstName = value.firstName,
-            lastName = value.lastName,
-            username = value.username.lowercase(),
-            profileImageUrl = value.profileImageUrl,
-            birthDate = value.birthDate ?: getCurrentDate(),
-            gender = value.gender,
-        )
+        val user = with(state.value) {
+            User(
+                id = userId!!,
+                firstName = firstName,
+                lastName = lastName,
+                username = username.lowercase(),
+                profileImageUrl = profileImageUrl,
+                birthDate = birthDate.orCurrentDate(),
+                gender = gender,
+            )
+        }
+
         updateProfileImage()
         userRepository.updateUser(user = user)
     }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/profile/ProfileScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/profile/ProfileScreen.kt
@@ -205,8 +205,12 @@ class ProfileScreen : BaseScreen<
         snackBarController: IdentitySnackBarController,
     ) {
         when (effect) {
-            ProfileScreenUIEffect.NavigateToEditProfileScreen -> {
-                navigator.push(EditUserProfileScreen())
+            is ProfileScreenUIEffect.NavigateToEditProfileScreen -> {
+                navigator.push(
+                    EditUserProfileScreen(
+                        userInfo = effect.userInfo
+                    )
+                )
             }
 
             ProfileScreenUIEffect.NavigateToLocationPickerScreen -> {

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/profile/ProfileScreenUIEffect.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/profile/ProfileScreenUIEffect.kt
@@ -1,10 +1,13 @@
 package net.thechance.mena.identity.presentation.screen.profile
 
+import net.thechance.mena.identity.domain.entity.User
 import org.jetbrains.compose.resources.StringResource
 
 
 sealed interface ProfileScreenUIEffect {
-    object NavigateToEditProfileScreen : ProfileScreenUIEffect
+    data class NavigateToEditProfileScreen(
+       val  userInfo: User? = null
+    ): ProfileScreenUIEffect
     object NavigateToLocationPickerScreen : ProfileScreenUIEffect
     data object NavigateToChangePasswordScreen : ProfileScreenUIEffect
 

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/profile/ProfileScreenViewModel.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/profile/ProfileScreenViewModel.kt
@@ -29,6 +29,8 @@ class ProfileScreenViewModel(
     ),
     ProfileScreenInteractionListener {
 
+    private var userInfo: User? = null
+
     init {
         getUserInfo()
         setAppVersion()
@@ -76,6 +78,7 @@ class ProfileScreenViewModel(
                 inviteLinkUrl = "$SHARE_URL${user.id}"
             )
         }
+        userInfo = user
     }
 
     private fun onUserInfoError(throwable: Throwable) {
@@ -88,7 +91,11 @@ class ProfileScreenViewModel(
     }
 
     override fun onEditProfileInfoClicked() =
-        sendNewEffect(createNavigateToEditProfileEffect())
+        sendNewEffect(
+            createNavigateToEditProfileEffect(
+                userInfo = userInfo
+            )
+        )
 
     override fun onShareClicked() =
         updateState { copy(showShareProfileDialog = true) }


### PR DESCRIPTION
This PR improve how the edit profile screen fetch its initial data. Previously, we were sending another request to fetch the initial data but now we reduced the number of requests by just passing the data fetched in the` Profile Screen`.

Additionally, it ensures that the date picker gets the  user's birthdate initially instead of today's date.

https://github.com/user-attachments/assets/75bf3623-7bfa-4766-8613-743240a4becb