### PR TITLE
Fix: Contact Us Crash When No App Support The Link.

### DIFF
--- a/identity_presentation/src/commonMain/composeResources/values-ar/strings.xml
+++ b/identity_presentation/src/commonMain/composeResources/values-ar/strings.xml
@@ -263,6 +263,7 @@
     <string name="contact_email_address">البريد الإلكتروني</string>
     <string name="contact_phone_number">رقم الهاتف</string>
     <string name="contact_facebook_account">حساب فيسبوك</string>
+    <string name="error_cant_open_link">تعذر فتح الرابط. يرجى التحقق من وجود تطبيق مناسب مثبت على جهازك.</string>
 
     <!-- Privacy and policy-->
     <string name="last_update">آخر تحديث: %1$s</string>

--- a/identity_presentation/src/commonMain/composeResources/values/strings.xml
+++ b/identity_presentation/src/commonMain/composeResources/values/strings.xml
@@ -280,4 +280,6 @@
     <string name="contact_email_address">Email address</string>
     <string name="contact_phone_number">Phone number</string>
     <string name="contact_facebook_account">Facebook account</string>
+    <string name="error_cant_open_link">Could not open the link. Please check if you have a supported app installed.</string>
+
 </resources>

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/contactUs/ContactUsScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/contactUs/ContactUsScreen.kt
@@ -25,6 +25,7 @@ import mena.identity_presentation.generated.resources.contact_facebook_account
 import mena.identity_presentation.generated.resources.contact_info
 import mena.identity_presentation.generated.resources.contact_phone_number
 import mena.identity_presentation.generated.resources.contact_us
+import mena.identity_presentation.generated.resources.error_cant_open_link
 import mena.identity_presentation.generated.resources.ic_arrow_left
 import mena.identity_presentation.generated.resources.ic_facebook
 import mena.identity_presentation.generated.resources.ic_mailbox
@@ -37,6 +38,7 @@ import net.thechance.mena.designsystem.presentation.theme.theme.Theme
 import net.thechance.mena.identity.presentation.base.BaseScreen
 import net.thechance.mena.identity.presentation.base.util.collectAsEffectWithLifeCycle
 import net.thechance.mena.identity.presentation.components.snackBar.IdentitySnackBarController
+import net.thechance.mena.identity.presentation.components.snackBar.LocalSnackBarController
 import net.thechance.mena.identity.presentation.screen.contactUs.components.ContactCard
 import net.thechance.mena.identity.presentation.screen.contactUs.components.ContactUsScreenShimmer
 import org.jetbrains.compose.resources.painterResource
@@ -51,10 +53,17 @@ class ContactUsScreen : BaseScreen<
     override fun Content() {
         val viewModel = getScreenModel<ContactUsViewModel>()
         val uriHandler = LocalUriHandler.current
+        val snackBarController = LocalSnackBarController.current
 
         viewModel.effect.collectAsEffectWithLifeCycle { effect ->
             if (effect is ContactUsUIEffect.OpenUrl) {
-                uriHandler.openUri(effect.url)
+                runCatching {
+                    uriHandler.openUri(effect.url)
+                }.onFailure {
+                    snackBarController.showSnackBarError(
+                        message = Res.string.error_cant_open_link
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
This PR adds error handling for when an external link (email) cannot be opened from the Contact Us screen. 

It fixes this issue [here](https://github.com/TheChance101/MENA-mobile/issues/1174)

https://github.com/user-attachments/assets/8b95fafb-1e54-4385-8438-bbfd099cf9c8