### PR TITLE
fix/FTH-199-tint-in-dark-mode-in-all-icons

### DIFF
--- a/faith_presentation/src/commonMain/composeResources/values-ar/strings.xml
+++ b/faith_presentation/src/commonMain/composeResources/values-ar/strings.xml
@@ -77,7 +77,7 @@
     <string name="error_network">خطأ في الشبكة. يرجى المحاولة لاحقاً.</string>
     <string name="error_latitude">يجب أن يكون خط العرض بين -90 و 90 درجة.</string>
     <string name="error_longitude">يجب أن يكون خط الطول بين -180 و 180 درجة.</string>
-    <string name="search_in_surah_hint">...ابحث في %1$s</string>
+    <string name="search_in_surah_hint">ابحث في %1$s...</string>
     <string name="start_searching_title">ابدأ البحث!</string>
     <string name="search_reciter">ابحث عن القارئ</string>
     <string name="start_searching_subtitle_for_ayah">أدخل كلمة من آية معينة لعرضها.</string>

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/components/ReciterItem.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/components/ReciterItem.kt
@@ -93,6 +93,7 @@ fun ReciterItem(
         if (!isDownloaded && isDownloadIconVisible) {
             Icon(
                 painterResource(Res.drawable.icon_download),
+                tint = Theme.colorScheme.primary.primary,
                 contentDescription = stringResource(Res.string.success),
                 modifier = Modifier
                     .size(size = 20.dp)

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/NearbyMosquesScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/mosque/NearbyMosquesScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -111,15 +110,14 @@ private fun Content(
                 leadingContent = {
                     Icon(
                         painter = painterResource(Res.drawable.arrow_left),
+                        tint = Theme.colorScheme.primary.primary,
                         contentDescription = stringResource(Res.string.arrow_left)
                     )
                 },
                 trailingContent = {
                     Icon(
-                        modifier = Modifier
-                            .size(20.dp)
-                            .clickable(onClick = listener::onAddMosqueClick),
                         painter = painterResource(Res.drawable.ic_add),
+                        tint = Theme.colorScheme.primary.primary,
                         contentDescription = stringResource(Res.string.add),
                     )
                 },
@@ -221,13 +219,12 @@ private fun Content(
                 modifier = Modifier
                     .padding(Theme.spacing._16)
                     .clip(RoundedCornerShape(Theme.radius.md))
-                    .background(color = Theme.colorScheme.primary.primary)
-                    .clickable {
-                        listener.getUserLocation()
-                    }
+                    .background(Theme.colorScheme.background.surfaceLow)
+                    .clickable { listener.getUserLocation() }
                     .padding(horizontal = Theme.spacing._16, vertical = 14.dp)
                     .align(Alignment.BottomStart),
                 painter = painterResource(Res.drawable.ic_gps),
+                tint = Theme.colorScheme.primary.primary,
                 contentDescription = stringResource(Res.string.icon_location)
             )
         }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/calibratedevice/CalibrateDeviceScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/calibratedevice/CalibrateDeviceScreen.kt
@@ -68,18 +68,15 @@ private fun Content(listener: CalibrateDeviceInteractionListener) {
                 leadingContent = {
                     Icon(
                         painter = painterResource(Res.drawable.ic_arrow_left),
+                        tint = Theme.colorScheme.primary.primary,
                         contentDescription = stringResource(Res.string.arrow_left)
                     )
                 },
                 onLeadingClick = listener::onBackClick
             )
         },
-        bottomBar = {
-            ContinueButton(listener = listener)
-        }
-    ) {
-        ConfigurationMessage()
-    }
+        bottomBar = { ContinueButton(listener = listener) }
+    ) { ConfigurationMessage() }
 }
 
 @Composable

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/compass/CompassScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/compass/CompassScreen.kt
@@ -2,7 +2,6 @@ package net.thechance.mena.faith.presentation.feature.qiblah.compass
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -249,8 +248,9 @@ private fun QiblahImage(qiblahDirection: Float, compassBearing: Float) {
             },
         contentAlignment = Alignment.TopCenter
     ) {
-        Image(
+        Icon(
             painter = painterResource(Res.drawable.ic_qiblah),
+            tint = Theme.colorScheme.primary.primary,
             contentDescription = stringResource(Res.string.qibla_direction),
             modifier = Modifier
                 .size(40.dp)

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/compass/CompassScreen.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/qiblah/compass/CompassScreen.kt
@@ -91,6 +91,7 @@ private fun Content(
                 leadingContent = {
                     Icon(
                         painter = painterResource(Res.drawable.ic_arrow_left),
+                        tint = Theme.colorScheme.primary.primary,
                         contentDescription = stringResource(Res.string.arrow_left)
                     )
                 },
@@ -156,8 +157,9 @@ private fun CompassView(
             contentAlignment = Alignment.Center
         ) {
             DirectionPlaceHolder(modifier = rotateModifier)
-            Image(
+            Icon(
                 painter = painterResource(Res.drawable.ic_directions),
+                tint = Theme.colorScheme.primary.primary,
                 contentDescription = "direction_arrow",
                 modifier = rotateModifier
                     .size(128.dp)
@@ -272,8 +274,9 @@ private fun QiblahTopBar(uiState: CompassUiState, onChangeLocation: () -> Unit) 
         horizontalArrangement = Arrangement.spacedBy(Theme.spacing._4),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Image(
+        Icon(
             painter = painterResource(Res.drawable.ic_location),
+            tint = Theme.colorScheme.shadePrimary,
             contentDescription = "icon_location",
             modifier = Modifier
                 .padding(start = Theme.spacing._4)

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/component/BookmarkAppBar.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/bookmark/component/BookmarkAppBar.kt
@@ -26,6 +26,7 @@ fun BookmarkAppBar(onBackClick: () -> Unit) {
         leadingContent = {
             Icon(
                 painter = painterResource(Res.drawable.ic_arrow_left),
+                tint = Theme.colorScheme.primary.primary,
                 contentDescription = stringResource(Res.string.arrow_left),
             )
         },

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/downloadedSur/components/DownloadedSurAppBar.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/downloadedSur/components/DownloadedSurAppBar.kt
@@ -27,6 +27,7 @@ fun DownloadedSurAppBar(
         leadingContent = {
             Icon(
                 painter = painterResource(Res.drawable.ic_arrow_left),
+                tint = Theme.colorScheme.primary.primary,
                 contentDescription = stringResource(Res.string.arrow_left),
             )
         },
@@ -42,6 +43,7 @@ fun DownloadedSurAppBar(
             ) {
                 Icon(
                     painter = painterResource(Res.drawable.ic_setting),
+                    tint = Theme.colorScheme.primary.primary,
                     contentDescription = stringResource(Res.string.reciters_settings),
                 )
             }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/downloadedSur/components/EmptyStateComponent.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/downloadedSur/components/EmptyStateComponent.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import mena.faith_presentation.generated.resources.Res
@@ -37,6 +38,7 @@ fun EmptyDownloadState(
 
         Image(
             painter = painterResource(Res.drawable.icon_empty_download),
+            colorFilter = ColorFilter.tint(Theme.colorScheme.primary.primary),
             contentDescription = stringResource(Res.string.empty_download_icon),
             modifier = Modifier.fillMaxWidth()
                 .size(128.dp)
@@ -45,6 +47,7 @@ fun EmptyDownloadState(
 
         Text(
             text = stringResource(Res.string.empty_download_text),
+            color = Theme.colorScheme.primary.primary,
             style = Theme.typography.title.small,
             textAlign = TextAlign.Center,
             modifier = Modifier.fillMaxWidth()

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/reciter/component/SearchReciter.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/reciter/component/SearchReciter.kt
@@ -1,6 +1,5 @@
 package net.thechance.mena.faith.presentation.feature.quran.reciter.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -93,6 +92,7 @@ private fun SearchModeBar(
             Icon(
                 modifier = Modifier.size(20.dp),
                 painter = painterResource(Res.drawable.ic_arrow_left),
+                tint = Theme.colorScheme.primary.primary,
                 contentDescription = stringResource(Res.string.back)
             )
         }
@@ -121,9 +121,10 @@ private fun NormalAppBar(
         modifier = modifier,
         title = title,
         leadingContent = {
-            Image(
+            Icon(
                 modifier = Modifier.size(20.dp),
                 painter = painterResource(Res.drawable.ic_arrow_left),
+                tint = Theme.colorScheme.primary.primary,
                 contentDescription = stringResource(Res.string.back)
             )
         },
@@ -132,9 +133,10 @@ private fun NormalAppBar(
             AppBarOptionContainer(
                 onClick = onSearchClick
             ) {
-                Image(
+                Icon(
                     modifier = Modifier.size(20.dp),
                     painter = painterResource(Res.drawable.ic_outline_search),
+                    tint = Theme.colorScheme.primary.primary,
                     contentDescription = "Search"
                 )
             }

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/search/ayah/component/SearchHeader.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/search/ayah/component/SearchHeader.kt
@@ -1,6 +1,5 @@
 package net.thechance.mena.faith.presentation.feature.quran.search.ayah.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -18,6 +17,7 @@ import mena.faith_presentation.generated.resources.back
 import mena.faith_presentation.generated.resources.ic_arrow_left
 import mena.faith_presentation.generated.resources.ic_clear
 import mena.faith_presentation.generated.resources.ic_outline_search
+import net.thechance.mena.designsystem.presentation.component.icon.Icon
 import net.thechance.mena.designsystem.presentation.component.textField.TextField
 import net.thechance.mena.designsystem.presentation.theme.theme.MenaTheme
 import net.thechance.mena.designsystem.presentation.theme.theme.Theme
@@ -48,11 +48,11 @@ fun SearchHeader(
                 .clickable(onClick = onBackClick),
             contentAlignment = Alignment.Center
         ) {
-            Image(
-                modifier = Modifier
-                    .size(20.dp),
+            Icon(
                 painter = painterResource(Res.drawable.ic_arrow_left),
-                contentDescription = stringResource(Res.string.back)
+                tint = Theme.colorScheme.primary.primary,
+                contentDescription = stringResource(Res.string.back),
+                modifier = Modifier.size(20.dp)
             )
         }
         TextField(

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/ReciterBox.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/ReciterBox.kt
@@ -49,6 +49,7 @@ fun ReciterBox(
 
         Icon(
             painter = painterResource(Res.drawable.icon_cancel),
+            tint = Theme.colorScheme.primary.primary,
             contentDescription = stringResource(Res.string.cancel_icon),
             modifier = modifier.size(24.dp)
                 .clickable(onClick = onCancelClick)

--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/SurahAppBar.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/SurahAppBar.kt
@@ -26,6 +26,7 @@ internal fun SurahAppBar(
         leadingContent = {
             Icon(
                 painter = painterResource(Res.drawable.ic_arrow_left),
+                tint = Theme.colorScheme.primary.primary,
                 contentDescription = stringResource(Res.string.arrow_left)
             )
         },
@@ -41,6 +42,7 @@ internal fun SurahAppBar(
             ) {
                 Icon(
                     painter = painterResource(Res.drawable.ic_search),
+                    tint = Theme.colorScheme.primary.primary,
                     contentDescription = stringResource(Res.string.arrow_left)
                 )
             }


### PR DESCRIPTION
presentation layer to use the primary color from the theme for their tint. This ensures a consistent look and feel. The `Image` composables have also been replaced with `Icon` composables where appropriate to support tinting.