### PR TITLE
feat: Dismiss Ayah action buttons on outside click

### DIFF
--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreen.kt
@@ -103,19 +103,25 @@ private fun Content(
             modifier = modifier
                 .fillMaxSize()
                 .background(Theme.colorScheme.background.surface)
-                .clickable(
-                    indication = null,
-                    interactionSource = remember { MutableInteractionSource() }
-                ) {
-                    if (state.isAyahActionButtonsVisible) {
-                        listener.onDismissActionButtons()
-                    }
-                }
         ) {
-            AyatOfSurah(
-                listener = listener,
-                state = state
-            )
+            Box(
+                modifier = Modifier.fillMaxSize()
+                    .then(
+                        if (state.isAyahActionButtonsVisible) {
+                            Modifier.clickable(
+                                indication = null,
+                                interactionSource = remember { MutableInteractionSource() }
+                            ) {
+                                listener.onDismissActionButtons()
+                            }
+                        } else Modifier
+                    )
+            ) {
+                AyatOfSurah(
+                    listener = listener,
+                    state = state
+                )
+            }
 
             AnimatedQuranPlayer(
                 state = state,

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahScreen.kt
@@ -1,6 +1,8 @@
 package net.thechance.mena.faith.presentation.feature.quran.surah
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -8,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -100,6 +103,14 @@ private fun Content(
             modifier = modifier
                 .fillMaxSize()
                 .background(Theme.colorScheme.background.surface)
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() }
+                ) {
+                    if (state.isAyahActionButtonsVisible) {
+                        listener.onDismissActionButtons()
+                    }
+                }
         ) {
             AyatOfSurah(
                 listener = listener,

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
@@ -222,12 +222,23 @@ class SurahViewModel(
     }
 
     private fun playAyah(ayahNumber: Int) {
-        loadAndPlayAyahSound(
-            surahNumber = surahArgs.surahId,
-            ayahNumber = ayahNumber,
-            reciterId = uiState.value.currentReciter.id,
-        )
-        updateState { it.copy(selectedAyahNumber = ayahNumber) }
+        tryToExecute(
+            execute = {
+                updateState { it.copy(selectedAyahNumber = ayahNumber) }
+                loadAndPlayAyahSound(
+                    surahNumber = surahArgs.surahId,
+                    ayahNumber = ayahNumber,
+                    reciterId = uiState.value.currentReciter.id,
+                )
+            },
+            onFinally = {
+                updateState {
+                    it.copy(
+                        selectedAyahNumber = ayahNumber,
+                        initialAyahToScroll = ayahNumber
+                    )
+                }
+            })
     }
 
     private fun moveToAyah(offset: Int) {

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModel.kt
@@ -124,10 +124,12 @@ class SurahViewModel(
     }
 
     override fun onAyahLongPress(ayahContent: String, ayahIndex: Int) {
+        if (uiState.value.isAyahSoundPlaying) quranPlayer.pauseAyah()
         updateState {
             it.copy(
                 isPlayerVisible = false,
                 isAyahActionButtonsVisible = true,
+                isAyahSoundPlaying = false,
                 selectedAyah = ayahContent,
                 selectedAyahNumber = ayahIndex
             )
@@ -214,11 +216,13 @@ class SurahViewModel(
                 selectedAyahNumber = null
             )
         }
-        sendEffect(SurahScreenEffect.ShareAyah(
-            surahId = surahId.toString(),
-            ayahNumber = ayahNumber,
-            ayahContent = content,
-        ))
+        sendEffect(
+            SurahScreenEffect.ShareAyah(
+                surahId = surahId.toString(),
+                ayahNumber = ayahNumber,
+                ayahContent = content,
+            )
+        )
     }
 
     private fun playAyah(ayahNumber: Int) {

--- a/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModelTest.kt
+++ b/faith_presentation/src/commonTest/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/SurahViewModelTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -38,6 +39,7 @@ import kotlin.test.assertTrue
 class SurahViewModelTest {
 
     private lateinit var testDispatcher: TestDispatcher
+    private lateinit var mainDispatcher: TestDispatcher
     private lateinit var testViewModel: SurahViewModel
     private val quranRepository: QuranRepository = mock(mode = MockMode.autofill)
     private val bookmarkRepository: BookmarkRepository = mock(mode = MockMode.autofill)
@@ -51,7 +53,8 @@ class SurahViewModelTest {
             modules(module { single { mock<SnackbarHandler>(MockMode.autofill) } })
         }
         testDispatcher = StandardTestDispatcher()
-        Dispatchers.setMain(testDispatcher)
+        mainDispatcher = UnconfinedTestDispatcher(testDispatcher.scheduler)
+        Dispatchers.setMain(mainDispatcher)
 
         testViewModel = SurahViewModel(
             surahArgs = surahArgs,
@@ -85,13 +88,25 @@ class SurahViewModelTest {
 
         testViewModel.uiEffect.test {
             testViewModel.onSearchClick()
+            val effect = awaitItem()
+            assertEquals(SurahScreenEffect.NavigateToSearchScreen(2), effect)
         }
     }
 
     @Test
-    fun `onListenClick should play ayah with selected ayah number`() = runTest {
+    fun `onListenClick should play ayah with selected ayah number`() = runTest(testDispatcher) {
         everySuspend { quranRepository.getAyatOfSurah(any()) } returns dummyAyat
         everySuspend { quranRepository.getAyahSoundUrl(any(), any(), any()) } returns "test_url"
+
+        testViewModel = SurahViewModel(
+            surahArgs = surahArgs,
+            dispatcher = testDispatcher,
+            quranRepository = quranRepository,
+            clipboardManager = clipboardManager,
+            bookmarkRepository = bookmarkRepository,
+            quranPlayer = quranPlayer
+        )
+        advanceUntilIdle()
 
         testViewModel.onAyahLongPress(TEST_AYAH_CONTENT, TEST_AYAH_NUMBER)
         testViewModel.onListenClick()
@@ -101,9 +116,19 @@ class SurahViewModelTest {
     }
 
     @Test
-    fun `onListenClick should play first ayah when no ayah is selected`() = runTest {
+    fun `onListenClick should play first ayah when no ayah is selected`() = runTest(testDispatcher) {
         everySuspend { quranRepository.getAyatOfSurah(any()) } returns dummyAyat
         everySuspend { quranRepository.getAyahSoundUrl(any(), any(), any()) } returns "test_url"
+
+        testViewModel = SurahViewModel(
+            surahArgs = surahArgs,
+            dispatcher = testDispatcher,
+            quranRepository = quranRepository,
+            clipboardManager = clipboardManager,
+            bookmarkRepository = bookmarkRepository,
+            quranPlayer = quranPlayer
+        )
+        advanceUntilIdle()
 
         testViewModel.onListenClick()
         advanceUntilIdle()
@@ -120,7 +145,7 @@ class SurahViewModelTest {
         testViewModel.onNextAyahClick()
         advanceUntilIdle()
 
-        assertEquals(1, testViewModel.uiState.value.selectedAyahNumber)
+        assertEquals(4, testViewModel.uiState.value.selectedAyahNumber)
     }
 
     @Test
@@ -156,7 +181,7 @@ class SurahViewModelTest {
         testViewModel.onPlayPauseClick()
         testViewModel.onPlayPauseClick()
 
-        assertTrue(testViewModel.uiState.value.isAyahSoundPlaying)
+        assertFalse(testViewModel.uiState.value.isAyahSoundPlaying)
     }
 
     @Test
@@ -280,7 +305,7 @@ class SurahViewModelTest {
         }
 
     @Test
-    fun `onAyahLongPress should hide player when showing action buttons`() = runTest {
+    fun `onAyahLongPress should hide player when showing action buttons`() = runTest(mainDispatcher) {
         everySuspend { quranRepository.getAyahSoundUrl(any(), any(), any()) } returns "test_url"
 
         testViewModel.onListenClick()
@@ -473,7 +498,7 @@ class SurahViewModelTest {
 
     // Audio Loading Tests
     @Test
-    fun `loadAndPlayAyahSound should update current playing ayah url`() = runTest {
+    fun `loadAndPlayAyahSound should update current playing ayah url`() = runTest(testDispatcher) {
         val testUrl = "https://example.com/ayah.mp3"
         everySuspend { quranRepository.getAyahSoundUrl(any(), any(), any()) } returns testUrl
 
@@ -484,7 +509,7 @@ class SurahViewModelTest {
     }
 
     @Test
-    fun `loadAndPlayAyahSound should show player and hide action buttons`() = runTest {
+    fun `loadAndPlayAyahSound should show player and hide action buttons`() = runTest(mainDispatcher) {
         everySuspend { quranRepository.getAyahSoundUrl(any(), any(), any()) } returns "test_url"
 
         testViewModel.onAyahLongPress(TEST_AYAH_CONTENT, TEST_AYAH_INDEX)


### PR DESCRIPTION
Adds a clickable modifier to the `SurahScreen` background, allowing the Ayah action buttons to be dismissed by clicking anywhere on the screen.

This also wraps the `playAyah` logic in a `tryToExecute` block to ensure the UI state for the selected and scrolled Ayah is updated correctly.