### PR TITLE
Fix/idn 104 primary button hidden by keyboard

### DIFF
--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/addEditLocation/AddEditLocationScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/addresses/addEditLocation/AddEditLocationScreen.kt
@@ -3,6 +3,7 @@ package net.thechance.mena.identity.presentation.screen.addresses.addEditLocatio
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -77,7 +78,8 @@ class AddEditLocationScreen(
                 PrimaryButton(
                     modifier = Modifier.fillMaxWidth()
                         .padding(horizontal = Theme.spacing._16)
-                        .padding(bottom = Theme.spacing._16),
+                        .padding(bottom = Theme.spacing._16)
+                        .imePadding(),
                     text = stringResource(Res.string.save),
                     onClick = listener::onClickSave,
                     isEnabled = state.isSaveEnabled,

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/changePassword/ChangePasswordScreen.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/changePassword/ChangePasswordScreen.kt
@@ -58,7 +58,6 @@ class ChangePasswordScreen() : BaseScreen<ChangePasswordScreenViewModel,
                 )
             }
         ) {
-
             Column(
                 modifier = Modifier.fillMaxWidth()
                     .background(Theme.colorScheme.background.surface)

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/changePassword/components/CurrentPasswordContent.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/changePassword/components/CurrentPasswordContent.kt
@@ -76,6 +76,7 @@ fun CurrentPasswordContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = Theme.spacing._12, top = Theme.spacing._24)
+                .imePadding()
         )
     }
 }

--- a/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/changePassword/components/NewPasswordContent.kt
+++ b/identity_presentation/src/commonMain/kotlin/net/thechance/mena/identity/presentation/screen/changePassword/components/NewPasswordContent.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -79,6 +80,7 @@ fun NewPasswordContent(
             contentPadding = PaddingValues(vertical = 13.dp),
             modifier = Modifier.fillMaxWidth()
                 .padding(bottom = Theme.spacing._12, top = Theme.spacing._24)
+                .imePadding()
         )
     }
 }


### PR DESCRIPTION
### fix primary button hidden by keyboard in 
1 - change password screen 
2 - new password screen 
3 - add edit location screen 

<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/a55fd754-ca70-4657-8df5-ecb92db466d5" width="100%" controls></img>
      <p style="text-align:center; font-weight:bold;">Before</p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/00fa4f0d-f2a3-48c8-ae2f-df578040d40a" width="100%" controls></img>
      <p style="text-align:center; font-weight:bold;">After</p>
    </td>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/951d22b4-b8ff-46b1-a7f9-4d39079e135a" width="100%" controls></img>
      <p style="text-align:center; font-weight:bold;">Before</p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/3c103fbe-4a08-4462-a62b-cc71b771c9dd" width="100%" controls></img>
      <p style="text-align:center; font-weight:bold;">After</p>
    </td>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/ea2a2dca-02a6-4afe-9a9c-b32d3d0f105f" width="100%" controls></img>
      <p style="text-align:center; font-weight:bold;">Before</p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/ee2c0f5a-3029-4283-a18c-40aa9e670d17" width="100%" controls></img>
      <p style="text-align:center; font-weight:bold;">After</p>
    </td>
  </tr>
</table>