### PR TITLE
Fix/trn 143 home scrolling issue

### DIFF
--- a/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/remote/repository/TrendsRepositoryImpl.kt
+++ b/trends_data/src/commonMain/kotlin/net/thechance/mena/trends/data/remote/repository/TrendsRepositoryImpl.kt
@@ -18,6 +18,7 @@ import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.asSource
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.io.buffered
 import net.thechance.mena.identity.domain.repository.UserRepository
@@ -53,6 +54,7 @@ import net.thechance.mena.trends.data.util.getLastMidnightTime
 import net.thechance.mena.trends.data.util.observeUploading
 import net.thechance.mena.trends.data.util.safeApiCall
 import net.thechance.mena.trends.domain.entity.Trend
+import net.thechance.mena.trends.domain.model.TrendUpdates
 import net.thechance.mena.trends.domain.model.TrendUrls
 import net.thechance.mena.trends.domain.model.TrendWatchSession
 import net.thechance.mena.trends.domain.model.UploadTrendProgress
@@ -74,6 +76,7 @@ internal class TrendsRepositoryImpl(
 ) : TrendsRepository {
 
     private val observableUploadingFlow: MutableSharedFlow<UploadTrendProgress> = MutableSharedFlow()
+    private val trendsUpdates: MutableSharedFlow<TrendUpdates> = MutableSharedFlow()
 
     override suspend fun deleteTrendById(id: String) {
         safeApiCall<Unit> {
@@ -259,5 +262,13 @@ internal class TrendsRepositoryImpl(
         val userId = userRepository.getUser().first()?.id.toString()
         if (trendWatchSession.watchStartTime != null)
             userEngagementDao.insertEngagement(trendWatchSession.toUserEngagement(userId))
+    }
+
+    override suspend fun sendTrendUpdates(trendUpdates: TrendUpdates) {
+        trendsUpdates.emit(trendUpdates)
+    }
+
+    override fun observeTrendUpdates(): SharedFlow<TrendUpdates> {
+        return trendsUpdates.asSharedFlow()
     }
 }

--- a/trends_data/src/commonTest/kotlin/net/thechance/mena/trends/data/repository/TrendRepositoryImplTest.kt
+++ b/trends_data/src/commonTest/kotlin/net/thechance/mena/trends/data/repository/TrendRepositoryImplTest.kt
@@ -1,5 +1,6 @@
 package net.thechance.mena.trends.data.repository
 
+import app.cash.turbine.test
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
@@ -14,6 +15,7 @@ import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
@@ -37,6 +39,7 @@ import net.thechance.mena.trends.data.repository.util.toggleLikeReelResponse
 import net.thechance.mena.trends.data.repository.util.updateReelResponse
 import net.thechance.mena.trends.data.repository.util.uploadReelResponse
 import net.thechance.mena.trends.data.repository.util.uploadReelThumbnailResponse
+import net.thechance.mena.trends.domain.model.TrendUpdates
 import net.thechance.mena.trends.domain.model.TrendWatchSession
 import net.thechance.mena.trends.domain.model.UploadTrendProgress
 import kotlin.test.Test
@@ -443,6 +446,14 @@ internal class TrendRepositoryImplTest {
         verifySuspend { userEngagementDao.deleteUserEngagementsBeforeGivenTime(any(), any()) }
     }
 
+    @Test
+    fun `observeTrendUpdates should emit values when sendTrendUpdates is called`() = runTest {
+        repository.observeTrendUpdates().test {
+            repository.sendTrendUpdates(trendUpdates)
+            assertThat(awaitItem()).isEqualTo(trendUpdates)
+        }
+    }
+
     private companion object {
         const val FAKE_SIZE = 1000L
         val FAKE_BYTES = ByteArray(FAKE_SIZE.toInt()) { 1 }
@@ -480,6 +491,14 @@ internal class TrendRepositoryImplTest {
                 percentageOfVideoWatched = 100f,
                 videoDurationInMilliseconds = 1000L
             )
+        )
+
+        val trendUpdates = TrendUpdates(
+            trendId = "1",
+            isLiked = true,
+            likesCount = 5,
+            viewsCount = 10,
+            isDeleted = false
         )
     }
 }

