### PR TITLE
fix/DKN-237-handle-multiple-clicking-chip-and-dukan-favorite

### DIFF
--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/search/component/SearchCompleteContent.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/screen/search/component/SearchCompleteContent.kt
@@ -166,6 +166,7 @@ private fun DukansList(
                 ) {
                     items(
                         count = dukanPagingItems.itemCount,
+                        key = { index -> dukanPagingItems[index]?.id ?: index },
                         contentType = { "Dukan Search Card" }
                     ) { index ->
                         dukanPagingItems[index]?.let { dukan ->

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchViewModel.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchViewModel.kt
@@ -6,8 +6,8 @@ import androidx.paging.PagingData
 import androidx.paging.map
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
 import mena.dukan_presentation.generated.resources.Res
 import mena.dukan_presentation.generated.resources.error_updating_favorites
 import mena.dukan_presentation.generated.resources.no_internet_message
@@ -31,6 +31,9 @@ class SearchViewModel(
     initialState = SearchUiState(),
     defaultDispatcher = defaultDispatcher
 ), SearchInteractionListener {
+
+    private var dukanSearchResultsFlow: MutableStateFlow<PagingData<SearchUiState.DukanUiState>> =
+        MutableStateFlow(PagingData.empty())
 
     override fun onSearchChanged(query: String) {
         updateState {
@@ -144,9 +147,10 @@ class SearchViewModel(
     }
 
     private fun onGetDukansByQueryCollect(dukanPagingData: PagingData<SearchUiState.DukanUiState>) {
+        dukanSearchResultsFlow.value = dukanPagingData
         updateState {
             copy(
-                dukanPagingFlow = flowOf(value = dukanPagingData),
+                dukanPagingFlow = dukanSearchResultsFlow,
             )
         }
     }
@@ -200,13 +204,13 @@ class SearchViewModel(
     }
 
     private fun onDukanFavoriteToggleSuccess( dukanId: Uuid) {
-        val favoriteToggledDukanPagingFlow = state.value.dukanPagingFlow.map { pagingData ->
-            pagingData.map { dukanItem ->
+        val currentSearchDukans = dukanSearchResultsFlow.value
+        val updatedSearchDukans = currentSearchDukans.map { dukanItem ->
                 if (dukanItem.id == dukanId) dukanItem.copy(isFavorite = !dukanItem.isFavorite)
                 else dukanItem
             }
-        }
-        updateState { copy(dukanPagingFlow = favoriteToggledDukanPagingFlow ) }
+        dukanSearchResultsFlow.value = updatedSearchDukans
+        updateState { copy(dukanPagingFlow = dukanSearchResultsFlow ) }
     }
 
     private fun onDukanFavoriteToggleError(exception: Exception) {

--- a/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchViewModel.kt
+++ b/dukan_presentation/src/commonMain/kotlin/net/thechance/mena/dukan/presentation/viewModel/search/SearchViewModel.kt
@@ -56,6 +56,8 @@ class SearchViewModel(
     }
 
     override fun onDukansSelected() {
+        if (state.value.userSelectionSearchList == SearchUiState.UserSelectionSearchList.Dukans)
+            return
         updateState {
             copy(
                 userSelectionSearchList = SearchUiState.UserSelectionSearchList.Dukans
@@ -65,6 +67,8 @@ class SearchViewModel(
     }
 
     override fun onProductsSelected() {
+        if (state.value.userSelectionSearchList == SearchUiState.UserSelectionSearchList.Products)
+            return
         updateState {
             copy(
                 userSelectionSearchList = SearchUiState.UserSelectionSearchList.Products


### PR DESCRIPTION
- update favorite icons in dukan list without refreshing the list
- prevent user from multiple selections in search chips ( dukans or products )

https://github.com/user-attachments/assets/2ca9052e-7963-4288-b4c8-0894e642be63


