### PR TITLE
refactor: remove fixed size for Dukan product card

### DIFF
--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/dukanDetails/components/wideImageDukanDetails/WideImageDukanProducts.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/dukanDetails/components/wideImageDukanDetails/WideImageDukanProducts.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -124,7 +126,8 @@ private fun ProductCard(
 
     Box(
         modifier = modifier
-            .size(width = 160.dp, height = 240.dp)
+            .width(160.dp)
+            .wrapContentHeight()
     ) {
         Column(
             modifier = Modifier


### PR DESCRIPTION
# Remove fixed size for Dukan product card

# Before
<img width="403" height="903" alt="image" src="https://github.com/user-attachments/assets/7d0bcbbd-93fb-40d1-a3c4-8c4efd6e553e" />

# After
<img width="421" height="890" alt="image" src="https://github.com/user-attachments/assets/ea668c9d-6efd-4282-8640-cbabb0abd723" />
