### PR TITLE
Fix/WLT-201-get-statements-by-user-id

### DIFF
--- a/wallet_data/src/commonMain/kotlin/net/thechance/mena/wallet/data/database/StatementDao.kt
+++ b/wallet_data/src/commonMain/kotlin/net/thechance/mena/wallet/data/database/StatementDao.kt
@@ -10,8 +10,13 @@ interface StatementDao {
     @Insert
     suspend fun insertStatement(localStatement: LocalStatement)
 
-    @Query("SELECT * FROM statement ORDER BY  createdAt DESC  LIMIT :limit OFFSET :offset")
-    suspend fun getAllStatement(limit: Int, offset: Int): List<LocalStatement>
+    @Query("""
+    SELECT * FROM statement 
+    WHERE userId = :userId
+    ORDER BY createdAt DESC 
+    LIMIT :limit OFFSET :offset
+    """)
+    suspend fun getAllStatement(userId: String, limit: Int, offset: Int): List<LocalStatement>
 
     @Query("DELETE FROM statement WHERE id = :id")
     suspend fun deleteStatementById(id: String)

--- a/wallet_data/src/commonMain/kotlin/net/thechance/mena/wallet/data/dto/local/LocalStatement.kt
+++ b/wallet_data/src/commonMain/kotlin/net/thechance/mena/wallet/data/dto/local/LocalStatement.kt
@@ -13,5 +13,6 @@ data class LocalStatement @OptIn(ExperimentalTime::class) constructor(
     val totalInflows: Double,
     val totalOutflows: Double,
     val createdAt: Long = Clock.System.now().toEpochMilliseconds(),
-    val fileName: String
+    val fileName: String,
+    val userId :String
 )

--- a/wallet_data/src/commonMain/kotlin/net/thechance/mena/wallet/data/mapper/statementMapper.kt
+++ b/wallet_data/src/commonMain/kotlin/net/thechance/mena/wallet/data/mapper/statementMapper.kt
@@ -38,14 +38,15 @@ fun TransactionFilterParams.toStatementRequest(): HttpRequestBuilder.() -> Unit 
 }
 
 @OptIn(ExperimentalUuidApi::class)
