### PR TITLE
Refactor: Improve scroll-based action button dismissal logic in Surah screen

### DIFF
--- a/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/ScrollTracking.kt
+++ b/faith_presentation/src/commonMain/kotlin/net/thechance/mena/faith/presentation/feature/quran/surah/component/ScrollTracking.kt
@@ -95,7 +95,7 @@ private fun HideAyahActionButtonsOnScroll(
     state: SurahUiState,
     listener: SurahInteractionListener
 ) {
-    LaunchedEffect(lazyListState, state.isAyahActionButtonsVisible) {
+    LaunchedEffect(lazyListState) {
         snapshotFlow { lazyListState.isScrollInProgress }
             .collect { isScrolling ->
                 if (isScrolling && state.isAyahActionButtonsVisible) listener.onDismissActionButtons()


### PR DESCRIPTION
This PR refines the logic responsible for hiding Ayah action buttons when the user scrolls in the Surah screen. Previously, the LaunchedEffect depended on both lazyListState and state.isAyahActionButtonsVisible, which caused the effect to restart more often than necessary and led to redundant recompositions.