### PR TITLE
Fix/IDN-201 bottom navigation bar visibility in profile feature

### DIFF
--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/api/IdentityFeatureApiImpl.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/api/IdentityFeatureApiImpl.kt
@@ -34,7 +34,7 @@ class IdentityFeatureApiImpl : IdentityFeatureApi {
             Navigator(initialScreen) { navigator ->
                 val current = navigator.lastItem
                 LaunchedEffect(current.key) {
-                    updateBottomNavigationVisibility(current == initialScreen)
+                    updateBottomNavigationVisibility(current is ProfileScreen)
                 }
 
                 FadeTransition(navigator = navigator, animationSpec = tween(easing = LinearEasing))


### PR DESCRIPTION
## Bug Description
When configuration change in profile screen, a new instance created from profile screen and bottom navigation route check leads to make it invisible

## Solution
Make bottom navigation route check is instance of ProfileScreen

## Video
https://github.com/user-attachments/assets/c238eca2-34e7-4e8b-9eb3-3968fca168e9

