### PR TITLE
Fix/cht 177 delete cache when logout

### DIFF
--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/di/repositoryModule.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/di/repositoryModule.kt
@@ -34,6 +34,7 @@ internal val repositoryModule = module {
             webSocketManager = get(),
             cachedChatSummaryDao = get(),
             dataStore = get(),
+            authRepository = get(),
             cachedChatDao = get()
         )
     }
@@ -47,6 +48,7 @@ internal val repositoryModule = module {
             json = get(named(CHAT_JSON)),
             cachedMessageDao = get(),
             quranService = get(),
+            authRepository = get(),
             chatSyncTimeDao = get()
         )
     }

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/repository/ChatRepositoryImpl.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/repository/ChatRepositoryImpl.kt
@@ -9,10 +9,16 @@ import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.util.reflect.typeInfo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import net.thechance.mena.core_chat.data.source.local.database.cachedChat.CachedChatDao
 import net.thechance.mena.core_chat.data.source.local.database.cachedChatSummary.CachedChatSummaryDao
 import net.thechance.mena.core_chat.data.source.local.database.cachedChatSummary.toCached
@@ -32,6 +38,7 @@ import net.thechance.mena.core_chat.domain.exception.OperationFailedException
 import net.thechance.mena.core_chat.domain.model.PagedData
 import net.thechance.mena.core_chat.domain.model.SyncState
 import net.thechance.mena.core_chat.domain.repository.ChatRepository
+import net.thechance.mena.identity.domain.repository.AuthenticationRepository
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -45,12 +52,17 @@ class ChatRepositoryImpl(
     private val webSocketManager: WebSocketManager,
     private val cachedChatDao: CachedChatDao,
     private val cachedChatSummaryDao: CachedChatSummaryDao,
+    private val authRepository: AuthenticationRepository,
     private val dataStore: DataStore<Preferences>
 ) : ChatRepository {
 
     private val _syncState = MutableSharedFlow<SyncState>()
     override fun observeChatSummariesSyncState(): Flow<SyncState> {
         return _syncState
+    }
+
+    init {
+        observeAuthenticationState()
     }
 
     @OptIn(ExperimentalTime::class)
@@ -118,6 +130,7 @@ class ChatRepositoryImpl(
             _syncState.emit(SyncState.DeletedChatsSynced(deletedChatsId))
         }
     }
