### PR TITLE
Fix: Empty Locales Crash

### DIFF
--- a/identity_presentation/src/androidMain/kotlin/net/thechance/mena/identity/presentation/util/AppLocalizer.android.kt
+++ b/identity_presentation/src/androidMain/kotlin/net/thechance/mena/identity/presentation/util/AppLocalizer.android.kt
@@ -2,10 +2,10 @@ package net.thechance.mena.identity.presentation.util
 
 import android.content.Context
 import android.os.LocaleList
+import androidx.core.os.LocaleListCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import net.thechance.mena.identity.domain.repository.SettingsRepository
 import net.thechance.mena.identity.domain.util.AppLanguage
@@ -19,24 +19,34 @@ actual class AppLocalizer(
 
     init {
         coroutineScope.launch {
-            settingsRepository.observeAppLanguage().collectLatest { lang ->
-                currentLanguage = lang.iso.ifEmpty {
-                    val deviceLocale = androidx.core.os.LocaleListCompat.getDefault()[0]
-                    val deviceIso = deviceLocale?.language ?: AppLanguage.ENGLISH.iso
-                    settingsRepository.applyLanguage(AppLanguage.fromIso(deviceIso))
-                    applyLocaleToContext(deviceIso)
-                    deviceIso
-                }
-                applyLocaleToContext(currentLanguage)
-            }
+            settingsLanguageFlow()
         }
     }
+
 
     fun applyLocaleToContext(iso: String = currentLanguage) {
         val localeList = LocaleList.forLanguageTags(iso)
         LocaleList.setDefault(localeList)
         val config = context.resources.configuration
         config.setLocales(localeList)
+    }
+
+    private suspend fun settingsLanguageFlow() {
+        settingsRepository.observeAppLanguage().collect { lang ->
+            currentLanguage = lang.iso.ifEmpty {
+                val deviceIso = getDeviceLanguageIso()
+                settingsRepository.applyLanguage(AppLanguage.fromIso(deviceIso))
+                applyLocaleToContext(deviceIso)
+                deviceIso
+            }
+
+            applyLocaleToContext(currentLanguage)
+        }
+    }
+
+    private fun getDeviceLanguageIso(): String {
+        val deviceLocale = LocaleListCompat.getDefault()[0]
+        return deviceLocale?.language ?: AppLanguage.ENGLISH.iso
     }
 }
 


### PR DESCRIPTION
This PR refactors the App Localizer class and use collect instead of collect latest to make sure the initial device language is also collected before another emission.