--- a/trends_domain/src/commonMain/kotlin/net/thechance/mena/trends/domain/model/TrendUpdates.kt
+++ b/trends_domain/src/commonMain/kotlin/net/thechance/mena/trends/domain/model/TrendUpdates.kt
@@ -1,0 +1,9 @@
+package net.thechance.mena.trends.domain.model
+
+data class TrendUpdates(
+    val trendId: String,
+    val isLiked: Boolean,
+    val likesCount: Int,
+    val viewsCount: Int,
+    val isDeleted: Boolean
+)

--- a/trends_domain/src/commonMain/kotlin/net/thechance/mena/trends/domain/repository/TrendsRepository.kt
+++ b/trends_domain/src/commonMain/kotlin/net/thechance/mena/trends/domain/repository/TrendsRepository.kt
@@ -2,6 +2,7 @@ package net.thechance.mena.trends.domain.repository
 
 import kotlinx.coroutines.flow.SharedFlow
 import net.thechance.mena.trends.domain.entity.Trend
+import net.thechance.mena.trends.domain.model.TrendUpdates
 import net.thechance.mena.trends.domain.model.TrendUrls
 import net.thechance.mena.trends.domain.model.TrendWatchSession
 import net.thechance.mena.trends.domain.model.UploadTrendProgress
@@ -22,4 +23,6 @@ interface TrendsRepository {
     suspend fun getTrendUrls(trendId: String): TrendUrls
     suspend fun saveUserEngagementWithTrend(trendWatchSession: TrendWatchSession)
     suspend fun getFavoriteTrends(pageNumber: Int, trendId: String? = null): List<Trend>
+    suspend fun sendTrendUpdates(trendUpdates: TrendUpdates)
+    fun observeTrendUpdates(): SharedFlow<TrendUpdates>
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreen.kt
@@ -71,8 +71,6 @@ internal fun HomeScreen(
         }
     }
 