-fun Statement.toLocal(): LocalStatement {
+fun Statement.toLocal(userId: String): LocalStatement {
     return LocalStatement(
         id = id.toString(),
         startDate = startDate.toString(),
         endDate = endDate.toString(),
         totalInflows = totalInflows,
         totalOutflows = totalOutflows,
-        fileName = fileName
+        fileName = fileName,
+        userId = userId
     )
 }
 

--- a/wallet_data/src/commonMain/kotlin/net/thechance/mena/wallet/data/repository/statement/StatementRepositoryImpl.kt
+++ b/wallet_data/src/commonMain/kotlin/net/thechance/mena/wallet/data/repository/statement/StatementRepositoryImpl.kt
@@ -3,6 +3,8 @@
 package net.thechance.mena.wallet.data.repository.statement
 
 import io.ktor.client.statement.HttpResponse
+import kotlinx.coroutines.flow.first
+import net.thechance.mena.identity.domain.repository.UserRepository
 import net.thechance.mena.wallet.data.database.StatementDao
 import net.thechance.mena.wallet.data.mapper.toEntity
 import net.thechance.mena.wallet.data.mapper.toLocal
@@ -14,6 +16,7 @@ import net.thechance.mena.wallet.data.utils.safeApiCall
 import net.thechance.mena.wallet.domain.entity.Statement
 import net.thechance.mena.wallet.domain.model.TransactionFilterParams
 import net.thechance.mena.wallet.domain.repository.StatementRepository
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -21,6 +24,7 @@ import kotlin.uuid.Uuid
 @Single
 class StatementRepositoryImpl(
     private val networkClient: NetworkClient,
+    @Provided private val userRepository: UserRepository,
     private val statementDao: StatementDao
 ) : StatementRepository {
 
@@ -34,13 +38,16 @@ class StatementRepositoryImpl(
     }.toStatementWithMetaData()
 
     override suspend fun getStatements(page: Int, pageSize: Int): List<Statement> {
+        val userId = userRepository.getUser().first()?.id.toString()
         val offset = (page - 1) * pageSize
-        return statementDao.getAllStatement(limit = pageSize, offset = offset)
+        return statementDao.getAllStatement(userId = userId, limit = pageSize, offset = offset)
             .toStatementEntityList()
     }
 
-    override suspend fun insertStatement(statement: Statement) =
-        statementDao.insertStatement(statement.toLocal())
+    override suspend fun insertStatement(statement: Statement) {
+        val userId = userRepository.getUser().first()?.id.toString()
+        statementDao.insertStatement(statement.toLocal(userId))
+    }
 
     override suspend fun deleteStatementById(id: Uuid) =
         statementDao.deleteStatementById(id.toString())

--- a/wallet_data/src/commonTest/kotlin/net/thechance/mena/wallet/repository/StatementRepositoryImplTest.kt
+++ b/wallet_data/src/commonTest/kotlin/net/thechance/mena/wallet/repository/StatementRepositoryImplTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.datetime.LocalDate
+import net.thechance.mena.identity.domain.repository.UserRepository
 import net.thechance.mena.wallet.data.database.StatementDao
 import net.thechance.mena.wallet.data.network_client.NetworkClient
 import net.thechance.mena.wallet.data.repository.statement.StatementRepositoryImpl
@@ -42,6 +43,7 @@ class StatementRepositoryImplTest {
     private lateinit var networkClient: NetworkClient
     private lateinit var statementDao: StatementDao
     private val testDispatcher = StandardTestDispatcher()
+    private val userRepository: UserRepository = mock()
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @BeforeTest
@@ -54,7 +56,7 @@ class StatementRepositoryImplTest {
     fun `getStatementWithMetadata should return statement with metadata when API call is successful`() =
         runTest(testDispatcher) {
             networkClient = createNetworkClient(getRespond = successPdfResponse)
-            statementRepository = StatementRepositoryImpl(networkClient, statementDao)
+            statementRepository = StatementRepositoryImpl(networkClient, userRepository,statementDao)
 
             val result = statementRepository.getStatementWithMetadata()
 
@@ -70,7 +72,7 @@ class StatementRepositoryImplTest {
     fun `getStatementWithMetadata should fetch new data after expiration time`() =
         runTest(testDispatcher) {
             networkClient = createNetworkClient(getRespond = successPdfResponse)
-            statementRepository = StatementRepositoryImpl(networkClient, statementDao)
+            statementRepository = StatementRepositoryImpl(networkClient, userRepository,statementDao)
 
             val firstResult = statementRepository.getStatementWithMetadata()
             advanceUntilIdle()
@@ -90,10 +92,11 @@ class StatementRepositoryImplTest {
         everySuspend {
             statementDao.getAllStatement(
                 limit = any(),
-                offset = any()
+                offset = any(),
+                userId = "123"
             )
         } throws Exception("db error")
-        statementRepository = StatementRepositoryImpl(networkClient, statementDao)
+        statementRepository = StatementRepositoryImpl(networkClient, userRepository,statementDao)
 
         // act & assert
         assertFailsWith<Exception> {
@@ -109,7 +112,7 @@ class StatementRepositoryImplTest {
             networkClient = createNetworkClient()
             statementDao = mock(mode = MockMode.autofill)
             everySuspend { statementDao.insertStatement(any()) } throws Exception("insert failed")
-            statementRepository = StatementRepositoryImpl(networkClient, statementDao)
+            statementRepository = StatementRepositoryImpl(networkClient, userRepository,statementDao)
 
             // act & assert
             assertFailsWith<Exception> {
@@ -125,7 +128,7 @@ class StatementRepositoryImplTest {
             networkClient = createNetworkClient()
             statementDao = mock(mode = MockMode.autofill)
             everySuspend { statementDao.deleteStatementById(any()) } throws Exception("delete failed")
-            statementRepository = StatementRepositoryImpl(networkClient, statementDao)
+            statementRepository = StatementRepositoryImpl(networkClient, userRepository,statementDao)
 
             // act & assert
             assertFailsWith<Exception> {
@@ -141,7 +144,7 @@ class StatementRepositoryImplTest {
             networkClient = createNetworkClient()
             statementDao = mock(mode = MockMode.autofill)
             everySuspend { statementDao.getStatementById(any()) } throws Exception("get by id failed")
-            statementRepository = StatementRepositoryImpl(networkClient, statementDao)
+            statementRepository = StatementRepositoryImpl(networkClient, userRepository,statementDao)
 
             // act & assert
             assertFailsWith<Exception> {

--- a/wallet_domain/src/commonMain/kotlin/net/thechance/mena/wallet/domain/repository/StatementRepository.kt
+++ b/wallet_domain/src/commonMain/kotlin/net/thechance/mena/wallet/domain/repository/StatementRepository.kt
@@ -10,7 +10,7 @@ import kotlin.uuid.Uuid
 
 interface StatementRepository {
     suspend fun getStatementWithMetadata(filterRequestParams: TransactionFilterParams? = null): StatementWithMetaData
-    suspend fun getStatements(page: Int, pageSize: Int, ): List<Statement>
+    suspend fun getStatements(page: Int, pageSize: Int): List<Statement>
     suspend fun insertStatement(statement: Statement)
     suspend fun deleteStatementById(id: Uuid)
     suspend fun getStatementById(id: Uuid): Statement


### PR DESCRIPTION
Fetch transaction statements using the current user’s ID to ensure that each user only sees their downloaded statements. This prevents statements from appearing across different accounts when logging out and logging back in.