+
     override suspend fun getChatSummaryById(chatId: Uuid): ChatSummary {
         return tryNetworkCall<ChatSummaryDto>(
             bodyType = typeInfo<ChatSummaryDto>()
@@ -183,6 +196,30 @@ class ChatRepositoryImpl(
 
     override suspend fun disconnect() {
         webSocketManager.disconnect()
+    }
+
+    private fun observeAuthenticationState() {
+        CoroutineScope(Dispatchers.IO).launch {
+            authRepository.observeTokenChange().collectLatest { token ->
+                if (token.isEmpty()) {
+                    clearAllChatCache()
+                }
+            }
+        }
+    }
+
+    private suspend fun clearAllChatCache() {
+        try {
+            webSocketManager.disconnect()
+            cachedChatDao.clearAllChats()
+            cachedChatSummaryDao.clearAllChatSummaries()
+            dataStore.edit { preferences ->
+                preferences.remove(LAST_TIME_CHAT_SUMMARIES_SYNCED_KEY)
+            }
+
+        } catch (e: Exception) {
+            println("ChatRepository ERROR: Failed to clear cache. Error: ${e.message}")
+        }
     }
 
     private companion object {

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/repository/MessageRepositoryImpl.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/repository/MessageRepositoryImpl.kt
@@ -370,6 +370,7 @@ class MessageRepositoryImpl(
             webSocketManager.disconnect()
             cachedMessageDao.clearAllMessages()
             pendingMessageDao.clearAllPendingMessages()
+            chatSyncTimeDao.clearAllSyncTimes()
 
         } catch (e:Throwable) {
             println("MessageRepository ERROR: Failed to clear cache. Error: ${e.message}")

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/repository/MessageRepositoryImpl.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/repository/MessageRepositoryImpl.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
@@ -50,6 +51,7 @@ import net.thechance.mena.core_chat.domain.model.PagedData
 import net.thechance.mena.core_chat.domain.repository.MessageRepository
 import net.thechance.mena.faith.domain.entity.Surah
 import net.thechance.mena.faith.domain.service.QuranService
+import net.thechance.mena.identity.domain.repository.AuthenticationRepository
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -64,6 +66,7 @@ class MessageRepositoryImpl(
     private val cachedMessageDao: CachedMessageDao,
     private val chatSyncTimeDao: ChatSyncTimeDao,
     private val quranService: QuranService,
+    private val authRepository: AuthenticationRepository,
     private val messageSenderFactory: MessageSenderFactory,
     private val json: Json,
 ) : MessageRepository {
@@ -74,6 +77,9 @@ class MessageRepositoryImpl(
     private val deleteReactionFlow = MutableSharedFlow<MessageReaction>()
     private val scope = CoroutineScope(Dispatchers.IO)
 
+    init {
+        observeAuthenticationState()
+    }
     override suspend fun loadMessages(chatId: Uuid, page: Int, pageSize: Int): PagedData<Message> {
 
         val cachedMessages = cachedMessageDao.getMessagesByChatIdWithOffset(
@@ -347,6 +353,27 @@ class MessageRepositoryImpl(
     private suspend fun getSurahNameById(surahId: Int): String {
         val surah: Surah = quranService.getSurahDetails(surahId)
         return surah.name
+    }
+
+    private fun observeAuthenticationState() {
+        scope.launch {
+            authRepository.observeTokenChange().collectLatest { token ->
+                if (token.isEmpty()) {
+                    clearAllMessagesCache()
+                }
+            }
+        }
+    }
+
+    private suspend fun clearAllMessagesCache() {
+        try {
+            webSocketManager.disconnect()
+            cachedMessageDao.clearAllMessages()
+            pendingMessageDao.clearAllPendingMessages()
+
+        } catch (e:Throwable) {
+            println("MessageRepository ERROR: Failed to clear cache. Error: ${e.message}")
+        }
     }
     private companion object {
         const val PAGE_NUMBER_PARAMETER = "page"

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/local/database/cachedChat/CachedChatDao.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/local/database/cachedChat/CachedChatDao.kt
@@ -18,4 +18,7 @@ interface CachedChatDao {
 
     @Query("DELETE FROM cached_chats WHERE id = :id")
     suspend fun deleteChatById(id: String)
+
+    @Query("DELETE FROM cached_chats")
+    suspend fun clearAllChats()
 }

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/local/database/cachedChatSummary/CachedChatSummaryDao.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/local/database/cachedChatSummary/CachedChatSummaryDao.kt
@@ -28,4 +28,7 @@ interface CachedChatSummaryDao {
 
     @Query("SELECT * FROM cached_chat_summary WHERE id = :chatId")
     suspend fun getChatSummaryById(chatId: String): CachedChatSummaryDto?
+
+    @Query("DELETE FROM cached_chat_summary")
+    suspend fun clearAllChatSummaries()
 }

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/local/database/cachedMessage/CachedMessageDao.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/local/database/cachedMessage/CachedMessageDao.kt
@@ -42,5 +42,6 @@ interface CachedMessageDao {
         readerId: String,
         newStatus: MessageStatus = MessageStatus.READ
     )
-
+    @Query("DELETE FROM cached_messages")
+    suspend fun clearAllMessages()
 }

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/local/database/chatSyncTime/ChatSyncTimeDao.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/local/database/chatSyncTime/ChatSyncTimeDao.kt
@@ -12,4 +12,7 @@ interface ChatSyncTimeDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(chatSyncTime: ChatSyncTime)
+
+    @Query("DELETE FROM chat_sync_times")
+    suspend fun clearAllSyncTimes()
 }

--- a/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/local/database/pendingMessage/PendingMessageDao.kt
+++ b/core_chat_data/src/commonMain/kotlin/net/thechance/mena/core_chat/data/source/local/database/pendingMessage/PendingMessageDao.kt
@@ -23,4 +23,7 @@ interface PendingMessageDao {
 
     @Query("DELETE FROM pending_messages WHERE id IN (:ids)")
     suspend fun deleteMessagesByIds(ids: List<String>)
+
+    @Query("DELETE FROM pending_messages")
+    suspend fun clearAllPendingMessages()
 }

--- a/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/chat/ChatRepositoryImplTest.kt
+++ b/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/chat/ChatRepositoryImplTest.kt
@@ -12,12 +12,14 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isTrue
 import dev.mokkery.answering.returns
+import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
@@ -76,6 +78,7 @@ class ChatRepositoryImplTest {
         cachedChatSummaryDao = mock<CachedChatSummaryDao>()
         dataStore = mock<DataStore<Preferences>>()
         val emptyPrefs = emptyPreferences()
+        every { authRepository.observeTokenChange() } returns MutableStateFlow("fake_token")
         everySuspend { dataStore.data } returns flowOf(emptyPrefs)
         everySuspend { dataStore.updateData(any()) } returns emptyPreferences()
         cachedChatDao = mock<CachedChatDao>()
@@ -84,7 +87,9 @@ class ChatRepositoryImplTest {
         everySuspend { cachedChatDao.insertChat(any()) } returns Unit
         everySuspend { cachedChatDao.insertAllChats(any()) } returns Unit
         everySuspend { cachedChatDao.deleteChatById(any()) } returns Unit
-
+        everySuspend { cachedChatSummaryDao.clearAllChatSummaries() } returns Unit
+        everySuspend { cachedChatDao.clearAllChats() } returns Unit
+        everySuspend { webSocketManager.disconnect() } returns Unit
         httpClient = createHttpClient()
         repository = createChatRepository(
             httpClient = httpClient,

--- a/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/chat/ChatRepositoryImplTest.kt
+++ b/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/chat/ChatRepositoryImplTest.kt
@@ -68,7 +68,6 @@ class ChatRepositoryImplTest {
     private lateinit var cachedChatDao: CachedChatDao
     private val authRepository = mock<AuthenticationRepository>()
 
-
     @BeforeTest
     fun setUp() {
         everySuspend { authRepository.getAccessToken() } returns "token"
@@ -92,6 +91,7 @@ class ChatRepositoryImplTest {
             webSocketManager = webSocketManager,
             cachedChatDao = cachedChatDao,
             dataStore = dataStore,
+            authRepository = authRepository,
             cachedChatSummaryDao = cachedChatSummaryDao,
         )
     }
@@ -104,6 +104,7 @@ class ChatRepositoryImplTest {
             webSocketManager = webSocketManager,
             dataStore = dataStore,
             cachedChatSummaryDao = cachedChatSummaryDao,
+            authRepository = authRepository,
             cachedChatDao = cachedChatDao
         )
 
@@ -122,6 +123,7 @@ class ChatRepositoryImplTest {
             webSocketManager = webSocketManager,
             cachedChatDao = cachedChatDao,
             dataStore = dataStore,
+            authRepository = authRepository,
             cachedChatSummaryDao = cachedChatSummaryDao,
         )
 
@@ -149,6 +151,7 @@ class ChatRepositoryImplTest {
             webSocketManager = webSocketManager,
             dataStore = dataStore,
             cachedChatSummaryDao = cachedChatSummaryDao,
+            authRepository = authRepository,
             cachedChatDao = cachedChatDao
         )
 
@@ -172,6 +175,7 @@ class ChatRepositoryImplTest {
             webSocketManager = webSocketManager,
             dataStore = dataStore,
             cachedChatSummaryDao = cachedChatSummaryDao,
+            authRepository = authRepository,
             cachedChatDao = cachedChatDao
 
         )
@@ -196,6 +200,7 @@ class ChatRepositoryImplTest {
                 webSocketManager = webSocketManager,
                 cachedChatSummaryDao = cachedChatSummaryDao,
                 dataStore = dataStore,
+                authRepository = authRepository,
                 cachedChatDao = cachedChatDao
             )
 
@@ -215,6 +220,7 @@ class ChatRepositoryImplTest {
                 webSocketManager = webSocketManager,
                 cachedChatSummaryDao = cachedChatSummaryDao,
                 dataStore = dataStore,
+                authRepository = authRepository,
                 cachedChatDao = cachedChatDao
             )
 
@@ -240,6 +246,7 @@ class ChatRepositoryImplTest {
             webSocketManager = webSocketManager,
             cachedChatSummaryDao = cachedChatSummaryDao,
             dataStore = dataStore,
+            authRepository = authRepository,
             cachedChatDao = cachedChatDao
         )
 
@@ -261,6 +268,7 @@ class ChatRepositoryImplTest {
             webSocketManager = webSocketManager,
             cachedChatSummaryDao = cachedChatSummaryDao,
             dataStore = dataStore,
+            authRepository = authRepository,
             cachedChatDao = cachedChatDao
         )
 
@@ -283,6 +291,7 @@ class ChatRepositoryImplTest {
             webSocketManager = webSocketManager,
             cachedChatSummaryDao = cachedChatSummaryDao,
             dataStore = dataStore,
+            authRepository = authRepository,
             cachedChatDao = cachedChatDao
         )
 
@@ -305,6 +314,7 @@ class ChatRepositoryImplTest {
             webSocketManager = webSocketManager,
             cachedChatSummaryDao = cachedChatSummaryDao,
             dataStore = dataStore,
+            authRepository = authRepository,
             cachedChatDao = cachedChatDao
         )
 
@@ -344,6 +354,7 @@ class ChatRepositoryImplTest {
             webSocketManager = webSocketManager,
             dataStore = dataStore,
             cachedChatSummaryDao = cachedChatSummaryDao,
+            authRepository = authRepository,
             cachedChatDao = cachedChatDao
         )
 
@@ -373,6 +384,7 @@ class ChatRepositoryImplTest {
             webSocketManager = webSocketManager,
             dataStore = dataStore,
             cachedChatSummaryDao = cachedChatSummaryDao,
+            authRepository = authRepository,
             cachedChatDao = cachedChatDao
         )
 
@@ -402,6 +414,7 @@ class ChatRepositoryImplTest {
             webSocketManager = webSocketManager,
             dataStore = dataStore,
             cachedChatSummaryDao = cachedChatSummaryDao,
+            authRepository = authRepository,
             cachedChatDao = cachedChatDao
         )
 
@@ -458,6 +471,7 @@ class ChatRepositoryImplTest {
             webSocketManager = webSocketManager,
             dataStore = dataStore,
             cachedChatSummaryDao = cachedChatSummaryDao,
+            authRepository = authRepository,
             cachedChatDao = cachedChatDao
         )
 
@@ -495,6 +509,7 @@ class ChatRepositoryImplTest {
             webSocketManager = webSocketManager,
             dataStore = dataStore,
             cachedChatSummaryDao = cachedChatSummaryDao,
+            authRepository = authRepository,
             cachedChatDao = cachedChatDao
         )
 
@@ -517,6 +532,7 @@ class ChatRepositoryImplTest {
             webSocketManager = webSocketManager,
             dataStore = dataStore,
             cachedChatSummaryDao = cachedChatSummaryDao,
+            authRepository = authRepository,
             cachedChatDao = cachedChatDao
         )
 

--- a/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/chat/MessageRepositoryImplTest.kt
+++ b/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/chat/MessageRepositoryImplTest.kt
@@ -18,6 +18,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.respondError
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -104,7 +105,7 @@ class MessageRepositoryImplTest {
                 audioMessageSender,
                 ayahMessageSender
             )
-
+        every { authRepository.observeTokenChange() } returns MutableStateFlow("fake_token")
         repository = createMessageRepository(
             webSocketManager = webSocketManager,
             pendingMessageDao = pendingMessageDao,

--- a/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/chat/MessageRepositoryImplTest.kt
+++ b/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/chat/MessageRepositoryImplTest.kt
@@ -54,6 +54,7 @@ import net.thechance.mena.core_chat.domain.exception.NotFoundException
 import net.thechance.mena.core_chat.domain.exception.SendMessageFailedException
 import net.thechance.mena.faith.domain.repository.QuranRepository
 import net.thechance.mena.faith.domain.service.QuranService
+import net.thechance.mena.identity.domain.repository.AuthenticationRepository
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -76,6 +77,7 @@ class MessageRepositoryImplTest {
     private lateinit var quranRepository: QuranRepository
     private lateinit var quranService: QuranService
     private lateinit var ayahMessageSender: AyahMessageSender
+    private lateinit var authRepository: AuthenticationRepository
 
     @BeforeTest
     fun setUp() {
@@ -85,6 +87,7 @@ class MessageRepositoryImplTest {
         chatSyncTimeDao = mock<ChatSyncTimeDao>()
         cachedMessageDao = mock<CachedMessageDao>()
         quranRepository =mock<QuranRepository>()
+        authRepository = mock<AuthenticationRepository>()
         quranService = QuranService(repository = quranRepository)
         textMessageSender = TextMessageSender(
             webSocketManager = webSocketManager,
@@ -109,6 +112,7 @@ class MessageRepositoryImplTest {
             cachedMessageDao = cachedMessageDao,
             chatSyncTimeDao = chatSyncTimeDao,
             httpClient = httpClient,
+            authRepository = authRepository,
             quranService = quranService
         )
     }
@@ -136,6 +140,7 @@ class MessageRepositoryImplTest {
             pendingMessageDao = pendingMessageDao,
             cachedMessageDao = cachedMessageDao,
             chatSyncTimeDao = chatSyncTimeDao,
+            authRepository = authRepository,
             quranService = quranService
         )
 
@@ -179,6 +184,7 @@ class MessageRepositoryImplTest {
             pendingMessageDao = pendingMessageDao,
             cachedMessageDao = cachedMessageDao,
             chatSyncTimeDao = chatSyncTimeDao,
+            authRepository = authRepository,
             quranService = quranService
         )
 
@@ -342,6 +348,7 @@ class MessageRepositoryImplTest {
                 pendingMessageDao = pendingMessageDao,
                 cachedMessageDao = cachedMessageDao,
                 chatSyncTimeDao = chatSyncTimeDao,
+                authRepository = authRepository,
                 quranService = quranService
             )
 
@@ -375,6 +382,7 @@ class MessageRepositoryImplTest {
             pendingMessageDao = pendingMessageDao,
             cachedMessageDao = cachedMessageDao,
             chatSyncTimeDao = chatSyncTimeDao,
+            authRepository = authRepository,
             quranService = quranService
         )
 
@@ -415,6 +423,7 @@ class MessageRepositoryImplTest {
                 pendingMessageDao = pendingMessageDao,
                 cachedMessageDao = cachedMessageDao,
                 chatSyncTimeDao = chatSyncTimeDao,
+                authRepository = authRepository,
                 quranService = quranService
             )
 
@@ -448,6 +457,7 @@ class MessageRepositoryImplTest {
             pendingMessageDao = pendingMessageDao,
             cachedMessageDao = cachedMessageDao,
             chatSyncTimeDao = chatSyncTimeDao,
+            authRepository = authRepository,
             quranService = quranService
         )
 
@@ -484,6 +494,7 @@ class MessageRepositoryImplTest {
             pendingMessageDao = pendingMessageDao,
             cachedMessageDao = cachedMessageDao,
             chatSyncTimeDao = chatSyncTimeDao,
+            authRepository = authRepository,
             quranService = quranService
         )
 
@@ -528,6 +539,7 @@ class MessageRepositoryImplTest {
             pendingMessageDao = pendingMessageDao,
             cachedMessageDao = cachedMessageDao,
             chatSyncTimeDao = chatSyncTimeDao,
+            authRepository = authRepository,
             quranService = quranService
         )
         repository.loadMessages(chatId, 0, 10)
@@ -551,6 +563,7 @@ class MessageRepositoryImplTest {
             pendingMessageDao = pendingMessageDao,
             cachedMessageDao = cachedMessageDao,
             chatSyncTimeDao = chatSyncTimeDao,
+            authRepository = authRepository,
             quranService = quranService
         )
         repository.syncAfterLastUpdate(chatId)
@@ -582,6 +595,7 @@ class MessageRepositoryImplTest {
             pendingMessageDao = pendingMessageDao,
             cachedMessageDao = cachedMessageDao,
             chatSyncTimeDao = chatSyncTimeDao,
+            authRepository = authRepository,
             quranService = quranService
         )
         val result = repository.loadMessages(chatId, 0, 20)
@@ -631,6 +645,7 @@ class MessageRepositoryImplTest {
             pendingMessageDao = pendingMessageDao,
             cachedMessageDao = cachedMessageDao,
             chatSyncTimeDao = chatSyncTimeDao,
+            authRepository = authRepository,
             quranService = quranService
         )
 

--- a/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/utils.kt
+++ b/core_chat_data/src/commonTest/kotlin/net/thechance/mena/core_chat/data/utils.kt
@@ -44,6 +44,7 @@ import net.thechance.mena.core_chat.data.source.remote.dto.PagedDataDto
 import net.thechance.mena.core_chat.data.source.remote.dto.UserDto
 import net.thechance.mena.core_chat.data.source.remote.network.WebSocketManager
 import net.thechance.mena.faith.domain.service.QuranService
+import net.thechance.mena.identity.domain.repository.AuthenticationRepository
 import kotlin.uuid.ExperimentalUuidApi
 
 val jsonSerialization = Json { ignoreUnknownKeys = true }
@@ -205,6 +206,7 @@ fun createChatRepository(
     dataStore: DataStore<Preferences>,
     cachedChatSummaryDao: CachedChatSummaryDao,
     cachedChatDao: CachedChatDao,
+    authRepository: AuthenticationRepository,
     chatHistoryResponse: (suspend MockRequestHandleScope.() -> HttpResponseData)? = null,
     chatResponse: (suspend MockRequestHandleScope.() -> HttpResponseData)? = null,
     chatSummaryResponse: (suspend MockRequestHandleScope.() -> HttpResponseData)? = null,
@@ -223,7 +225,8 @@ fun createChatRepository(
         webSocketManager = webSocketManager,
         dataStore = dataStore,
         cachedChatSummaryDao = cachedChatSummaryDao,
-        cachedChatDao = cachedChatDao
+        cachedChatDao = cachedChatDao,
+        authRepository = authRepository
     )
 
 }
@@ -234,6 +237,7 @@ fun createMessageRepository(
     messageSenderFactory: MessageSenderFactory,
     pendingMessageDao: PendingMessageDao,
     cachedMessageDao: CachedMessageDao,
+    authRepository: AuthenticationRepository,
     quranService: QuranService,
     chatSyncTimeDao: ChatSyncTimeDao
 ): MessageRepositoryImpl {
@@ -245,6 +249,7 @@ fun createMessageRepository(
         messageSenderFactory = messageSenderFactory,
         cachedMessageDao = cachedMessageDao,
         quranService = quranService,
+        authRepository = authRepository,
         json = jsonSerialization
     )
 }


### PR DESCRIPTION
delete chat cache on logout by having the Chat Module observe the AuthenticationRepository's token flow and executing local DAO clear operations when the token becomes empty upon logout