-    LaunchedEffect(Unit) { viewModel.getFeedTrends() }
-
     HomeScreenContent(
         state = state,
         listener = viewModel,

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreenState.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeScreenState.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import net.thechance.mena.trends.presentation.shared.base.ErrorState
+import net.thechance.mena.trends.presentation.shared.base.PagingEvents
 import net.thechance.mena.trends.presentation.shared.util.TimeAgoValue
 import org.jetbrains.compose.resources.StringResource
 
@@ -13,8 +14,8 @@ data class HomeScreenState(
     val isLoading: Boolean = true,
     val error: ErrorState? = null,
     val trends: Flow<PagingData<TrendUiState>> = flowOf(),
-    val trendsStateFlow: MutableStateFlow<PagingData<TrendUiState>> = MutableStateFlow(PagingData.empty()),
     val errorMessage: StringResource? = null,
+    val pagingEvents: MutableStateFlow<List<PagingEvents<TrendUiState>>> = MutableStateFlow(emptyList())
 )
 
 data class TrendUiState(

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeViewModel.kt
@@ -7,10 +7,15 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import net.thechance.mena.trends.domain.entity.Trend
+import net.thechance.mena.trends.domain.model.TrendUpdates
 import net.thechance.mena.trends.domain.repository.TrendsRepository
+import net.thechance.mena.trends.presentation.screen.user_trend.UserTrendUiState
 import net.thechance.mena.trends.presentation.shared.base.BaseViewModel
+import net.thechance.mena.trends.presentation.shared.base.PagingEvents
+import net.thechance.mena.trends.presentation.shared.base.applyEvent
 import net.thechance.mena.trends.presentation.shared.base.createPager
 import org.koin.android.annotation.KoinViewModel
 import org.koin.core.annotation.Provided
@@ -24,67 +29,64 @@ internal class HomeViewModel(
 
     init {
         getFeedTrends()
+        observeTrendsUpdates()
     }
 
-    fun addTrendLike(trendId: String) {
+    private fun observeTrendsUpdates() {
+        tryToCollectFlow(
+            block = repository::observeTrendUpdates,
+            onNewValue = ::onTrendUpdates,
+            onError = {},
+            dispatcher = defaultDispatcher
+        )
+    }
+
+    private fun onTrendUpdates(trendUpdates: TrendUpdates) {
+        if(trendUpdates.isDeleted) {
+            sendPagingEvent(PagingEvents.Remove(trendUpdates.trendId))
+            return
+        }
+        sendPagingEvent(
+            PagingEvents.Update(
+                itemId = trendUpdates.trendId,
+                transform = { trend ->
+                    trend.copy(
+                        isLiked = trendUpdates.isLiked,
+                        likesCount = trendUpdates.likesCount,
+                        viewsCount = trendUpdates.viewsCount
+                    )
+                }
+            )
+        )
+    }
+
+    private fun addTrendLike(trendId: String) {
         tryToExecute(
-            onStart = { updateLikesOnUi(trendId) },
             block = { repository.addTrendLike(trendId) },
             onError = { error ->
-                updateLikesOnUi(trendId)
+                toggleTrendLike(trendId)
                 updateState { copy(error = error) }
             },
             dispatcher = defaultDispatcher,
-            onSuccess = { updatedTrend ->
-                onAddLikeSuccess(trendId = trendId, updatedTrend = updatedTrend)
-            }
         )
     }
 
-    private fun onAddLikeSuccess(trendId: String, updatedTrend: Trend) {
-        updateTrendInPagingData(trendId) {
-            updatedTrend.toUiState().copy(isDescriptionExpanded = it.isDescriptionExpanded)
-        }
-    }
-
-    private fun updateLikesOnUi(trendId: String) {
-        updateTrendInPagingData(trendId) { trend ->
-            trend.copy(
-                isLiked = !trend.isLiked,
-                likesCount = if (trend.isLiked) trend.likesCount - 1 else trend.likesCount + 1
-            )
-        }
-    }
-
-    fun removeTrendLike(trendId: String) {
+    private fun removeTrendLike(trendId: String) {
         tryToExecute(
-            onStart = { updateLikesOnUi(trendId) },
             block = { repository.removeTrendLike(trendId) },
             onError = { error ->
-                updateLikesOnUi(trendId)
+                toggleTrendLike(trendId)
                 updateState { copy(error = error) }
             },
             dispatcher = defaultDispatcher,
         )
     }
 
-    private fun updateTrendInPagingData(trendId: String, transform: (TrendUiState) -> TrendUiState) {
-        val currentData = state.value.trendsStateFlow.value
-        val updatedData = currentData.map { trend ->
-            if (trend.id == trendId) transform(trend) else trend
-        }
-        state.value.trendsStateFlow.value = updatedData
-        updateState { copy(trends = state.value.trendsStateFlow) }
-    }
-
-    fun getFeedTrends() {
-        tryToCollectFlow(
+    private fun getFeedTrends() {
+        tryToExecute(
             block = ::createPager,
             onStart = { updateState { copy(isLoading = true) } },
-            onNewValue = { uiPagingData ->
-                state.value.trendsStateFlow.value = uiPagingData
-                updateState { copy(trends = trendsStateFlow, isLoading = false) }
-            },
+            onSuccess = { trends -> updateState { copy(trends = trends) } },
             onError = { error -> updateState { copy(error = error, isLoading = false) } },
             onEnd = { updateState { copy(isLoading = false) } },
             dispatcher = defaultDispatcher
@@ -96,6 +98,14 @@ internal class HomeViewModel(
             scope = viewModelScope,
             loadPage = { page -> repository.getFeedTrends(page) }
         ).map { pagingData -> pagingData.map { it.toUiState() } }
+            .combine(state.value.pagingEvents) { pagingDate, pagingEvents ->
+                pagingEvents.fold(pagingDate) { data, event ->
+                    data.applyEvent(
+                        event = event,
+                        getItemId = { it.id }
+                    )
+                }
+            }
     }
 
     override fun onClickAddTrend() {
@@ -115,11 +125,26 @@ internal class HomeViewModel(
     }
 
     override fun onClickLike(trendId: String, isLiked: Boolean) {
+        toggleTrendLike(trendId)
         if (isLiked) {
             removeTrendLike(trendId)
         } else {
             addTrendLike(trendId)
         }
+    }
+
+    private fun toggleTrendLike(trendId: String) {
+        sendPagingEvent(
+            event = PagingEvents.Update(
+                itemId = trendId,
+                transform = { trend ->
+                    trend.copy(
+                        isLiked = !trend.isLiked,
+                        likesCount = if(trend.isLiked) trend.likesCount-1 else trend.likesCount+1
+                    )
+                }
+            )
+        )
     }
 
     override fun onClickRetry() {
@@ -128,11 +153,14 @@ internal class HomeViewModel(
     }
 
     override fun onClickExpandDescription(trendId: String) {
-        state.value.trendsStateFlow.value =
-            state.value.trendsStateFlow.value.map { trend ->
-                trend.takeIf { it.id != trendId }
-                    ?: trend.copy(isDescriptionExpanded = !trend.isDescriptionExpanded)
-            }
+        sendPagingEvent(
+            PagingEvents.Update(
+                itemId = trendId,
+                transform = { trend ->
+                    trend.copy(isDescriptionExpanded = !trend.isDescriptionExpanded)
+                }
+            )
+        )
     }
 
     override fun onGetRefreshedThumbnail(trendId: String) {
@@ -145,10 +173,15 @@ internal class HomeViewModel(
     }
 
     private fun onGetRefreshedThumbnailSuccess(refreshedUrl: String, trendId: String) {
-        state.value.trendsStateFlow.value =
-            state.value.trendsStateFlow.value.map { trend ->
-                trend.takeIf { it.id != trendId }
-                    ?: trend.copy(thumbnailUrl = refreshedUrl)
-            }
+        sendPagingEvent(
+            PagingEvents.Update(
+                itemId = trendId,
+                transform = { trend -> trend.copy(thumbnailUrl = refreshedUrl) }
+            )
+        )
+    }
+
+    private fun sendPagingEvent(event: PagingEvents<TrendUiState>) {
+        state.value.pagingEvents.value = state.value.pagingEvents.value + event
     }
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_trend/UserTrendMapper.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_trend/UserTrendMapper.kt
@@ -1,6 +1,7 @@
 package net.thechance.mena.trends.presentation.screen.user_trend
 
 import net.thechance.mena.trends.domain.entity.Trend
+import net.thechance.mena.trends.domain.model.TrendUpdates
 import net.thechance.mena.trends.domain.model.TrendWatchSession
 import net.thechance.mena.trends.presentation.shared.util.timeAgoValue
 
@@ -24,5 +25,15 @@ internal fun TrendWatchSessionState.toEntity(percentageOfVideoWatched: Float): T
         watchEndTime = watchEndTime,
         videoDurationInMilliseconds = videoDurationInMilliseconds,
         percentageOfVideoWatched = percentageOfVideoWatched
+    )
+}
+
+internal fun UserTrendUiState.toTrendUpdates(isDeleted: Boolean): TrendUpdates {
+    return TrendUpdates(
+        trendId = id,
+        isLiked = isLiked,
+        likesCount = likesCount,
+        viewsCount = viewsCount,
+        isDeleted = isDeleted
     )
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_trend/UserTrendState.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_trend/UserTrendState.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.datetime.LocalDateTime
 import net.thechance.mena.trends.presentation.shared.base.ErrorState
+import net.thechance.mena.trends.presentation.shared.base.PagingEvents
 import net.thechance.mena.trends.presentation.shared.util.TimeAgoValue
 
 internal data class UserTrendState(
@@ -16,7 +17,7 @@ internal data class UserTrendState(
     val isConfirmationDialogVisible: Boolean = false,
     val isTrendDeleted: Boolean? = null,
     val isDescriptionExpanded: Boolean = false,
-    val trendsStateFlow: MutableStateFlow<PagingData<UserTrendUiState>> = MutableStateFlow(PagingData.empty())
+    val pagingEvents: MutableStateFlow<List<PagingEvents<UserTrendUiState>>> = MutableStateFlow(emptyList())
 )
 
 internal data class UserTrendUiState(

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_trend/UserTrendViewModel.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/screen/user_trend/UserTrendViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import net.thechance.mena.trends.domain.entity.Trend
 import net.thechance.mena.trends.domain.model.TrendWatchSession
@@ -15,6 +16,8 @@ import net.thechance.mena.trends.presentation.navigation.Route
 import net.thechance.mena.trends.presentation.screen.user_trend.args.UserTrendArgs
 import net.thechance.mena.trends.presentation.shared.base.BaseViewModel
 import net.thechance.mena.trends.presentation.shared.base.ErrorState
+import net.thechance.mena.trends.presentation.shared.base.PagingEvents
+import net.thechance.mena.trends.presentation.shared.base.applyEvent
 import net.thechance.mena.trends.presentation.shared.base.createPager
 import org.koin.android.annotation.KoinViewModel
 import org.koin.core.annotation.Provided
@@ -32,13 +35,10 @@ internal class UserTrendViewModel(
     }
 
     private fun getFeedTrends() {
-        tryToCollectFlow(
+        tryToExecute(
             block = ::createPager,
             onStart = { updateState { copy(isLoading = true) } },
-            onNewValue = { uiPagingData ->
-                state.value.trendsStateFlow.value = uiPagingData
-                updateState { copy(trends = trendsStateFlow, isLoading = false) }
-            },
+            onSuccess = { trends -> updateState { copy(trends = trends) } },
             onError = { error -> updateState { copy(error = error, isLoading = false) } },
             onEnd = { updateState { copy(isLoading = false) } },
             dispatcher = defaultDispatcher
@@ -55,6 +55,14 @@ internal class UserTrendViewModel(
                 )
             }
         ).map { pagingData -> pagingData.map { it.toUserTrendUiState() } }
+            .combine(state.value.pagingEvents) { pagingDate, pagingEvents ->
+                pagingEvents.fold(pagingDate) { data, event ->
+                    data.applyEvent(
+                        event = event,
+                        getItemId = { it.id }
+                    )
+                }
+            }
     }
 
     private suspend fun getTrendsBasedOnSource(
@@ -68,25 +76,22 @@ internal class UserTrendViewModel(
         }
     }
 
-    fun addTrendLike(trendId: String) {
+    private fun addTrendLike(trendId: String) {
         tryToExecute(
-            onStart = { updateLikesOnUi(trendId) },
             block = { trendsRepository.addTrendLike(trendId) },
             onError = { error ->
-                onLikeClickFailed(trendId)
+                toggleTrendLike(trendId)
                 updateState { copy(error = error) }
             },
             dispatcher = defaultDispatcher,
-            onSuccess = { updatedTrend -> updateTrendInPagingData(trendId) { updatedTrend.toUserTrendUiState() } }
         )
     }
 
-    fun removeTrendLike(trendId: String) {
+    private fun removeTrendLike(trendId: String) {
         tryToExecute(
-            onStart = { updateLikesOnUi(trendId) },
             block = { trendsRepository.removeTrendLike(trendId) },
             onError = { error ->
-                onLikeClickFailed(trendId)
+                toggleTrendLike(trendId)
                 updateState { copy(error = error) }
             },
             dispatcher = defaultDispatcher,
@@ -113,11 +118,38 @@ internal class UserTrendViewModel(
     }
 
     override fun onClickLike(trendId: String, isLiked: Boolean) {
+        toggleTrendLike(trendId)
         if (isLiked) {
             removeTrendLike(trendId)
         } else {
             addTrendLike(trendId)
         }
+    }
+
+    private fun toggleTrendLike(trendId: String) {
+        sendPagingEvent(
+            event = PagingEvents.Update(
+                itemId = trendId,
+                transform = { trend ->
+                    trend.copy(
+                        isLiked = !trend.isLiked,
+                        likesCount = if(trend.isLiked) trend.likesCount-1 else trend.likesCount+1
+                    ).also(::sendTrendUpdates)
+                }
+            )
+        )
+    }
+
+    private fun sendTrendUpdates(
+        trend: UserTrendUiState,
+        isDeleted: Boolean = false
+    ) {
+        tryToExecute(
+            block = {
+                trendsRepository.sendTrendUpdates(trend.toTrendUpdates(isDeleted = isDeleted))
+            },
+            dispatcher = defaultDispatcher
+        )
     }
 
     override fun onGetRefreshVideoUrl(trendId: String) {
@@ -166,41 +198,14 @@ internal class UserTrendViewModel(
     }
 
     private fun onGetRefreshVideoUrl(refreshedUrl: String, trendId: String) {
-        state.value.trendsStateFlow.value =
-            state.value.trendsStateFlow.value.map { trend ->
-                trend.takeIf { it.id != trendId }
-                    ?: trend.copy(videoUrl = refreshedUrl)
-            }
-    }
-
-    private fun onLikeClickFailed(trendId: String) {
-        updateTrendInPagingData(trendId) { trend ->
-            trend.copy(
-                isLiked = !trend.isLiked,
-                likesCount = if (trend.isLiked) trend.likesCount - 1 else trend.likesCount + 1
+        sendPagingEvent(
+            event = PagingEvents.Update(
+                itemId = trendId,
+                transform = { trend ->
+                    trend.copy(videoUrl = refreshedUrl)
+                }
             )
-        }
-    }
-
-    private fun updateTrendInPagingData(
-        trendId: String,
-        transform: (UserTrendUiState) -> UserTrendUiState
-    ) {
-        val currentData = state.value.trendsStateFlow.value
-        val updatedData = currentData.map { trend ->
-            if (trend.id == trendId) transform(trend) else trend
-        }
-        state.value.trendsStateFlow.value = updatedData
-        updateState { copy(trends = trendsStateFlow) }
-    }
-
-    private fun updateLikesOnUi(trendId: String) {
-        updateTrendInPagingData(trendId) { trend ->
-            trend.copy(
-                isLiked = !trend.isLiked,
-                likesCount = if (trend.isLiked) trend.likesCount - 1 else trend.likesCount + 1
-            )
-        }
+        )
     }
 
     override fun onClickBack() {
@@ -235,6 +240,12 @@ internal class UserTrendViewModel(
 
     private fun onDeleteTrendSuccess() {
         updateState { copy(isConfirmationDialogVisible = false, isTrendDeleted = true) }
+        sendPagingEvent(
+            event = PagingEvents.Remove(
+                itemId = state.value.currentTrendId,
+                action = { trend -> sendTrendUpdates(trend = trend, isDeleted = true) }
+            )
+        )
     }
 
     override fun onDismissSuccessDialog() {
@@ -253,5 +264,9 @@ internal class UserTrendViewModel(
         updateState {
             copy(isTrendDeleted = null, isConfirmationDialogVisible = false, error = null)
         }
+    }
+
+    private fun sendPagingEvent(event: PagingEvents<UserTrendUiState>) {
+        state.value.pagingEvents.value = state.value.pagingEvents.value + event
     }
 }

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/base/PagingEvents.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/base/PagingEvents.kt
@@ -1,0 +1,38 @@
+package net.thechance.mena.trends.presentation.shared.base
+
+import androidx.paging.PagingData
+import androidx.paging.filter
+import androidx.paging.map
+
+sealed interface PagingEvents<T> {
+    data class Update<T>(
+        val itemId: String,
+        val transform: (T) -> T
+    ): PagingEvents<T>
+
+    data class Remove<T>(
+        val itemId: String,
+        val action: (T) -> Unit = {}
+    ): PagingEvents<T>
+}
+
+fun <T : Any> PagingData<T>.applyEvent(
+    event: PagingEvents<T>,
+    getItemId: (T) -> String
+): PagingData<T> {
+    return when(event) {
+        is PagingEvents.Update<T> -> {
+            this.map { item ->
+                if(getItemId(item) == event.itemId) event.transform(item) else item
+            }
+        }
+        is PagingEvents.Remove<T> -> {
+            this.filter { item ->
+                val shouldFilter = getItemId(item) == event.itemId
+                if(shouldFilter) event.action(item)
+
+                !shouldFilter
+            }
+        }
+    }
+}

--- a/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/base/PagingEvents.kt
+++ b/trends_presentation/src/commonMain/kotlin/net/thechance/mena/trends/presentation/shared/base/PagingEvents.kt
@@ -28,10 +28,10 @@ fun <T : Any> PagingData<T>.applyEvent(
         }
         is PagingEvents.Remove<T> -> {
             this.filter { item ->
-                val shouldFilter = getItemId(item) == event.itemId
-                if(shouldFilter) event.action(item)
-
-                !shouldFilter
+                if(getItemId(item) == event.itemId) {
+                    event.action(item)
+                    false
+                } else true
             }
         }
     }

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/home/HomeViewModelTest.kt
@@ -9,17 +9,20 @@ import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
+import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import net.thechance.mena.trends.domain.entity.Trend
+import net.thechance.mena.trends.domain.model.TrendUpdates
 import net.thechance.mena.trends.domain.model.TrendUrls
 import net.thechance.mena.trends.domain.repository.TrendsRepository
 import kotlin.test.BeforeTest
@@ -94,7 +97,7 @@ class HomeViewModelTest {
         advanceUntilIdle()
 
         val initial = viewModel.state.value.trends.asSnapshot().first()
-        viewModel.addTrendLike("1")
+        viewModel.onClickLike("1", true)
         advanceUntilIdle()
 
         viewModel.state.test {
@@ -114,7 +117,7 @@ class HomeViewModelTest {
         advanceUntilIdle()
 
         val initial = viewModel.state.value.trends.asSnapshot().first { it.id == "2" }
-        viewModel.removeTrendLike("2")
+        viewModel.onClickLike("2", true)
         advanceUntilIdle()
 
         viewModel.state.test {
@@ -153,7 +156,6 @@ class HomeViewModelTest {
         viewModel.state.test {
             val state = awaitItem()
             assertThat(state.error).isNull()
-            verifySuspend { viewModel.getFeedTrends() }
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -196,6 +198,38 @@ class HomeViewModelTest {
         }
     }
 
+    @Test
+    fun `observeTrendsUpdates should call repository observeTrendUpdates`() = runTest {
+        val updatesFlow = MutableSharedFlow<TrendUpdates>()
+        every { repository.observeTrendUpdates() } returns updatesFlow
+
+        viewModel = HomeViewModel(repository, testDispatcher)
+        advanceUntilIdle()
+
+        verifySuspend { repository.observeTrendUpdates() }
+    }
+
+    @Test
+    fun `observeTrendsUpdates should update trend properties when isDeleted is false`() = runTest(testDispatcher) {
+        val updatesFlow = MutableSharedFlow<TrendUpdates>()
+        everySuspend { repository.getFeedTrends(page = 1) } returns trends
+        every { repository.observeTrendUpdates() } returns updatesFlow
+
+        viewModel = HomeViewModel(repository, testDispatcher)
+        advanceUntilIdle()
+
+        updatesFlow.emit(trendUpdates)
+        advanceUntilIdle()
+
+        viewModel.state.test {
+            val snapshot = awaitItem().trends.asSnapshot()
+            val updatedTrend = snapshot.first { it.id == trendUpdates.trendId }
+
+            assertThat(updatedTrend.isLiked).isEqualTo(trendUpdates.isLiked)
+            assertThat(updatedTrend.likesCount).isEqualTo(trendUpdates.likesCount)
+            assertThat(updatedTrend.viewsCount).isEqualTo(trendUpdates.viewsCount)
+        }
+    }
 
     companion object {
 
@@ -226,6 +260,14 @@ class HomeViewModelTest {
                 isCurrentUserOwner = false,
                 isLiked = true
             )
+        )
+
+        val trendUpdates = TrendUpdates(
+            trendId = "1",
+            isLiked = false,
+            likesCount = 6,
+            viewsCount = 51,
+            isDeleted = false
         )
     }
 }

--- a/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserTrendViewModelTest.kt
+++ b/trends_presentation/src/commonTest/kotlin/net/thechance/mena/trends/presentation/screen/user_reel/UserTrendViewModelTest.kt
@@ -5,7 +5,6 @@ import app.cash.turbine.test
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
-import assertk.assertions.isTrue
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.answering.throws
@@ -57,7 +56,7 @@ class UserTrendViewModelTest {
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        everySuspend { mockTrendsRepository.getFeedTrends(any(), any()) } returns feedReels
+        everySuspend { mockTrendsRepository.getFeedTrends(any(), any()) } returns feedTrends
         every { userTrendArgs.trendSource } returns Route.TrendSource.Home
         viewModel = UserTrendViewModel(userTrendArgs, mockTrendsRepository, testDispatcher)
     }
@@ -65,7 +64,6 @@ class UserTrendViewModelTest {
     @Test
     fun `should initialize UserReelUiState with default state`() = runTest {
         viewModel.state.test {
-            skipItems(1)
             val initialState = awaitItem()
 
             assertThat(initialState.currentTrendId).isEqualTo("2")
@@ -81,7 +79,7 @@ class UserTrendViewModelTest {
     @Test
     fun `viewmodel should update state by reels when getFeedReels return data`() =
         runTest(testDispatcher) {
-            everySuspend { mockTrendsRepository.getFeedTrends(any()) } returns feedReels
+            everySuspend { mockTrendsRepository.getFeedTrends(any()) } returns feedTrends
             advanceUntilIdle()
             viewModel.state.test {
                 val state = awaitItem()
@@ -94,7 +92,7 @@ class UserTrendViewModelTest {
     @Test
     fun `viewmodel init should update isLoading to false getFeedReels return data`() =
         runTest(testDispatcher) {
-            everySuspend { mockTrendsRepository.getFeedTrends(any()) } returns feedReels
+            everySuspend { mockTrendsRepository.getFeedTrends(any()) } returns feedTrends
 
             advanceUntilIdle()
 
@@ -256,36 +254,12 @@ class UserTrendViewModelTest {
         }
 
     @Test
-    fun `onAddReelLike method should add like to Reel when called`() = runTest {
-        everySuspend { mockTrendsRepository.addTrendLike("2") } returns feedReels[0].copy(
-            isLiked = true,
-            likesCount = feedReels[0].likesCount + 1
-        )
-
-        advanceUntilIdle()
-
-        val initial = viewModel.state.value.trends.asSnapshot().first()
-        viewModel.addTrendLike("2")
-        advanceUntilIdle()
-
-        viewModel.state.test {
-            val state = awaitItem()
-            val updated = state.trends.asSnapshot().first()
-
-            assertThat(updated.likesCount).isEqualTo(initial.likesCount + 1)
-            assertThat(updated.isLiked).isTrue()
-
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
     fun `onRemoveReelLike method should remove like from Reel when called`() = runTest {
         everySuspend { mockTrendsRepository.removeTrendLike("2") } returns Unit
         advanceUntilIdle()
 
         val initial = viewModel.state.value.trends.asSnapshot().first { it.id == "2" }
-        viewModel.removeTrendLike("2")
+        viewModel.onClickLike("2", true)
         advanceUntilIdle()
 
         viewModel.state.test {
@@ -318,20 +292,17 @@ class UserTrendViewModelTest {
 
     @Test
     fun `updateReelInPagingData should only update the specific reel by id`() = runTest {
-        everySuspend { mockTrendsRepository.addTrendLike("2") } returns trend2.copy(
-            isLiked = true,
-            likesCount = 51
-        )
+        everySuspend { mockTrendsRepository.addTrendLike("2") } returns trend2
 
-        advanceUntilIdle()
-        viewModel.onClickLike("2", false)
+        viewModel.onClickLike("2", true)
         advanceUntilIdle()
 
         viewModel.state.test {
             val state = awaitItem()
-            val reelsSnapshot = state.trends.asSnapshot().first()
+            val updated = state.trends.asSnapshot().first { it.id == "2" }
 
-            assertThat(reelsSnapshot.likesCount).isEqualTo(51)
+            assertThat(updated.likesCount).isEqualTo(49)
+            assertThat(updated.isLiked).isFalse()
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -426,9 +397,9 @@ class UserTrendViewModelTest {
             isLiked = true
         )
 
-        val feedReels = listOf(trend2, trend1)
+        val feedTrends = listOf(trend2, trend1)
 
-        val expectedReelUiStateList = feedReels.map { it.toUserTrendUiState() }
+        val expectedReelUiStateList = feedTrends.map { it.toUserTrendUiState() }
 
         val trendWatchSessionState = TrendWatchSessionState(
             trendId = "",


### PR DESCRIPTION
## Description
- solve problem of updating paging data in real time without create pager each time 
- observe updates of Trends in home screen, so if user add or remove like or delete trend in player screen it will affect that trend in home screen

## Screenshots
 <table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/cbf9d67d-394f-4ca0-98b4-8c6804015b8c" controls></video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/8c4fddb3-d02f-4cc3-8b2b-73bfca47f166" controls></video>
    </td>
  </tr>
</table>